### PR TITLE
Release v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.16] - 2026-02-10
+
+### Fixed
+
+- Fix `export_cadence_netlist` to reuse existing `Allegro/` or `allegro/` output directory instead of always creating `Allegro/`
+
+### Changed
+
+- Extract `resolveAllegroDir` for Allegro output directory resolution
+- Clean up test formatting and remove redundant spy restores
+
 ## [0.0.15] - 2026-02-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -50,11 +50,13 @@ vi.mock("fs", async () => {
         if (normalized.includes("cadence")) {
           return ["SPB_17.4"];
         }
-        if (normalized.includes("allegro")) {
+        if (normalized.endsWith("allegro")) {
           return ["pstchip.dat", "pstxnet.dat", "pstxprt.dat"];
         }
-        return [];
+        // Schematic directory: contains DSN file and Allegro output folder
+        return ["Board.dsn", "Allegro"];
       }),
+      mkdir: vi.fn(async () => undefined),
     },
   };
 });
@@ -160,7 +162,7 @@ describe("listDesigns searchPath and pattern", () => {
 
     expect(parsers.discoverDesigns).toHaveBeenCalledWith(
       "C:\\projects\\sub\\dir",
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 
@@ -169,10 +171,7 @@ describe("listDesigns searchPath and pattern", () => {
 
     await listDesigns();
 
-    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
-      "C:\\projects",
-      expect.any(Object),
-    );
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith("C:\\projects", expect.any(Object));
   });
 
   it("filters designs by pattern", async () => {
@@ -243,7 +242,7 @@ describe("listDesigns filesystem errors", () => {
     vi.mocked(parsers.discoverDesigns).mockRejectedValue(
       Object.assign(new Error("ENOENT: no such file or directory, scandir 'C:\\nonexistent'"), {
         code: "ENOENT",
-      }),
+      })
     );
 
     const result = await listDesigns({ searchPath: "C:\\nonexistent" });
@@ -257,7 +256,7 @@ describe("listDesigns filesystem errors", () => {
     vi.mocked(parsers.discoverDesigns).mockRejectedValue(
       Object.assign(new Error("ENOTDIR: not a directory, scandir 'C:\\file.txt'"), {
         code: "ENOTDIR",
-      }),
+      })
     );
 
     const result = await listDesigns({ searchPath: "C:\\file.txt" });
@@ -319,10 +318,7 @@ describe("listDesigns maxDepth", () => {
 
     await listDesigns({ maxDepth: 2 });
 
-    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
-      expect.any(String),
-      { maxDepth: 2 },
-    );
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(expect.any(String), { maxDepth: 2 });
   });
 
   it("passes undefined maxDepth when omitted", async () => {
@@ -330,10 +326,9 @@ describe("listDesigns maxDepth", () => {
 
     await listDesigns();
 
-    expect(parsers.discoverDesigns).toHaveBeenCalledWith(
-      expect.any(String),
-      { maxDepth: undefined },
-    );
+    expect(parsers.discoverDesigns).toHaveBeenCalledWith(expect.any(String), {
+      maxDepth: undefined,
+    });
   });
 });
 

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -2,30 +2,20 @@
  * Service Unit Tests - MPN handling and notes
  */
 
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeAll,
-  afterAll,
-  beforeEach,
-} from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach, beforeEach } from "vitest";
 import {
   MPN_MISSING_NOTE,
   groupComponentsByMpn,
   aggregateCircuitByMpn,
   detectCadenceVersions,
   exportCadenceNetlist,
+  resolveAllegroDir,
 } from "./service.js";
-import type {
-  ComponentDetails,
-  CircuitComponent,
-  ErrorResult,
-  ParsedNetlist,
-} from "./types.js";
+import type { ComponentDetails, CircuitComponent, ErrorResult, ParsedNetlist } from "./types.js";
 import * as parsersModule from "./parsers/index.js";
 import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
 
 /**
  * Helper to check if result is an error.
@@ -46,9 +36,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       U1: { pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -63,9 +51,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       U1: { mpn: "TPS62088", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -78,9 +64,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       U1: { mpn: "", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -93,9 +77,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       U1: { mpn: "   ", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -117,9 +99,7 @@ describe("groupComponentsByMpn", () => {
         pins: { "1": "NET2", "2": "GND" },
       },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -133,9 +113,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       C1: { mpn: "CAP_0603", value: "10uF", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -147,9 +125,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       U1: { mpn: "TPS62088", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -166,9 +142,7 @@ describe("groupComponentsByMpn", () => {
         pins: { "1": "VCC", "2": "GND" },
       },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, true);
 
@@ -180,9 +154,7 @@ describe("groupComponentsByMpn", () => {
     const components: ComponentDetails = {
       C1: { mpn: "CAP_0603", pins: { "1": "VCC", "2": "GND" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -195,9 +167,7 @@ describe("groupComponentsByMpn", () => {
       U1: { description: "IC", pins: { "1": "VCC" } },
       U2: { description: "IC", pins: { "1": "VCC" } },
     };
-    const entries = Object.entries(components) as Array<
-      [string, ComponentDetails[string]]
-    >;
+    const entries = Object.entries(components) as Array<[string, ComponentDetails[string]]>;
 
     const result = groupComponentsByMpn(entries, false);
 
@@ -540,7 +510,7 @@ describe("detectCadenceVersions", () => {
 
   it("returns empty array when cadence directory does not exist", async () => {
     vi.spyOn(fs.promises, "readdir").mockRejectedValue(
-      new Error("ENOENT: no such file or directory"),
+      new Error("ENOENT: no such file or directory")
     );
 
     const versions = await detectCadenceVersions("/nonexistent/path");
@@ -581,5 +551,56 @@ describe("detectCadenceVersions", () => {
     // Without Cadence installed, no versions will be returned
     // But we've verified the readdir was called with our mock data
     expect(Array.isArray(versions)).toBe(true);
+  });
+});
+
+describe("resolveAllegroDir", () => {
+  let tmpDir: string;
+
+  const cleanup = async (dir: string) => {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  };
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netlist-test-"));
+  });
+
+  afterEach(async () => {
+    await cleanup(tmpDir);
+  });
+
+  it("uses existing Allegro/ directory", async () => {
+    await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
+    const result = await resolveAllegroDir(tmpDir);
+    expect(result.dirName).toBe("Allegro");
+    expect(result.outputDir).toBe(path.join(tmpDir, "Allegro"));
+  });
+
+  it("uses existing allegro/ directory", async () => {
+    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+    const result = await resolveAllegroDir(tmpDir);
+    expect(result.dirName).toBe("allegro");
+    expect(result.outputDir).toBe(path.join(tmpDir, "allegro"));
+  });
+
+  it("prefers Allegro/ over allegro/ when both exist", async () => {
+    // On case-insensitive FS (macOS), both dirs can't coexist.
+    // Use a mock to simulate case-sensitive FS behavior.
+    vi.spyOn(fs.promises, "readdir")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValueOnce(["Allegro", "allegro"] as any);
+    vi.spyOn(fs.promises, "mkdir").mockResolvedValueOnce(undefined);
+
+    const result = await resolveAllegroDir(tmpDir);
+    expect(result.dirName).toBe("Allegro");
+  });
+
+  it("creates allegro/ when neither exists", async () => {
+    const result = await resolveAllegroDir(tmpDir);
+    expect(result.dirName).toBe("allegro");
+    expect(result.outputDir).toBe(path.join(tmpDir, "allegro"));
+    const stat = await fs.promises.stat(result.outputDir);
+    expect(stat.isDirectory()).toBe(true);
   });
 });

--- a/src/service.ts
+++ b/src/service.ts
@@ -898,6 +898,30 @@ export const getLatestCadence = async (): Promise<CadenceInstall | null> => {
 };
 
 /**
+ * Resolve the Allegro output directory for netlist export.
+ * Uses an existing Allegro/ or allegro/ directory if present, otherwise creates allegro/.
+ */
+export const resolveAllegroDir = async (
+  dsnDir: string
+): Promise<{ outputDir: string; dirName: string }> => {
+  let dirName = "allegro";
+  try {
+    const entries = await fs.promises.readdir(dsnDir);
+    for (const candidate of ["Allegro", "allegro"]) {
+      if (entries.includes(candidate)) {
+        dirName = candidate;
+        break;
+      }
+    }
+  } catch {
+    // parent doesn't exist or can't be read
+  }
+  const outputDir = path.join(dsnDir, dirName);
+  await fs.promises.mkdir(outputDir, { recursive: true });
+  return { outputDir, dirName };
+};
+
+/**
  * Export Cadence schematic netlist to Allegro PCB format.
  * Uses the pstswp utility from Cadence SPB installation.
  *
@@ -927,14 +951,14 @@ export const exportCadenceNetlist = async (
   const resolvedDsnPath = resolvePath(dsnPath);
   const dsnDir = path.dirname(resolvedDsnPath);
   const dsnFile = path.basename(dsnPath);
-  const outputDir = path.join(dsnDir, "Allegro");
+  const { outputDir, dirName: outputDirName } = await resolveAllegroDir(dsnDir);
 
   // Convert to bash paths for command execution (GitBash compatibility)
   const bashDsnDir = toBashPath(dsnDir);
   const pstswp = toBashPath(cadence.pstswp);
   const config = toBashPath(cadence.config);
 
-  const command = `cd "${bashDsnDir}" && "${pstswp}" -pst -d "${dsnFile}" -n "Allegro" -c "${config}" -v 3 -l 255 -j "PCB Footprint"`;
+  const command = `cd "${bashDsnDir}" && "${pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${config}" -v 3 -l 255 -j "PCB Footprint"`;
 
   try {
     const { stdout, stderr } = await execAsync(command, {


### PR DESCRIPTION
## Summary

- Fix `export_cadence_netlist` to reuse existing `Allegro/` or `allegro/` output directory instead of always creating `Allegro/`
- Extract `resolveAllegroDir` for Allegro output directory resolution
- Clean up test formatting and remove redundant spy restores

## Test plan

- [x] `npm test` — all 235 tests pass