### PR TITLE
Fix export_cadence_netlist failing when .DSNlck lock files are present

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -9,6 +9,8 @@ import {
   aggregateCircuitByMpn,
   detectCadenceVersions,
   exportCadenceNetlist,
+  relocateLockFile,
+  restoreLockFile,
   resolveAllegroDir,
 } from "./service.js";
 import type { ComponentDetails, CircuitComponent, ErrorResult, ParsedNetlist } from "./types.js";
@@ -500,6 +502,97 @@ describe("exportCadenceNetlist", () => {
       expect((result as ErrorResult).error).toContain("Windows");
       expect((result as ErrorResult).error).toContain("pstswp");
     }
+  });
+});
+
+describe("relocateLockFile", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "lock-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when no lock file exists", async () => {
+    const dsnPath = path.join(tmpDir, "design.DSN");
+    await fs.promises.writeFile(dsnPath, "");
+
+    const result = await relocateLockFile(dsnPath);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("moves lock file to temp dir and returns temp path", async () => {
+    const dsnPath = path.join(tmpDir, "design.DSN");
+    const lockPath = path.join(tmpDir, "design.DSNlck");
+    await fs.promises.writeFile(dsnPath, "");
+    await fs.promises.writeFile(lockPath, "lock-content");
+
+    const tempPath = await relocateLockFile(dsnPath);
+
+    expect(tempPath).toBeDefined();
+    // Lock file should no longer exist at original location
+    await expect(fs.promises.access(lockPath)).rejects.toThrow();
+    // Lock file content should be at temp location
+    const content = await fs.promises.readFile(tempPath!, "utf-8");
+    expect(content).toBe("lock-content");
+
+    // Cleanup temp file
+    await fs.promises.unlink(tempPath!);
+  });
+
+  it("handles case-insensitive .dsn extension", async () => {
+    const dsnPath = path.join(tmpDir, "design.dsn");
+    const lockPath = path.join(tmpDir, "design.DSNlck");
+    await fs.promises.writeFile(dsnPath, "");
+    await fs.promises.writeFile(lockPath, "lock");
+
+    const tempPath = await relocateLockFile(dsnPath);
+
+    expect(tempPath).toBeDefined();
+    await expect(fs.promises.access(lockPath)).rejects.toThrow();
+
+    await fs.promises.unlink(tempPath!);
+  });
+});
+
+describe("restoreLockFile", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "lock-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("restores lock file from temp path to original location", async () => {
+    const dsnPath = path.join(tmpDir, "design.DSN");
+    const lockPath = path.join(tmpDir, "design.DSNlck");
+    const tempPath = path.join(tmpDir, "design.DSNlck.temp");
+    await fs.promises.writeFile(tempPath, "lock-content");
+
+    await restoreLockFile(dsnPath, tempPath);
+
+    const content = await fs.promises.readFile(lockPath, "utf-8");
+    expect(content).toBe("lock-content");
+    // Temp file should no longer exist
+    await expect(fs.promises.access(tempPath)).rejects.toThrow();
+  });
+
+  it("warns but does not throw when temp file is missing", async () => {
+    const dsnPath = path.join(tmpDir, "design.DSN");
+    const tempPath = path.join(tmpDir, "nonexistent.tmp");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await restoreLockFile(dsnPath, tempPath);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to restore lock file"));
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -7,6 +7,7 @@
 
 import { exec } from "child_process";
 import * as fs from "fs";
+import { tmpdir } from "os";
 import path from "path";
 import { promisify } from "util";
 import { discoverDesigns, findHandler, parseDesign } from "./parsers/index.js";
@@ -922,6 +923,35 @@ export const resolveAllegroDir = async (
 };
 
 /**
+ * Temporarily relocate a .DSNlck lock file so pstswp can proceed.
+ * Returns the temporary path if relocated, or undefined if no lock file exists.
+ */
+export const relocateLockFile = async (dsnPath: string): Promise<string | undefined> => {
+  const lockPath = dsnPath.replace(/\.DSN$/i, ".DSNlck");
+  try {
+    await fs.promises.access(lockPath);
+  } catch {
+    return undefined;
+  }
+  const tempPath = path.join(tmpdir(), `${path.basename(lockPath)}.${Date.now()}`);
+  await fs.promises.rename(lockPath, tempPath);
+  return tempPath;
+};
+
+/**
+ * Restore a previously relocated .DSNlck lock file.
+ * Logs a warning if restoration fails (e.g. temp file was cleaned up).
+ */
+export const restoreLockFile = async (dsnPath: string, tempPath: string): Promise<void> => {
+  const lockPath = dsnPath.replace(/\.DSN$/i, ".DSNlck");
+  try {
+    await fs.promises.rename(tempPath, lockPath);
+  } catch {
+    console.warn(`Failed to restore lock file. Temporary location: ${tempPath}`);
+  }
+};
+
+/**
  * Export Cadence schematic netlist to Allegro PCB format.
  * Uses the pstswp utility from Cadence SPB installation.
  *
@@ -952,6 +982,9 @@ export const exportCadenceNetlist = async (
   const dsnDir = path.dirname(resolvedDsnPath);
   const dsnFile = path.basename(dsnPath);
   const { outputDir, dirName: outputDirName } = await resolveAllegroDir(dsnDir);
+
+  // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
+  const lockTempPath = await relocateLockFile(resolvedDsnPath);
 
   // Convert to bash paths for command execution (GitBash compatibility)
   const bashDsnDir = toBashPath(dsnDir);
@@ -988,9 +1021,16 @@ export const exportCadenceNetlist = async (
       stdout?: string;
       stderr?: string;
     };
+    const lockNote = lockTempPath
+      ? ` A .DSNlck lock file was found and temporarily relocated — this is often the cause of pstswp failures.`
+      : "";
     return {
-      error: `Cadence pstswp failed: ${execError.message ?? "Unknown error"}`,
+      error: `Cadence pstswp failed: ${execError.message ?? "Unknown error"}${lockNote}`,
     };
+  } finally {
+    if (lockTempPath) {
+      await restoreLockFile(resolvedDsnPath, lockTempPath);
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

- Temporarily relocate `.DSNlck` lock files before invoking `pstswp.exe`, restoring them in a `finally` block
- Extract `relocateLockFile` / `restoreLockFile` helpers for testability
- Surface lock file presence in `pstswp` error messages

Closes #15

## Test plan

- [x] `relocateLockFile` returns `undefined` when no lock file exists
- [x] `relocateLockFile` moves lock file to temp dir and preserves content
- [x] `relocateLockFile` handles case-insensitive `.dsn` extension
- [x] `restoreLockFile` restores lock file to original location
- [x] `restoreLockFile` warns without throwing when temp file is missing
- [x] `npm run type-check && npm run lint && npm test` — 240 tests pass