### PR TITLE
Update CLAUDE.md with setup, compilation, and release details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ MCP server for querying EDA netlists and tracing circuit connectivity. Supports 
 ### Setup
 
 ```bash
-npm install
+bun install         # Prefer bun over npm
+npm run setup       # Initialize test fixture submodules
 npm run dev
 ```
+
+**Note:** Test fixtures are git submodules. Run `npm run setup` after clone.
 
 ### Commands
 
@@ -24,7 +27,20 @@ npm run lint         # ESLint
 npm run lint:fix     # ESLint with auto-fix
 npm test             # Run tests with Vitest
 npm run test:watch   # Run tests in watch mode
+npm run compile:all  # Build all platform binaries
 ```
+
+### Binary Compilation
+
+Uses Bun to compile TypeScript into standalone executables:
+
+```bash
+bun build src/index.ts --compile --minify --target=bun-<platform> --outfile=bin/<name>-<platform>
+```
+
+Platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `windows-x64`
+
+macOS binaries require code signing with `entitlements.plist` (for Bun JIT) and Apple notarization.
 
 ### Before Committing
 
@@ -39,15 +55,19 @@ Branch protection requires releases to go through a PR:
 1. `git checkout -b release/vX.Y.Z`
 2. Update `CHANGELOG.md` with new version section
 3. `git commit -am "Add vX.Y.Z changelog"`
-4. `npm version patch -m "v%s"` (bumps `package.json`, creates commit)
-5. Push branch and open PR: `git push -u origin release/vX.Y.Z && gh pr create`
-6. Merge the PR
-7. Tag the merge commit and push:
+4. `npm version patch --no-git-tag-version` (bumps `package.json` only, no tag)
+5. `git commit -am "vX.Y.Z"`
+6. Push branch and open PR: `git push -u origin release/vX.Y.Z && gh pr create`
+7. Merge the PR
+8. Tag the merge commit and push:
+
    ```bash
    git checkout main && git pull
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
+
+   **Note:** Do NOT use `npm version` without `--no-git-tag-version` — it creates a local git tag that points to the release branch commit, not the merge commit on main. The tag must be created manually on the merge commit.
 
 The tag push triggers the release workflow, which automatically:
 - Builds signed binaries for all platforms


### PR DESCRIPTION
## Summary
- Prefer bun over npm for installation
- Add note about test fixture submodules requiring `npm run setup`
- Document binary compilation process and supported platforms
- Clarify release process to create tags on merge commit (not release branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)