### PR TITLE
Add max_depth and max_results to list_designs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,32 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request. Focus on:
+            - Correctness and potential bugs
+            - Security concerns
+            - Performance considerations
+            - Adherence to project conventions in CLAUDE.md
+
+            Be concise and constructive. Only flag issues that matter.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/src/parsers/altium/discovery.ts
+++ b/src/parsers/altium/discovery.ts
@@ -94,14 +94,18 @@ const readProjectSchDocs = async (projectPath: string): Promise<string[]> => {
 
 /**
  * Walk directory tree to find Altium-related files.
+ *
+ * @param rootDir - Root directory to search
+ * @param maxDepth - Maximum recursion depth (0 = root only). Omit for unlimited.
  */
 const walkForAltiumFiles = async (
   rootDir: string,
+  maxDepth?: number,
 ): Promise<{ projects: string[]; schdocs: string[] }> => {
   const projects: string[] = [];
   const schdocs: string[] = [];
 
-  const walk = async (currentDir: string): Promise<void> => {
+  const walk = async (currentDir: string, depth: number): Promise<void> => {
     let entries;
     try {
       entries = await readdir(currentDir, { withFileTypes: true });
@@ -119,7 +123,9 @@ const walkForAltiumFiles = async (
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        await walk(fullPath);
+        if (maxDepth === undefined || depth < maxDepth) {
+          await walk(fullPath, depth + 1);
+        }
         continue;
       }
 
@@ -137,7 +143,7 @@ const walkForAltiumFiles = async (
     }
   };
 
-  await walk(rootDir);
+  await walk(rootDir, 0);
   return { projects, schdocs };
 };
 
@@ -161,9 +167,10 @@ const fallbackProjectSchDocs = (
  */
 export const discoverAltiumDesigns = async (
   rootDir: string,
+  options?: { maxDepth?: number },
 ): Promise<AltiumDiscoveredDesign[]> => {
   const absoluteRootDir = path.resolve(rootDir);
-  const { projects, schdocs } = await walkForAltiumFiles(absoluteRootDir);
+  const { projects, schdocs } = await walkForAltiumFiles(absoluteRootDir, options?.maxDepth);
 
   const designs: AltiumDiscoveredDesign[] = [];
 

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -52,14 +52,18 @@ interface DatFileSet {
 
 /**
  * Walk directory tree to find Cadence design files and complete .dat file sets.
+ *
+ * @param rootDir - Root directory to search
+ * @param maxDepth - Maximum recursion depth (0 = root only). Omit for unlimited.
  */
 const walkForCadenceFiles = async (
   rootDir: string,
+  maxDepth?: number,
 ): Promise<{ designFiles: string[]; datSets: DatFileSet[] }> => {
   const designFiles: string[] = [];
   const datFilesByDir = new Map<string, Map<string, string>>();
 
-  const walk = async (currentDir: string): Promise<void> => {
+  const walk = async (currentDir: string, depth: number): Promise<void> => {
     let entries;
     try {
       entries = await readdir(currentDir, { withFileTypes: true });
@@ -77,7 +81,9 @@ const walkForCadenceFiles = async (
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        await walk(fullPath);
+        if (maxDepth === undefined || depth < maxDepth) {
+          await walk(fullPath, depth + 1);
+        }
         continue;
       }
 
@@ -108,7 +114,7 @@ const walkForCadenceFiles = async (
     }
   };
 
-  await walk(rootDir);
+  await walk(rootDir, 0);
 
   // Convert to complete DatFileSets (only directories with all 3 required files)
   const datSets: DatFileSet[] = [];
@@ -292,10 +298,11 @@ const normalizeSeparators = (p: string): string => {
  */
 export const discoverCadenceDesigns = async (
   rootDir: string,
+  options?: { maxDepth?: number },
 ): Promise<CadenceDiscoveredDesign[]> => {
   // Normalize separators before resolving to handle cross-platform paths
   const absoluteRootDir = path.resolve(normalizeSeparators(rootDir));
-  const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir);
+  const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir, options?.maxDepth);
 
   // Match dat sets to designs
   const assignments = matchDatSetsToDesigns(designFiles, datSets);

--- a/src/parsers/discovery.test.ts
+++ b/src/parsers/discovery.test.ts
@@ -140,6 +140,65 @@ describe("discoverDesigns", () => {
     });
   });
 
+  describe("maxDepth", () => {
+    it("should find designs at depth 0 (root only)", async () => {
+      // Design file directly in testDir
+      await writeFile(join(testDir, "root.DSN"), "");
+
+      // Design file one level deep — should NOT be found
+      const subDir = join(testDir, "sub");
+      await mkdir(subDir, { recursive: true });
+      await writeFile(join(subDir, "nested.DSN"), "");
+
+      const designs = await discoverDesigns(testDir, { maxDepth: 0 });
+      expect(designs).toHaveLength(1);
+      expect(designs[0].name).toBe("root");
+    });
+
+    it("should find designs up to depth 1", async () => {
+      await writeFile(join(testDir, "root.DSN"), "");
+
+      const subDir = join(testDir, "sub");
+      await mkdir(subDir, { recursive: true });
+      await writeFile(join(subDir, "shallow.DSN"), "");
+
+      const deepDir = join(subDir, "deep");
+      await mkdir(deepDir, { recursive: true });
+      await writeFile(join(deepDir, "deep.DSN"), "");
+
+      const designs = await discoverDesigns(testDir, { maxDepth: 1 });
+      const names = designs.map((d) => d.name).sort();
+      expect(names).toEqual(["root", "shallow"]);
+    });
+
+    it("should find all designs when maxDepth is omitted", async () => {
+      await writeFile(join(testDir, "root.DSN"), "");
+
+      const deepDir = join(testDir, "a", "b", "c");
+      await mkdir(deepDir, { recursive: true });
+      await writeFile(join(deepDir, "deep.DSN"), "");
+
+      const designs = await discoverDesigns(testDir);
+      expect(designs).toHaveLength(2);
+    });
+
+    it("should respect maxDepth for Altium projects", async () => {
+      // Project at depth 1 — should be found with maxDepth: 1
+      const projectDir = join(testDir, "project");
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(join(projectDir, "board.PrjPcb"), "");
+
+      // Project at depth 2 — should NOT be found with maxDepth: 1
+      const deepDir = join(testDir, "a", "b");
+      await mkdir(deepDir, { recursive: true });
+      await writeFile(join(deepDir, "deep.PrjPcb"), "");
+
+      const designs = await discoverDesigns(testDir, { maxDepth: 1 });
+      expect(designs).toHaveLength(1);
+      expect(designs[0].name).toBe("board");
+    });
+  });
+
   describe("Multiple formats", () => {
     it("should discover both Cadence and Altium designs", async () => {
       // Cadence design

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -8,7 +8,7 @@
  * 3. Import and register the handler here
  */
 
-import type { DiscoveredDesign, ParsedNetlist, EDAProjectFormatHandler } from '../types.js';
+import type { DiscoveredDesign, DiscoverDesignsOptions, ParsedNetlist, EDAProjectFormatHandler } from '../types.js';
 import { cadenceHandler } from './cadence/index.js';
 import { altiumHandler } from './altium/index.js';
 
@@ -31,8 +31,8 @@ export const findHandler = (filePath: string): EDAProjectFormatHandler | undefin
 /**
  * Discover all designs of all supported formats in a directory.
  */
-export const discoverDesigns = async (rootDir: string): Promise<DiscoveredDesign[]> => {
-  const results = await Promise.all(handlers.map((h) => h.discoverDesigns(rootDir)));
+export const discoverDesigns = async (rootDir: string, options?: DiscoverDesignsOptions): Promise<DiscoveredDesign[]> => {
+  const results = await Promise.all(handlers.map((h) => h.discoverDesigns(rootDir, options)));
   return results.flat().sort((a, b) => a.name.localeCompare(b.name));
 };
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -1,7 +1,7 @@
 /**
  * Path resolution tests.
  *
- * All tests run under win32 path semantics (vi.mock("path") → path.win32)
+ * All tests run under win32 path semantics (vi.mock("path") -> path.win32)
  * so they are deterministic across macOS/Linux/Windows CI.
  */
 import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
@@ -70,7 +70,6 @@ vi.mock("./parsers/index.js", () => ({
 // =============================================================================
 
 let resolvePath: typeof import("./paths.js").resolvePath;
-let toRelativePath: typeof import("./paths.js").toRelativePath;
 let listDesigns: typeof import("./service.js").listDesigns;
 let exportCadenceNetlist: typeof import("./service.js").exportCadenceNetlist;
 let parsers: typeof import("./parsers/index.js");
@@ -84,7 +83,7 @@ const definePlatform = (value: string) => {
 
 beforeAll(async () => {
   path = await import("path");
-  ({ resolvePath, toRelativePath } = await import("./paths.js"));
+  ({ resolvePath } = await import("./paths.js"));
   parsers = await import("./parsers/index.js");
   ({ listDesigns, exportCadenceNetlist } = await import("./service.js"));
 });
@@ -126,45 +125,15 @@ describe("resolvePath", () => {
 });
 
 // =============================================================================
-// toRelativePath
-// =============================================================================
-
-describe("toRelativePath", () => {
-  it("converts absolute path under CWD to relative", () => {
-    const rel = toRelativePath("C:\\projects\\Board\\Board.PrjPcb");
-    expect(rel).toBe("Board\\Board.PrjPcb");
-    expect(path.isAbsolute(rel)).toBe(false);
-  });
-
-  it("returns empty string for CWD itself", () => {
-    expect(toRelativePath("C:\\projects")).toBe("");
-  });
-
-  it("uses .. for paths above CWD", () => {
-    expect(toRelativePath("C:\\")).toBe("..");
-  });
-
-  it("returns absolute path when on a different drive (no relative representation)", () => {
-    const result = toRelativePath("D:\\other\\design.dsn");
-    expect(result).toBe("D:\\other\\design.dsn");
-    expect(path.isAbsolute(result)).toBe(true);
-  });
-});
-
-// =============================================================================
-// listDesigns — relative output
+// listDesigns — absolute output paths
 // =============================================================================
 
 describe("listDesigns output paths", () => {
-  beforeEach(() => {
-    vi.spyOn(process, "cwd").mockReturnValue("C:\\repo");
-  });
-
-  it("returns relative path when on the same drive", async () => {
+  it("returns absolute paths", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
-        sourcePath: "C:\\repo\\projects\\Board\\Board.PrjPcb",
+        sourcePath: "C:\\projects\\Board\\Board.PrjPcb",
         format: "altium",
         schdocPaths: [],
       },
@@ -174,57 +143,179 @@ describe("listDesigns output paths", () => {
 
     expect(Array.isArray(result)).toBe(true);
     const designPath = (result as Array<{ path: string }>)[0]?.path;
-    expect(designPath).toBe("projects\\Board\\Board.PrjPcb");
-    expect(path.isAbsolute(designPath)).toBe(false);
-  });
-
-  it("falls back to absolute path when drives differ", async () => {
-    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
-      {
-        name: "Board",
-        sourcePath: "D:\\projects\\Board\\Board.PrjPcb",
-        format: "altium",
-        schdocPaths: [],
-      },
-    ]);
-
-    const result = await listDesigns();
-
-    expect(Array.isArray(result)).toBe(true);
-    const designPath = (result as Array<{ path: string }>)[0]?.path;
-    expect(designPath).toBe("D:\\projects\\Board\\Board.PrjPcb");
+    expect(designPath).toBe("C:\\projects\\Board\\Board.PrjPcb");
     expect(path.isAbsolute(designPath)).toBe(true);
   });
 });
 
 // =============================================================================
-// exportCadenceNetlist — relative output
+// listDesigns — searchPath and pattern
+// =============================================================================
+
+describe("listDesigns searchPath and pattern", () => {
+  it("resolves searchPath and passes it to discoverDesigns", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns({ searchPath: "sub\\dir" });
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
+      "C:\\projects\\sub\\dir",
+      expect.any(Object),
+    );
+  });
+
+  it("defaults searchPath to CWD", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns();
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
+      "C:\\projects",
+      expect.any(Object),
+    );
+  });
+
+  it("filters designs by pattern", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      { name: "Alpha", sourcePath: "C:\\Alpha.PrjPcb", format: "altium", schdocPaths: [] },
+      { name: "Beta", sourcePath: "C:\\Beta.PrjPcb", format: "altium", schdocPaths: [] },
+      { name: "AlphaV2", sourcePath: "C:\\AlphaV2.PrjPcb", format: "altium", schdocPaths: [] },
+    ]);
+
+    const result = await listDesigns({ pattern: "^Alpha" });
+
+    expect(Array.isArray(result)).toBe(true);
+    const names = (result as Array<{ name: string }>).map((d) => d.name);
+    expect(names).toEqual(["Alpha", "AlphaV2"]);
+  });
+
+  it("returns error for invalid regex pattern", async () => {
+    const result = await listDesigns({ pattern: "[invalid" });
+
+    expect(Array.isArray(result)).toBe(false);
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("Invalid regex pattern");
+  });
+});
+
+// =============================================================================
+// listDesigns — error passthrough
+// =============================================================================
+
+describe("listDesigns error passthrough", () => {
+  it("forwards design error field to output", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      {
+        name: "Broken",
+        sourcePath: "C:\\Broken.DSN",
+        format: "cadence-cis",
+        datFiles: { pstxnet: null, pstxprt: null, pstchip: null },
+        error: "Netlist files not exported.",
+      },
+    ]);
+
+    const result = await listDesigns();
+
+    expect(Array.isArray(result)).toBe(true);
+    const design = (result as Array<{ name: string; error?: string }>)[0];
+    expect(design.error).toBe("Netlist files not exported.");
+  });
+
+  it("omits error field when design has no error", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      { name: "Good", sourcePath: "C:\\Good.PrjPcb", format: "altium", schdocPaths: [] },
+    ]);
+
+    const result = await listDesigns();
+
+    expect(Array.isArray(result)).toBe(true);
+    const design = (result as Array<{ name: string; error?: string }>)[0];
+    expect(design.error).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// listDesigns — maxResults
+// =============================================================================
+
+describe("listDesigns maxResults", () => {
+  const makeDesigns = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      name: `Design${i}`,
+      sourcePath: `C:\\projects\\Design${i}\\Design${i}.PrjPcb`,
+      format: "altium" as const,
+      schdocPaths: [],
+    }));
+
+  it("defaults to 50 results", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue(makeDesigns(100));
+
+    const result = await listDesigns();
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(50);
+  });
+
+  it("respects custom maxResults", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue(makeDesigns(100));
+
+    const result = await listDesigns({ maxResults: 10 });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(10);
+  });
+
+  it("returns all results when fewer than maxResults", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue(makeDesigns(3));
+
+    const result = await listDesigns({ maxResults: 10 });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(3);
+  });
+});
+
+// =============================================================================
+// listDesigns — maxDepth
+// =============================================================================
+
+describe("listDesigns maxDepth", () => {
+  it("passes maxDepth to discoverDesigns", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns({ maxDepth: 2 });
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
+      expect.any(String),
+      { maxDepth: 2 },
+    );
+  });
+
+  it("passes undefined maxDepth when omitted", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    await listDesigns();
+
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
+      expect.any(String),
+      { maxDepth: undefined },
+    );
+  });
+});
+
+// =============================================================================
+// exportCadenceNetlist — absolute output paths
 // =============================================================================
 
 describe("exportCadenceNetlist output paths", () => {
-  beforeEach(() => {
-    vi.spyOn(process, "cwd").mockReturnValue("C:\\repo");
-  });
-
-  it("returns relative outputDir on the same drive", async () => {
+  it("returns absolute outputDir", async () => {
     const result = await exportCadenceNetlist("C:\\repo\\schem\\Board.dsn");
 
     if ("error" in result) {
       throw new Error(`Unexpected error: ${result.error}`);
     }
 
-    expect(result.outputDir).toBe("schem\\Allegro");
-    expect(path.isAbsolute(result.outputDir)).toBe(false);
-  });
-
-  it("falls back to absolute outputDir when drives differ", async () => {
-    const result = await exportCadenceNetlist("D:\\schem\\Board.dsn");
-
-    if ("error" in result) {
-      throw new Error(`Unexpected error: ${result.error}`);
-    }
-
-    expect(result.outputDir).toBe("D:\\schem\\Allegro");
+    expect(result.outputDir).toBe("C:\\repo\\schem\\Allegro");
     expect(path.isAbsolute(result.outputDir)).toBe(true);
   });
 });

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -235,6 +235,40 @@ describe("listDesigns error passthrough", () => {
 });
 
 // =============================================================================
+// listDesigns — filesystem errors
+// =============================================================================
+
+describe("listDesigns filesystem errors", () => {
+  it("returns error for nonexistent path", async () => {
+    vi.mocked(parsers.discoverDesigns).mockRejectedValue(
+      Object.assign(new Error("ENOENT: no such file or directory, scandir 'C:\\nonexistent'"), {
+        code: "ENOENT",
+      }),
+    );
+
+    const result = await listDesigns({ searchPath: "C:\\nonexistent" });
+
+    expect(Array.isArray(result)).toBe(false);
+    expect((result as { error: string }).error).toContain("Failed to search");
+    expect((result as { error: string }).error).toContain("ENOENT");
+  });
+
+  it("returns error when path is a file", async () => {
+    vi.mocked(parsers.discoverDesigns).mockRejectedValue(
+      Object.assign(new Error("ENOTDIR: not a directory, scandir 'C:\\file.txt'"), {
+        code: "ENOTDIR",
+      }),
+    );
+
+    const result = await listDesigns({ searchPath: "C:\\file.txt" });
+
+    expect(Array.isArray(result)).toBe(false);
+    expect((result as { error: string }).error).toContain("Failed to search");
+    expect((result as { error: string }).error).toContain("ENOTDIR");
+  });
+});
+
+// =============================================================================
 // listDesigns — maxResults
 // =============================================================================
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,8 +1,7 @@
 /**
  * Path resolution utilities.
  *
- * Converts between relative and absolute paths for tool input/output.
- * Relative paths are resolved against the current working directory.
+ * Resolves relative paths against the current working directory.
  */
 
 import path from "path";
@@ -28,14 +27,3 @@ export const resolvePath = (inputPath: string): string => {
   // On Unix, convert backslashes to forward slashes before normalizing
   return path.resolve(path.normalize(inputPath.replace(/\\/g, "/")));
 };
-
-/**
- * Convert an absolute path to a path relative to the current working directory.
- *
- * On Windows, when the target is on a different drive than CWD,
- * `path.relative()` returns an absolute path since no relative
- * representation exists. This is a known limitation — the absolute
- * path is returned as-is in that case.
- */
-export const toRelativePath = (absolutePath: string): string =>
-  path.relative(process.cwd(), absolutePath);

--- a/src/server.ts
+++ b/src/server.ts
@@ -116,10 +116,30 @@ export const createServer = (): McpServer => {
           .string()
           .optional()
           .describe("Regex pattern to filter design names"),
+        max_depth: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Max directory recursion depth (0 = no recursion). Omit for unlimited.",
+          ),
+        max_results: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .default(50)
+          .describe("Max designs to return. Default: 50."),
       },
     },
-    async ({ path, pattern }) => {
-      const result = await listDesigns(path, pattern);
+    async ({ path, pattern, max_depth, max_results }) => {
+      const result = await listDesigns({
+        searchPath: path,
+        pattern,
+        maxDepth: max_depth,
+        maxResults: max_results,
+      });
       return formatResult(result);
     },
   );

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,7 +10,7 @@ import * as fs from "fs";
 import path from "path";
 import { promisify } from "util";
 import { discoverDesigns, findHandler, parseDesign } from "./parsers/index.js";
-import { resolvePath, toRelativePath } from "./paths.js";
+import { resolvePath } from "./paths.js";
 
 import {
   naturalSort,
@@ -341,15 +341,22 @@ const aggregateCircuitByMpn = (
 // =============================================================================
 
 /**
+ * Options for listDesigns.
+ */
+export interface ListDesignsOptions {
+  searchPath?: string;
+  pattern?: string;
+  maxDepth?: number;
+  maxResults?: number;
+}
+
+/**
  * List all designs in a directory.
- *
- * @param searchPath - Path to search (defaults to current working directory)
- * @param pattern - Regex pattern to filter design names
  */
 export const listDesigns = async (
-  searchPath?: string,
-  pattern = ".*"
+  options: ListDesignsOptions = {}
 ): Promise<Array<{ name: string; path: string; error?: string }> | ErrorResult> => {
+  const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");
 
   let regex: RegExp;
@@ -359,14 +366,14 @@ export const listDesigns = async (
     return { error: `Invalid regex pattern '${pattern}'` };
   }
 
-  const designs = await discoverDesigns(resolvedPath);
-  return designs
-    .filter((design) => regex.test(design.name))
-    .map((design) => ({
-      name: design.name,
-      path: toRelativePath(design.sourcePath),
-      error: design.error,
-    }));
+  const designs = await discoverDesigns(resolvedPath, { maxDepth });
+  const filtered = designs.filter((design) => regex.test(design.name));
+  const limited = filtered.slice(0, maxResults);
+  return limited.map((design) => ({
+    name: design.name,
+    path: design.sourcePath,
+    error: design.error,
+  }));
 };
 
 /**
@@ -939,7 +946,7 @@ export const exportCadenceNetlist = async (
 
     return {
       success: true,
-      outputDir: toRelativePath(outputDir),
+      outputDir,
       log: (stdout + stderr).trim() || undefined,
       cadenceVersion: cadence.version,
       generatedFiles,

--- a/src/service.ts
+++ b/src/service.ts
@@ -366,7 +366,14 @@ export const listDesigns = async (
     return { error: `Invalid regex pattern '${pattern}'` };
   }
 
-  const designs = await discoverDesigns(resolvedPath, { maxDepth });
+  let designs;
+  try {
+    designs = await discoverDesigns(resolvedPath, { maxDepth });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error occurred";
+    return { error: `Failed to search '${resolvedPath}': ${message}` };
+  }
+
   const filtered = designs.filter((design) => regex.test(design.name));
   const limited = filtered.slice(0, maxResults);
   return limited.map((design) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,14 @@ export const isErrorResult = (result: unknown): result is ErrorResult =>
   Boolean(result && typeof (result as ErrorResult).error === "string");
 
 /**
+ * Options for design discovery.
+ */
+export interface DiscoverDesignsOptions {
+  /** Maximum directory recursion depth (0 = no recursion). Omit for unlimited. */
+  maxDepth?: number;
+}
+
+/**
  * Handler interface for EDA project format plugins.
  * Each EDA tool (Cadence, Altium, KiCad, etc.) implements this interface.
  */
@@ -248,7 +256,7 @@ export interface EDAProjectFormatHandler {
   canHandle(filePath: string): boolean;
 
   /** Discover all designs of this format in a directory */
-  discoverDesigns(rootDir: string): Promise<DiscoveredDesign[]>;
+  discoverDesigns(rootDir: string, options?: DiscoverDesignsOptions): Promise<DiscoveredDesign[]>;
 
   /** Parse a design file into the unified ParsedNetlist format */
   parse(designPath: string): Promise<ParsedNetlist>;


### PR DESCRIPTION
## Summary

Supersedes #3. Reimplemented from scratch on a fresh branch from `main`.

- Refactor `listDesigns` to accept an options object (`searchPath`, `pattern`, `maxDepth`, `maxResults`)
- Add depth-limited directory walking to both Altium and Cadence discovery (`maxDepth: 0` = root only, omit for unlimited)
- Default `maxResults` to 50 to prevent unbounded output
- Revert `list_designs` and `export_cadence_netlist` to return absolute paths (undo relative path changes from `89fd01e`)
- Remove `toRelativePath` from `paths.ts` (no longer used)

### MCP tool schema

```
list_designs(
  path?: string       "Path to directory to search for designs"
  pattern?: string    "Regex pattern to filter design names"
  max_depth?: int     "Max directory recursion depth (0 = no recursion). Omit for unlimited."
  max_results?: int   "Max designs to return. Default: 50."
)
```

### Files changed (9)

| File | What |
|------|------|
| `src/types.ts` | Add `DiscoverDesignsOptions`, update handler interface |
| `src/parsers/altium/discovery.ts` | `maxDepth` in walk |
| `src/parsers/cadence/discovery.ts` | `maxDepth` in walk |
| `src/parsers/index.ts` | Thread options to handlers |
| `src/service.ts` | Options object, absolute paths, remove `toRelativePath` |
| `src/server.ts` | Wire `max_depth`/`max_results` to tool schema |
| `src/paths.ts` | Remove `toRelativePath` |
| `src/paths.test.ts` | Updated tests for options object, absolute paths, new params |
| `src/parsers/discovery.test.ts` | Integration tests for `maxDepth` with real filesystem |

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 229 tests pass
- [x] Manual test via MCP: `max_depth: 0`, `1`, `3`, `5` against real fixtures
- [x] Manual test via MCP: `max_results: 3` correctly limits output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3