### PR TITLE
Fix list_designs unbounded recursion and confusing paths (#2)

### DIFF
--- a/src/parsers/altium/discovery.ts
+++ b/src/parsers/altium/discovery.ts
@@ -74,10 +74,7 @@ const readProjectSchDocs = async (projectPath: string): Promise<string[]> => {
     }
 
     // Skip absolute paths from the project file
-    if (
-      path.win32.isAbsolute(normalized) ||
-      path.posix.isAbsolute(normalized)
-    ) {
+    if (path.win32.isAbsolute(normalized) || path.posix.isAbsolute(normalized)) {
       continue;
     }
 
@@ -94,23 +91,23 @@ const readProjectSchDocs = async (projectPath: string): Promise<string[]> => {
 
 /**
  * Walk directory tree to find Altium-related files.
+ *
+ * @param rootDir - Root directory to start searching from
+ * @param maxDepth - Maximum directory depth to recurse (0 = root only, undefined = unlimited)
  */
 const walkForAltiumFiles = async (
   rootDir: string,
+  maxDepth?: number
 ): Promise<{ projects: string[]; schdocs: string[] }> => {
   const projects: string[] = [];
   const schdocs: string[] = [];
 
-  const walk = async (currentDir: string): Promise<void> => {
+  const walk = async (currentDir: string, depth: number): Promise<void> => {
     let entries;
     try {
       entries = await readdir(currentDir, { withFileTypes: true });
     } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !("code" in error) ||
-        error.code !== "EACCES"
-      ) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EACCES") {
         throw error;
       }
       return;
@@ -119,7 +116,9 @@ const walkForAltiumFiles = async (
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        await walk(fullPath);
+        if (maxDepth === undefined || depth < maxDepth) {
+          await walk(fullPath, depth + 1);
+        }
         continue;
       }
 
@@ -137,17 +136,14 @@ const walkForAltiumFiles = async (
     }
   };
 
-  await walk(rootDir);
+  await walk(rootDir, 0);
   return { projects, schdocs };
 };
 
 /**
  * Fallback: find SchDoc files in the project directory if none found in project file.
  */
-const fallbackProjectSchDocs = (
-  projectDir: string,
-  schdocs: string[],
-): string[] => {
+const fallbackProjectSchDocs = (projectDir: string, schdocs: string[]): string[] => {
   const candidates = schdocs.filter((schdoc) => {
     const schdocDir = path.dirname(schdoc);
     return schdocDir === projectDir || schdoc.startsWith(projectDir + path.sep);
@@ -158,12 +154,16 @@ const fallbackProjectSchDocs = (
 
 /**
  * Discover Altium designs in a directory.
+ *
+ * @param rootDir - Root directory to search
+ * @param options - Discovery options (maxDepth)
  */
 export const discoverAltiumDesigns = async (
   rootDir: string,
+  options?: { maxDepth?: number }
 ): Promise<AltiumDiscoveredDesign[]> => {
   const absoluteRootDir = path.resolve(rootDir);
-  const { projects, schdocs } = await walkForAltiumFiles(absoluteRootDir);
+  const { projects, schdocs } = await walkForAltiumFiles(absoluteRootDir, options?.maxDepth);
 
   const designs: AltiumDiscoveredDesign[] = [];
 
@@ -196,9 +196,7 @@ export const discoverAltiumDesigns = async (
 /**
  * Find SchDoc files for a specific Altium project file.
  */
-export const findAltiumSchDocs = async (
-  projectPath: string,
-): Promise<string[]> => {
+export const findAltiumSchDocs = async (projectPath: string): Promise<string[]> => {
   const schdocPaths = await readProjectSchDocs(projectPath);
 
   if (schdocPaths.length === 0) {

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -28,11 +28,7 @@ export interface CadenceDiscoveredDesign {
 }
 
 /** Required .dat files for a complete netlist export */
-const REQUIRED_DAT_FILES = [
-  "pstxnet.dat",
-  "pstxprt.dat",
-  "pstchip.dat",
-] as const;
+const REQUIRED_DAT_FILES = ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"] as const;
 
 interface CadenceDatFiles {
   pstxnet: string | null;
@@ -52,23 +48,23 @@ interface DatFileSet {
 
 /**
  * Walk directory tree to find Cadence design files and complete .dat file sets.
+ *
+ * @param rootDir - Root directory to start searching from
+ * @param maxDepth - Maximum directory depth to recurse (0 = root only, undefined = unlimited)
  */
 const walkForCadenceFiles = async (
   rootDir: string,
+  maxDepth?: number
 ): Promise<{ designFiles: string[]; datSets: DatFileSet[] }> => {
   const designFiles: string[] = [];
   const datFilesByDir = new Map<string, Map<string, string>>();
 
-  const walk = async (currentDir: string): Promise<void> => {
+  const walk = async (currentDir: string, depth: number): Promise<void> => {
     let entries;
     try {
       entries = await readdir(currentDir, { withFileTypes: true });
     } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !("code" in error) ||
-        error.code !== "EACCES"
-      ) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EACCES") {
         throw error;
       }
       return;
@@ -77,7 +73,9 @@ const walkForCadenceFiles = async (
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        await walk(fullPath);
+        if (maxDepth === undefined || depth < maxDepth) {
+          await walk(fullPath, depth + 1);
+        }
         continue;
       }
 
@@ -87,18 +85,14 @@ const walkForCadenceFiles = async (
       const baseName = entry.name.toLowerCase();
 
       // Collect design files
-      if (
-        CADENCE_EXTENSIONS.includes(ext as (typeof CADENCE_EXTENSIONS)[number])
-      ) {
+      if (CADENCE_EXTENSIONS.includes(ext as (typeof CADENCE_EXTENSIONS)[number])) {
         designFiles.push(fullPath);
       }
 
       // Collect .dat files grouped by directory
       if (
         ext === ".dat" &&
-        REQUIRED_DAT_FILES.includes(
-          baseName as (typeof REQUIRED_DAT_FILES)[number],
-        )
+        REQUIRED_DAT_FILES.includes(baseName as (typeof REQUIRED_DAT_FILES)[number])
       ) {
         if (!datFilesByDir.has(currentDir)) {
           datFilesByDir.set(currentDir, new Map());
@@ -108,7 +102,7 @@ const walkForCadenceFiles = async (
     }
   };
 
-  await walk(rootDir);
+  await walk(rootDir, 0);
 
   // Convert to complete DatFileSets (only directories with all 3 required files)
   const datSets: DatFileSet[] = [];
@@ -135,9 +129,7 @@ const normalizeForComparison = (p: string): string => {
   // On Windows, path.normalize converts / to \
   // On Unix, we must manually convert \ to / since path.normalize doesn't
   const normalized =
-    process.platform === "win32"
-      ? path.normalize(p)
-      : path.normalize(p.replace(/\\/g, "/"));
+    process.platform === "win32" ? path.normalize(p) : path.normalize(p.replace(/\\/g, "/"));
   // Windows is case-insensitive, Unix is case-sensitive
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 };
@@ -163,10 +155,7 @@ const isDescendantOrEqual = (childDir: string, parentDir: string): boolean => {
  * Check if design name appears as an exact directory component in a relative path.
  * Case-insensitive matching.
  */
-const designNameInRelativePath = (
-  relPath: string,
-  designName: string,
-): boolean => {
+const designNameInRelativePath = (relPath: string, designName: string): boolean => {
   if (relPath === "" || relPath === ".") return false;
   const components = relPath.split(path.sep);
   const lowerName = designName.toLowerCase();
@@ -176,11 +165,7 @@ const designNameInRelativePath = (
 /**
  * Score a dat set candidate for a design. Higher score = better match.
  */
-const scoreDatSetMatch = (
-  designDir: string,
-  designName: string,
-  datSet: DatFileSet,
-): number => {
+const scoreDatSetMatch = (designDir: string, designName: string, datSet: DatFileSet): number => {
   let score = 0;
 
   // Get relative path from design directory to dat set
@@ -219,7 +204,7 @@ interface MatchCandidate {
  */
 const matchDatSetsToDesigns = (
   designFiles: string[],
-  datSets: DatFileSet[],
+  datSets: DatFileSet[]
 ): Map<string, DatFileSet | null> => {
   const assignments = new Map<string, DatFileSet | null>();
 
@@ -260,10 +245,7 @@ const matchDatSetsToDesigns = (
   const assignedDesigns = new Set<string>();
 
   for (const candidate of candidates) {
-    if (
-      assignedDesigns.has(candidate.designPath) ||
-      usedDatSets.has(candidate.datSet.directory)
-    ) {
+    if (assignedDesigns.has(candidate.designPath) || usedDatSets.has(candidate.datSet.directory)) {
       continue;
     }
 
@@ -289,13 +271,17 @@ const normalizeSeparators = (p: string): string => {
 /**
  * Discover Cadence designs in a directory.
  * Uses subtree-scoped matching to associate .dat files with designs.
+ *
+ * @param rootDir - Root directory to search
+ * @param options - Discovery options (maxDepth)
  */
 export const discoverCadenceDesigns = async (
   rootDir: string,
+  options?: { maxDepth?: number }
 ): Promise<CadenceDiscoveredDesign[]> => {
   // Normalize separators before resolving to handle cross-platform paths
   const absoluteRootDir = path.resolve(normalizeSeparators(rootDir));
-  const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir);
+  const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir, options?.maxDepth);
 
   // Match dat sets to designs
   const assignments = matchDatSetsToDesigns(designFiles, datSets);
@@ -326,8 +312,7 @@ export const discoverCadenceDesigns = async (
     };
 
     if (!matchedDatSet) {
-      design.error =
-        "Netlist files not exported. Run export_cadence_netlist to generate them.";
+      design.error = "Netlist files not exported. Run export_cadence_netlist to generate them.";
     }
 
     designs.push(design);
@@ -340,23 +325,16 @@ export const discoverCadenceDesigns = async (
  * Find Cadence .dat files for a specific design file.
  * Searches in the design's directory and all subdirectories.
  */
-export const findCadenceDatFiles = async (
-  designFilePath: string,
-): Promise<CadenceDatFiles> => {
+export const findCadenceDatFiles = async (designFilePath: string): Promise<CadenceDatFiles> => {
   // Normalize separators before processing to handle cross-platform paths
   const normalizedPath = normalizeSeparators(designFilePath);
   const designDir = path.dirname(normalizedPath);
-  const designName = path.basename(
-    normalizedPath,
-    path.extname(normalizedPath),
-  );
+  const designName = path.basename(normalizedPath, path.extname(normalizedPath));
 
   const { datSets } = await walkForCadenceFiles(designDir);
 
   // Find dat sets in this design's subtree
-  const candidates = datSets.filter((ds) =>
-    isDescendantOrEqual(ds.directory, designDir),
-  );
+  const candidates = datSets.filter((ds) => isDescendantOrEqual(ds.directory, designDir));
 
   if (candidates.length === 0) {
     return { pstxnet: null, pstxprt: null, pstchip: null };
@@ -387,9 +365,7 @@ export const findCadenceDatFiles = async (
  */
 export const isCadenceFile = (filePath: string): boolean => {
   const ext = path.extname(filePath).toLowerCase();
-  return CADENCE_EXTENSIONS.includes(
-    ext as (typeof CADENCE_EXTENSIONS)[number],
-  );
+  return CADENCE_EXTENSIONS.includes(ext as (typeof CADENCE_EXTENSIONS)[number]);
 };
 
 /** Cadence file extensions */

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -8,13 +8,18 @@
  * 3. Import and register the handler here
  */
 
-import type { DiscoveredDesign, ParsedNetlist, EDAProjectFormatHandler } from '../types.js';
-import { cadenceHandler } from './cadence/index.js';
-import { altiumHandler } from './altium/index.js';
+import type {
+  DiscoveredDesign,
+  DiscoverDesignsOptions,
+  ParsedNetlist,
+  EDAProjectFormatHandler,
+} from "../types.js";
+import { cadenceHandler } from "./cadence/index.js";
+import { altiumHandler } from "./altium/index.js";
 
 // Re-export handlers for direct access
-export { cadenceHandler } from './cadence/index.js';
-export { altiumHandler } from './altium/index.js';
+export { cadenceHandler } from "./cadence/index.js";
+export { altiumHandler } from "./altium/index.js";
 
 /**
  * Registry of all supported EDA project format handlers.
@@ -31,8 +36,11 @@ export const findHandler = (filePath: string): EDAProjectFormatHandler | undefin
 /**
  * Discover all designs of all supported formats in a directory.
  */
-export const discoverDesigns = async (rootDir: string): Promise<DiscoveredDesign[]> => {
-  const results = await Promise.all(handlers.map((h) => h.discoverDesigns(rootDir)));
+export const discoverDesigns = async (
+  rootDir: string,
+  options?: DiscoverDesignsOptions
+): Promise<DiscoveredDesign[]> => {
+  const results = await Promise.all(handlers.map((h) => h.discoverDesigns(rootDir, options)));
   return results.flat().sort((a, b) => a.name.localeCompare(b.name));
 };
 
@@ -55,5 +63,4 @@ export const getHandlers = (): readonly EDAProjectFormatHandler[] => handlers;
 /**
  * Get all supported file extensions across all handlers.
  */
-export const getSupportedExtensions = (): string[] =>
-  handlers.flatMap((h) => [...h.extensions]);
+export const getSupportedExtensions = (): string[] => handlers.flatMap((h) => [...h.extensions]);

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -152,7 +152,7 @@ describe("toRelativePath", () => {
 });
 
 // =============================================================================
-// listDesigns — relative output
+// listDesigns — relative output (paths relative to search directory)
 // =============================================================================
 
 describe("listDesigns output paths", () => {
@@ -160,7 +160,7 @@ describe("listDesigns output paths", () => {
     vi.spyOn(process, "cwd").mockReturnValue("C:\\repo");
   });
 
-  it("returns relative path when on the same drive", async () => {
+  it("returns path relative to search directory (defaults to CWD)", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
@@ -175,6 +175,24 @@ describe("listDesigns output paths", () => {
     expect(Array.isArray(result)).toBe(true);
     const designPath = (result as Array<{ path: string }>)[0]?.path;
     expect(designPath).toBe("projects\\Board\\Board.PrjPcb");
+    expect(path.isAbsolute(designPath)).toBe(false);
+  });
+
+  it("returns path relative to explicit search path", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      {
+        name: "Board",
+        sourcePath: "C:\\repo\\projects\\Board\\Board.PrjPcb",
+        format: "altium",
+        schdocPaths: [],
+      },
+    ]);
+
+    const result = await listDesigns("C:\\repo\\projects");
+
+    expect(Array.isArray(result)).toBe(true);
+    const designPath = (result as Array<{ path: string }>)[0]?.path;
+    expect(designPath).toBe("Board\\Board.PrjPcb");
     expect(path.isAbsolute(designPath)).toBe(false);
   });
 
@@ -194,6 +212,79 @@ describe("listDesigns output paths", () => {
     const designPath = (result as Array<{ path: string }>)[0]?.path;
     expect(designPath).toBe("D:\\projects\\Board\\Board.PrjPcb");
     expect(path.isAbsolute(designPath)).toBe(true);
+  });
+});
+
+// =============================================================================
+// listDesigns — max_depth and max_results
+// =============================================================================
+
+describe("listDesigns max_depth", () => {
+  it("passes maxDepth to discoverDesigns", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns(undefined, ".*", 3);
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(expect.any(String), { maxDepth: 3 });
+  });
+
+  it("passes undefined maxDepth when not specified", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns();
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(expect.any(String), {
+      maxDepth: undefined,
+    });
+  });
+});
+
+describe("listDesigns max_results", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "cwd").mockReturnValue("C:\\repo");
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      {
+        name: "A",
+        sourcePath: "C:\\repo\\A\\A.dsn",
+        format: "cadence-cis",
+        datFiles: { pstxnet: null, pstxprt: null, pstchip: null },
+      },
+      {
+        name: "B",
+        sourcePath: "C:\\repo\\B\\B.dsn",
+        format: "cadence-cis",
+        datFiles: { pstxnet: null, pstxprt: null, pstchip: null },
+      },
+      {
+        name: "C",
+        sourcePath: "C:\\repo\\C\\C.dsn",
+        format: "cadence-cis",
+        datFiles: { pstxnet: null, pstxprt: null, pstchip: null },
+      },
+    ]);
+  });
+
+  it("limits results when max_results is set", async () => {
+    const result = await listDesigns(undefined, ".*", undefined, 2);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as Array<{ name: string }>).length).toBe(2);
+    expect((result as Array<{ name: string }>)[0].name).toBe("A");
+    expect((result as Array<{ name: string }>)[1].name).toBe("B");
+  });
+
+  it("returns all results when max_results is not set", async () => {
+    const result = await listDesigns();
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as Array<{ name: string }>).length).toBe(3);
+  });
+
+  it("returns all results when max_results exceeds count", async () => {
+    const result = await listDesigns(undefined, ".*", undefined, 10);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as Array<{ name: string }>).length).toBe(3);
   });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,9 +73,7 @@ Use \`export_cadence_netlist\` to generate Allegro-compatible netlist files from
 /**
  * Format a result as MCP tool response content.
  */
-const formatResult = (
-  result: unknown,
-): { content: { type: "text"; text: string }[] } => ({
+const formatResult = (result: unknown): { content: { type: "text"; text: string }[] } => ({
   content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
 });
 
@@ -97,7 +95,7 @@ export const createServer = (): McpServer => {
         tools: {},
       },
       instructions: SERVER_INSTRUCTIONS,
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -108,20 +106,28 @@ export const createServer = (): McpServer => {
     {
       description: "List all design projects in the given directory",
       inputSchema: {
-        path: z
-          .string()
+        path: z.string().optional().describe("Path to directory to search for designs"),
+        pattern: z.string().optional().describe("Regex pattern to filter design names"),
+        max_depth: z
+          .number()
+          .int()
+          .min(0)
           .optional()
-          .describe("Path to directory to search for designs"),
-        pattern: z
-          .string()
+          .describe(
+            "Maximum directory depth to recurse (0 = search path only). Omit for unlimited depth."
+          ),
+        max_results: z
+          .number()
+          .int()
+          .min(1)
           .optional()
-          .describe("Regex pattern to filter design names"),
+          .describe("Maximum number of designs to return. Omit for unlimited results."),
       },
     },
-    async ({ path, pattern }) => {
-      const result = await listDesigns(path, pattern);
+    async ({ path, pattern, max_depth, max_results }) => {
+      const result = await listDesigns(path, pattern, max_depth, max_results);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -132,11 +138,7 @@ export const createServer = (): McpServer => {
     {
       description: "List components of a specific type in a design",
       inputSchema: {
-        design: z
-          .string()
-          .describe(
-            "Path to design file (e.g., ./Design.PrjPcb)",
-          ),
+        design: z.string().describe("Path to design file (e.g., ./Design.PrjPcb)"),
         type: z.string().describe("Component prefix: U, C, R, L, etc."),
         include_dns: z
           .boolean()
@@ -148,7 +150,7 @@ export const createServer = (): McpServer => {
     async ({ design, type, include_dns }) => {
       const result = await listComponents(design, type, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -165,7 +167,7 @@ export const createServer = (): McpServer => {
     async ({ design }) => {
       const result = await listNets(design);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -183,7 +185,7 @@ export const createServer = (): McpServer => {
     async ({ pattern, design }) => {
       const result = await searchNets(pattern, design);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -196,21 +198,13 @@ export const createServer = (): McpServer => {
       inputSchema: {
         pattern: z.string().describe("Regex pattern for refdes"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
-      const result = await searchComponentsByRefdes(
-        pattern,
-        design,
-        include_dns,
-      );
+      const result = await searchComponentsByRefdes(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -219,22 +213,17 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_mpn",
     {
-      description:
-        "Search for components by MPN (Manufacturer Part Number) pattern",
+      description: "Search for components by MPN (Manufacturer Part Number) pattern",
       inputSchema: {
         pattern: z.string().describe("Regex pattern for MPN"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
       const result = await searchComponentsByMpn(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -247,21 +236,13 @@ export const createServer = (): McpServer => {
       inputSchema: {
         pattern: z.string().describe("Regex pattern for description"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
-      const result = await searchComponentsByDescription(
-        pattern,
-        design,
-        include_dns,
-      );
+      const result = await searchComponentsByDescription(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -278,22 +259,13 @@ export const createServer = (): McpServer => {
           .array(z.string())
           .optional()
           .describe("Component prefixes to exclude (e.g., ['C', 'L'])"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ design, net_name, skip_types, include_dns }) => {
-      const result = await queryXnetByNetName(
-        design,
-        net_name,
-        skip_types,
-        include_dns,
-      );
+      const result = await queryXnetByNetName(design, net_name, skip_types, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -305,29 +277,15 @@ export const createServer = (): McpServer => {
       description: "Get full XNET connectivity starting from a component pin",
       inputSchema: {
         design: z.string().describe("Path to design file"),
-        pin_name: z
-          .string()
-          .describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
-        skip_types: z
-          .array(z.string())
-          .optional()
-          .describe("Component prefixes to exclude"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        pin_name: z.string().describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
+        skip_types: z.array(z.string()).optional().describe("Component prefixes to exclude"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ design, pin_name, skip_types, include_dns }) => {
-      const result = await queryXnetByPinName(
-        design,
-        pin_name,
-        skip_types,
-        include_dns,
-      );
+      const result = await queryXnetByPinName(design, pin_name, skip_types, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -345,7 +303,7 @@ export const createServer = (): McpServer => {
     async ({ design, refdes }) => {
       const result = await queryComponent(design, refdes);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -363,7 +321,7 @@ export const createServer = (): McpServer => {
     async ({ design }) => {
       const result = await exportCadenceNetlist(design);
       return formatResult(result);
-    },
+    }
   );
 
   return server;

--- a/src/service.ts
+++ b/src/service.ts
@@ -345,10 +345,14 @@ const aggregateCircuitByMpn = (
  *
  * @param searchPath - Path to search (defaults to current working directory)
  * @param pattern - Regex pattern to filter design names
+ * @param maxDepth - Maximum directory depth to recurse (0 = search path only, undefined = unlimited)
+ * @param maxResults - Maximum number of designs to return (undefined = unlimited)
  */
 export const listDesigns = async (
   searchPath?: string,
-  pattern = ".*"
+  pattern = ".*",
+  maxDepth?: number,
+  maxResults?: number
 ): Promise<Array<{ name: string; path: string; error?: string }> | ErrorResult> => {
   const resolvedPath = resolvePath(searchPath ?? ".");
 
@@ -359,14 +363,30 @@ export const listDesigns = async (
     return { error: `Invalid regex pattern '${pattern}'` };
   }
 
-  const designs = await discoverDesigns(resolvedPath);
-  return designs
-    .filter((design) => regex.test(design.name))
-    .map((design) => ({
-      name: design.name,
-      path: toRelativePath(design.sourcePath),
-      error: design.error,
-    }));
+  const designs = await discoverDesigns(resolvedPath, { maxDepth });
+  let filtered = designs.filter((design) => regex.test(design.name));
+  if (maxResults !== undefined && filtered.length > maxResults) {
+    filtered = filtered.slice(0, maxResults);
+  }
+  return filtered.map((design) => ({
+    name: design.name,
+    path: toSearchRelativePath(design.sourcePath, resolvedPath),
+    error: design.error,
+  }));
+};
+
+/**
+ * Convert an absolute path to a clean path relative to the search directory.
+ * Returns absolute path if the target is not within the search directory
+ * (e.g., different drive on Windows, or parent directory traversal).
+ */
+const toSearchRelativePath = (absolutePath: string, searchDir: string): string => {
+  const rel = path.relative(searchDir, absolutePath);
+  // If relative path requires ".." traversal or is absolute (cross-drive on Windows), use absolute
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return absolutePath;
+  }
+  return rel;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,7 @@ import type { AltiumDiscoveredDesign } from "./parsers/altium/discovery.js";
  * Compact single-element arrays to scalar values for token savings.
  * Returns the single element if array has length 1, otherwise returns the array.
  */
-export const compactArray = <T>(arr: T[]): T | T[] =>
-  arr.length === 1 ? arr[0] : arr;
+export const compactArray = <T>(arr: T[]): T | T[] => (arr.length === 1 ? arr[0] : arr);
 
 /**
  * Net connections from netlist
@@ -36,7 +35,7 @@ export type PinEntry = string | { name: string; net: string };
 export const createPinEntry = (
   pinNumber: string,
   pinName: string | undefined,
-  netName: string,
+  netName: string
 ): PinEntry => {
   const normalizedName = pinName?.trim();
   if (normalizedName && normalizedName !== pinNumber) {
@@ -234,6 +233,14 @@ export const isErrorResult = (result: unknown): result is ErrorResult =>
   Boolean(result && typeof (result as ErrorResult).error === "string");
 
 /**
+ * Options for design discovery.
+ */
+export interface DiscoverDesignsOptions {
+  /** Maximum directory depth to recurse (0 = root only, undefined = unlimited) */
+  maxDepth?: number;
+}
+
+/**
  * Handler interface for EDA project format plugins.
  * Each EDA tool (Cadence, Altium, KiCad, etc.) implements this interface.
  */
@@ -248,7 +255,7 @@ export interface EDAProjectFormatHandler {
   canHandle(filePath: string): boolean;
 
   /** Discover all designs of this format in a directory */
-  discoverDesigns(rootDir: string): Promise<DiscoveredDesign[]>;
+  discoverDesigns(rootDir: string, options?: DiscoverDesignsOptions): Promise<DiscoveredDesign[]>;
 
   /** Parse a design file into the unified ParsedNetlist format */
   parse(designPath: string): Promise<ParsedNetlist>;


### PR DESCRIPTION
Add max_depth and max_results parameters to list_designs to prevent
unbounded recursive searches that exhaust token limits on large projects.
Change path output to be relative to the search directory instead of CWD,
eliminating confusing ../../../ traversal paths.

- Add maxDepth parameter to Cadence and Altium directory walk functions
- Add DiscoverDesignsOptions type and thread through handler interface
- Add max_depth (directory recursion limit) to list_designs tool schema
- Add max_results (output count cap) to list_designs tool schema
- Return paths relative to search path, falling back to absolute for
  cross-drive or out-of-scope targets
- Add tests for new parameters and path behavior

https://claude.ai/code/session_012A433hjhjW7fqGTyD4E66u