### PR TITLE
Update docs for v0.0.16 export_cadence_netlist changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `query_xnet_by_pin_name` - Trace connectivity from a pin
 - `export_cadence_netlist` - Export to Allegro format
 
+[0.0.16]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.16
 [0.0.15]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.15
 [0.0.14]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.14
 [0.0.13]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.13

--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -110,6 +110,6 @@ Response (success):
 
 - Cadence SPB is auto-detected from `C:/Cadence` (e.g., `C:/Cadence/SPB_17.4`)
 - When multiple versions are installed, the latest version is used
-- Output files are written to an `Allegro` subdirectory next to the schematic
+- Output files are written to an `Allegro/` or `allegro/` subdirectory next to the schematic (reuses whichever exists; creates `allegro/` if neither is present)
 - The export uses pstswp flags: `-pst -v 3 -l 255 -j "PCB Footprint"`
 - Timeout is set to 2 minutes for large designs


### PR DESCRIPTION
## Summary

- Document `Allegro/`/`allegro/` directory reuse behavior in `export_cadence_netlist` tool docs
- Add missing `[0.0.16]` release link in CHANGELOG

## Test plan

- [ ] Verify docs render correctly on GitHub