### PR TITLE
Update README platforms table for macOS universal binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ Then enable it in **Configure Tools** (click the tools icon in Copilot chat).
 
 | Platform | Binary |
 |----------|--------|
-| macOS (Intel) | `universal-netlist-darwin-x64` |
-| macOS (Apple Silicon) | `universal-netlist-darwin-arm64` |
+| macOS (Universal) | `universal-netlist-darwin-universal` |
 | Linux (x64) | `universal-netlist-linux-x64` |
 | Linux (ARM64) | `universal-netlist-linux-arm64` |
 | Windows (x64) | `universal-netlist-windows-x64.exe` |


### PR DESCRIPTION
## Summary
- Replace separate macOS Intel and Apple Silicon rows with a single universal binary row in the supported platforms table

## Test plan
- [x] `npm run type-check && npm run lint && npm test` all pass
- [ ] Visually confirm table renders correctly in markdown preview