### PR TITLE
Release v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2026-02-04
+
+### Added
+
+- `list_designs`: add `max_depth` parameter to limit directory recursion depth ([#2](https://github.com/IntelligentElectron/universal-netlist/issues/2))
+- `list_designs`: add `max_results` parameter to cap returned designs (default: 50)
+- Claude Code GitHub Actions workflows for automated PR review
+
+### Fixed
+
+- `list_designs`: return absolute paths instead of confusing `..\..\` relative paths ([#2](https://github.com/IntelligentElectron/universal-netlist/issues/2))
+- `list_designs`: return structured error instead of crashing on nonexistent or invalid paths
+
 ## [0.0.13] - 2026-02-03
 
 ### Changed
@@ -122,6 +135,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `query_xnet_by_pin_name` - Trace connectivity from a pin
 - `export_cadence_netlist` - Export to Allegro format
 
+[0.0.14]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.14
+[0.0.13]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.13
+[0.0.12]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.12
+[0.0.11]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.11
+[0.0.10]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.10
 [0.0.9]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.9
 [0.0.8]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.8
 [0.0.7]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,22 @@ npm run type-check && npm run lint && npm test
 
 ### Releasing
 
-1. Update `CHANGELOG.md` with new version section
-2. Commit changelog: `git commit -am "Add vX.Y.Z changelog"`
-3. Bump version: `npm version patch -m "v%s"`
-4. Push: `git push && git push origin vX.Y.Z`
+Branch protection requires releases to go through a PR:
 
-The release workflow automatically:
+1. `git checkout -b release/vX.Y.Z`
+2. Update `CHANGELOG.md` with new version section
+3. `git commit -am "Add vX.Y.Z changelog"`
+4. `npm version patch -m "v%s"` (bumps `package.json`, creates commit)
+5. Push branch and open PR: `git push -u origin release/vX.Y.Z && gh pr create`
+6. Merge the PR
+7. Tag the merge commit and push:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+The tag push triggers the release workflow, which automatically:
 - Builds signed binaries for all platforms
 - Creates GitHub Release with binaries
 - Publishes to npm via OIDC (no tokens)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Add v0.0.14 changelog
- Bump version to 0.0.14

### Changes in this release

**Added**
- `list_designs`: `max_depth` parameter to limit directory recursion depth (#2)
- `list_designs`: `max_results` parameter to cap returned designs (default: 50)
- Claude Code GitHub Actions workflows for automated PR review

**Fixed**
- `list_designs`: return absolute paths instead of confusing relative paths (#2)
- `list_designs`: return structured error instead of crashing on nonexistent/invalid paths

## After merge

Tag the merge commit and push to trigger the release workflow:
```bash
git checkout main && git pull
git tag v0.0.14
git push origin v0.0.14
```