### PR TITLE
Fix search tools rejecting (?i) inline regex flags

### DIFF
--- a/docs/tools/search_components_by_description.md
+++ b/docs/tools/search_components_by_description.md
@@ -105,6 +105,7 @@ Response:
 ## Notes
 
 - Pattern matching is **case-insensitive**
+- Inline flags like `(?i)` are accepted (matching is already case-insensitive by default)
 - Only searches components that have description data
 - If a design has no description data, `notes` will suggest asking for a BOM
 - Descriptions typically include package size, value, and function

--- a/docs/tools/search_components_by_mpn.md
+++ b/docs/tools/search_components_by_mpn.md
@@ -104,6 +104,7 @@ Response:
 ## Notes
 
 - Pattern matching is **case-insensitive**
+- Inline flags like `(?i)` are accepted (matching is already case-insensitive by default)
 - Only searches components that have MPN data
 - If a design has no MPN data at all, `notes` will suggest asking for a BOM
 - Components without MPN cannot be found with this tool; use `search_components_by_refdes` instead

--- a/docs/tools/search_components_by_refdes.md
+++ b/docs/tools/search_components_by_refdes.md
@@ -89,6 +89,7 @@ Response:
 ## Notes
 
 - Pattern matching is **case-insensitive** (unlike `search_nets`)
+- Inline flags like `(?i)` are accepted (matching is already case-insensitive by default)
 - Results are grouped by MPN for compactness
 - Components without MPN are listed individually with a `notes` field
 - Single-element arrays are compacted to scalar strings

--- a/docs/tools/search_nets.md
+++ b/docs/tools/search_nets.md
@@ -93,10 +93,12 @@ Response:
 | `_[PN]$` | Nets ending with "_P" or "_N" (differential pairs) |
 | `SPI.*MOSI` | SPI MOSI signals |
 | `CLK\|CLOCK` | Nets containing "CLK" or "CLOCK" |
+| `(?i)vdd` | Case-insensitive: matches "VDD", "vdd", "Vdd" |
 
 ## Notes
 
-- Pattern matching is case-sensitive
+- Pattern matching is case-sensitive by default
+- Inline flags like `(?i)` are supported for case-insensitive matching
 - Results are sorted alphabetically
 - The design name (without extension) is used as the results key
 - Empty results include a `notes` field explaining the empty match

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -7,6 +7,7 @@ import {
   MPN_MISSING_NOTE,
   groupComponentsByMpn,
   aggregateCircuitByMpn,
+  parseRegexPattern,
   detectCadenceVersions,
   exportCadenceNetlist,
   relocateLockFile,
@@ -361,6 +362,104 @@ describe("aggregateCircuitByMpn", () => {
     expect(result).toHaveLength(1);
     expect(result[0].description).toBeUndefined();
     expect("description" in result[0]).toBe(false);
+  });
+});
+
+describe("parseRegexPattern", () => {
+  it("returns regex for plain pattern with no flags", () => {
+    const result = parseRegexPattern("foo");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.source).toBe("foo");
+      expect(result.regex.flags).toBe("");
+    }
+  });
+
+  it("applies default flags when no inline flags present", () => {
+    const result = parseRegexPattern("foo", "i");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.flags).toBe("i");
+    }
+  });
+
+  it("strips (?i) and applies i flag", () => {
+    const result = parseRegexPattern("(?i)vdd");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.source).toBe("vdd");
+      expect(result.regex.flags).toBe("i");
+    }
+  });
+
+  it("strips (?m) and applies m flag", () => {
+    const result = parseRegexPattern("(?m)^line");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.source).toBe("^line");
+      expect(result.regex.flags).toBe("m");
+    }
+  });
+
+  it("strips combined (?im) flags", () => {
+    const result = parseRegexPattern("(?im)pattern");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.source).toBe("pattern");
+      expect(result.regex.flags).toContain("i");
+      expect(result.regex.flags).toContain("m");
+    }
+  });
+
+  it("deduplicates when inline flag matches default", () => {
+    const result = parseRegexPattern("(?i)test", "i");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.flags).toBe("i");
+    }
+  });
+
+  it("merges inline flags with different defaults", () => {
+    const result = parseRegexPattern("(?m)test", "i");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.flags).toContain("i");
+      expect(result.regex.flags).toContain("m");
+    }
+  });
+
+  it("returns error for (?i) in the middle of pattern", () => {
+    const result = parseRegexPattern("foo(?i)bar");
+    expect("error" in result).toBe(true);
+  });
+
+  it("does not strip scoped group (?i:...)", () => {
+    const result = parseRegexPattern("(?i:foo)bar");
+    expect("error" in result).toBe(true);
+  });
+
+  it("returns error for invalid regex after flag stripping", () => {
+    const result = parseRegexPattern("(?i)[unclosed");
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("Invalid regex pattern");
+    }
+  });
+
+  it("(?i)vdd matches VDD_1V8", () => {
+    const result = parseRegexPattern("(?i)vdd");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.test("VDD_1V8")).toBe(true);
+    }
+  });
+
+  it("plain vdd does NOT match VDD_1V8", () => {
+    const result = parseRegexPattern("vdd");
+    expect("regex" in result).toBe(true);
+    if ("regex" in result) {
+      expect(result.regex.test("VDD_1V8")).toBe(false);
+    }
   });
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -338,6 +338,35 @@ const aggregateCircuitByMpn = (
 };
 
 // =============================================================================
+// Regex Helpers
+// =============================================================================
+
+/**
+ * Parse PCRE-style inline flags from a regex pattern and convert to JS RegExp flags.
+ * Supports (?i), (?m), (?s), (?u) and combinations like (?im) at the start of the pattern.
+ */
+const parseRegexPattern = (
+  pattern: string,
+  defaultFlags = ""
+): { regex: RegExp } | { error: string } => {
+  let flags = defaultFlags;
+  let cleanPattern = pattern;
+
+  const inlineFlagMatch = cleanPattern.match(/^\(\?([imsu]+)\)/);
+  if (inlineFlagMatch) {
+    cleanPattern = cleanPattern.slice(inlineFlagMatch[0].length);
+    const allFlags = new Set([...flags, ...inlineFlagMatch[1]]);
+    flags = [...allFlags].filter((f) => "gimsuvy".includes(f)).join("");
+  }
+
+  try {
+    return { regex: new RegExp(cleanPattern, flags) };
+  } catch {
+    return { error: `Invalid regex pattern '${pattern}'` };
+  }
+};
+
+// =============================================================================
 // Public API
 // =============================================================================
 
@@ -360,12 +389,9 @@ export const listDesigns = async (
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");
 
-  let regex: RegExp;
-  try {
-    regex = new RegExp(pattern);
-  } catch {
-    return { error: `Invalid regex pattern '${pattern}'` };
-  }
+  const parsed = parseRegexPattern(pattern);
+  if ("error" in parsed) return parsed;
+  const regex = parsed.regex;
 
   let designs;
   try {
@@ -451,12 +477,9 @@ export const searchNets = async (
   pattern: string,
   design: string
 ): Promise<SearchNetsResult | ErrorResult> => {
-  let regex: RegExp;
-  try {
-    regex = new RegExp(pattern);
-  } catch {
-    return { error: `Invalid regex pattern '${pattern}'` };
-  }
+  const parsed = parseRegexPattern(pattern);
+  if ("error" in parsed) return parsed;
+  const regex = parsed.regex;
 
   const netlist = await loadNetlist(design);
   if (isErrorResult(netlist)) {
@@ -489,13 +512,9 @@ export const searchComponentsByRefdes = async (
   design: string,
   includeDns = false
 ): Promise<SearchComponentsResult | ErrorResult> => {
-  // TODO: Support (?i) inline flag for case-insensitive matching
-  let regex: RegExp;
-  try {
-    regex = new RegExp(pattern, "i");
-  } catch {
-    return { error: `Invalid regex pattern '${pattern}'` };
-  }
+  const parsed = parseRegexPattern(pattern, "i");
+  if ("error" in parsed) return parsed;
+  const regex = parsed.regex;
 
   const netlist = await loadNetlist(design);
   if (isErrorResult(netlist)) {
@@ -529,13 +548,9 @@ export const searchComponentsByMpn = async (
   design: string,
   includeDns = false
 ): Promise<SearchComponentsResult | ErrorResult> => {
-  // TODO: Support (?i) inline flag for case-insensitive matching
-  let regex: RegExp;
-  try {
-    regex = new RegExp(pattern, "i");
-  } catch {
-    return { error: `Invalid regex pattern '${pattern}'` };
-  }
+  const parsed = parseRegexPattern(pattern, "i");
+  if ("error" in parsed) return parsed;
+  const regex = parsed.regex;
 
   const netlist = await loadNetlist(design);
   if (isErrorResult(netlist)) {
@@ -582,13 +597,9 @@ export const searchComponentsByDescription = async (
   design: string,
   includeDns = false
 ): Promise<SearchComponentsResult | ErrorResult> => {
-  // TODO: Support (?i) inline flag for case-insensitive matching
-  let regex: RegExp;
-  try {
-    regex = new RegExp(pattern, "i");
-  } catch {
-    return { error: `Invalid regex pattern '${pattern}'` };
-  }
+  const parsed = parseRegexPattern(pattern, "i");
+  if ("error" in parsed) return parsed;
+  const regex = parsed.regex;
 
   const netlist = await loadNetlist(design);
   if (isErrorResult(netlist)) {
@@ -1042,4 +1053,4 @@ export const exportCadenceNetlist = async (
  * Internal exports for testing purposes only.
  * @internal
  */
-export { MPN_MISSING_NOTE, groupComponentsByMpn, aggregateCircuitByMpn };
+export { MPN_MISSING_NOTE, groupComponentsByMpn, aggregateCircuitByMpn, parseRegexPattern };


### PR DESCRIPTION
## Summary

- Add `parseRegexPattern` helper that strips PCRE-style inline flags (`(?i)`, `(?m)`, `(?s)`, `(?u)`, `(?im)`, etc.) from the start of regex patterns and converts them to JS `RegExp` flags
- Update all 5 search tool call sites (`listDesigns`, `searchNets`, `searchComponentsByRefdes`, `searchComponentsByMpn`, `searchComponentsByDescription`)
- Remove 3 TODO comments that tracked this issue
- Add 12 unit tests for the helper
- Document inline flag support in tool docs

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (252 tests)
- [x] End-to-end validation: `(?i)gnd` matches `GND` via `searchNets` on real fixture
- [x] End-to-end validation: `gnd` (no flag) does NOT match `GND` (case-sensitive default preserved)
- [x] Edge cases validated: empty body, combined flags, mid-pattern flags, scoped groups, lookaheads, invalid regex after stripping, 10k char patterns

Closes #14