### PR TITLE
Serialize export_cadence_netlist to prevent license conflicts

### DIFF
--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -113,3 +113,5 @@ Response (success):
 - Output files are written to an `Allegro/` or `allegro/` subdirectory next to the schematic (reuses whichever exists; creates `allegro/` if neither is present)
 - The export uses pstswp flags: `-pst -v 3 -l 255 -j "PCB Footprint"`
 - Timeout is set to 2 minutes for large designs
+- Concurrent calls are queued and run one at a time to avoid Cadence license conflicts
+- `.DSNlck` lock files are automatically relocated during export and restored afterward

--- a/src/async-mutex.test.ts
+++ b/src/async-mutex.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createMutex } from "./async-mutex.js";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("createMutex", () => {
+  it("serializes concurrent calls in FIFO order", async () => {
+    const serialize = createMutex();
+    const log: string[] = [];
+
+    const task = (id: string, ms: number) =>
+      serialize(async () => {
+        log.push(`start-${id}`);
+        await delay(ms);
+        log.push(`end-${id}`);
+      });
+
+    await Promise.all([task("A", 30), task("B", 10), task("C", 10)]);
+
+    expect(log).toEqual(["start-A", "end-A", "start-B", "end-B", "start-C", "end-C"]);
+  });
+
+  it("isolates errors — subsequent calls still execute", async () => {
+    const serialize = createMutex();
+
+    const failing = serialize(async () => {
+      throw new Error("boom");
+    });
+
+    const passing = serialize(async () => "ok");
+
+    await expect(failing).rejects.toThrow("boom");
+    await expect(passing).resolves.toBe("ok");
+  });
+
+  it("returns distinct results to each caller", async () => {
+    const serialize = createMutex();
+
+    const results = await Promise.all([
+      serialize(async () => {
+        await delay(10);
+        return 1;
+      }),
+      serialize(async () => {
+        await delay(10);
+        return 2;
+      }),
+      serialize(async () => {
+        await delay(10);
+        return 3;
+      }),
+    ]);
+
+    expect(results).toEqual([1, 2, 3]);
+  });
+});

--- a/src/async-mutex.ts
+++ b/src/async-mutex.ts
@@ -1,0 +1,17 @@
+/**
+ * Creates a promise-chain mutex that serializes async operations.
+ * Each call queues the provided function and waits for prior calls to complete.
+ * Errors are isolated — one rejection doesn't block subsequent calls.
+ */
+export const createMutex = (): (<T>(fn: () => Promise<T>) => Promise<T>) => {
+  let chain: Promise<void> = Promise.resolve();
+
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    const result = chain.then(fn);
+    chain = result.then(
+      () => {},
+      () => {}
+    );
+    return result;
+  };
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,9 +73,7 @@ Use \`export_cadence_netlist\` to generate Allegro-compatible netlist files from
 /**
  * Format a result as MCP tool response content.
  */
-const formatResult = (
-  result: unknown,
-): { content: { type: "text"; text: string }[] } => ({
+const formatResult = (result: unknown): { content: { type: "text"; text: string }[] } => ({
   content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
 });
 
@@ -97,7 +95,7 @@ export const createServer = (): McpServer => {
         tools: {},
       },
       instructions: SERVER_INSTRUCTIONS,
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -108,22 +106,14 @@ export const createServer = (): McpServer => {
     {
       description: "List all design projects in the given directory",
       inputSchema: {
-        path: z
-          .string()
-          .optional()
-          .describe("Path to directory to search for designs"),
-        pattern: z
-          .string()
-          .optional()
-          .describe("Regex pattern to filter design names"),
+        path: z.string().optional().describe("Path to directory to search for designs"),
+        pattern: z.string().optional().describe("Regex pattern to filter design names"),
         max_depth: z
           .number()
           .int()
           .min(0)
           .optional()
-          .describe(
-            "Max directory recursion depth (0 = no recursion). Omit for unlimited.",
-          ),
+          .describe("Max directory recursion depth (0 = no recursion). Omit for unlimited."),
         max_results: z
           .number()
           .int()
@@ -141,7 +131,7 @@ export const createServer = (): McpServer => {
         maxResults: max_results,
       });
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -152,11 +142,7 @@ export const createServer = (): McpServer => {
     {
       description: "List components of a specific type in a design",
       inputSchema: {
-        design: z
-          .string()
-          .describe(
-            "Path to design file (e.g., ./Design.PrjPcb)",
-          ),
+        design: z.string().describe("Path to design file (e.g., ./Design.PrjPcb)"),
         type: z.string().describe("Component prefix: U, C, R, L, etc."),
         include_dns: z
           .boolean()
@@ -168,7 +154,7 @@ export const createServer = (): McpServer => {
     async ({ design, type, include_dns }) => {
       const result = await listComponents(design, type, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -185,7 +171,7 @@ export const createServer = (): McpServer => {
     async ({ design }) => {
       const result = await listNets(design);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -203,7 +189,7 @@ export const createServer = (): McpServer => {
     async ({ pattern, design }) => {
       const result = await searchNets(pattern, design);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -216,21 +202,13 @@ export const createServer = (): McpServer => {
       inputSchema: {
         pattern: z.string().describe("Regex pattern for refdes"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
-      const result = await searchComponentsByRefdes(
-        pattern,
-        design,
-        include_dns,
-      );
+      const result = await searchComponentsByRefdes(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -239,22 +217,17 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_mpn",
     {
-      description:
-        "Search for components by MPN (Manufacturer Part Number) pattern",
+      description: "Search for components by MPN (Manufacturer Part Number) pattern",
       inputSchema: {
         pattern: z.string().describe("Regex pattern for MPN"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
       const result = await searchComponentsByMpn(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -267,21 +240,13 @@ export const createServer = (): McpServer => {
       inputSchema: {
         pattern: z.string().describe("Regex pattern for description"),
         design: z.string().describe("Path to design file"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ pattern, design, include_dns }) => {
-      const result = await searchComponentsByDescription(
-        pattern,
-        design,
-        include_dns,
-      );
+      const result = await searchComponentsByDescription(pattern, design, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -298,22 +263,13 @@ export const createServer = (): McpServer => {
           .array(z.string())
           .optional()
           .describe("Component prefixes to exclude (e.g., ['C', 'L'])"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ design, net_name, skip_types, include_dns }) => {
-      const result = await queryXnetByNetName(
-        design,
-        net_name,
-        skip_types,
-        include_dns,
-      );
+      const result = await queryXnetByNetName(design, net_name, skip_types, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -325,29 +281,15 @@ export const createServer = (): McpServer => {
       description: "Get full XNET connectivity starting from a component pin",
       inputSchema: {
         design: z.string().describe("Path to design file"),
-        pin_name: z
-          .string()
-          .describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
-        skip_types: z
-          .array(z.string())
-          .optional()
-          .describe("Component prefixes to exclude"),
-        include_dns: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe("Include DNS components"),
+        pin_name: z.string().describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
+        skip_types: z.array(z.string()).optional().describe("Component prefixes to exclude"),
+        include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
       },
     },
     async ({ design, pin_name, skip_types, include_dns }) => {
-      const result = await queryXnetByPinName(
-        design,
-        pin_name,
-        skip_types,
-        include_dns,
-      );
+      const result = await queryXnetByPinName(design, pin_name, skip_types, include_dns);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -365,7 +307,7 @@ export const createServer = (): McpServer => {
     async ({ design, refdes }) => {
       const result = await queryComponent(design, refdes);
       return formatResult(result);
-    },
+    }
   );
 
   // -------------------------------------------------------------------------
@@ -375,7 +317,7 @@ export const createServer = (): McpServer => {
     "export_cadence_netlist",
     {
       description:
-        "Export Cadence schematic netlist to Allegro PCB format. Windows only. Requires Cadence SPB installation.",
+        "Export Cadence schematic netlist to Allegro PCB format. Windows only. Requires Cadence SPB installation. Calls are queued internally so it is safe to call in parallel for multiple designs, but serialize calls if you encounter license or timeout errors. DSN lock files are handled automatically.",
       inputSchema: {
         design: z.string().describe("Path to .DSN schematic file"),
       },
@@ -383,7 +325,7 @@ export const createServer = (): McpServer => {
     async ({ design }) => {
       const result = await exportCadenceNetlist(design);
       return formatResult(result);
-    },
+    }
   );
 
   return server;

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { promisify } from "util";
+import { createMutex } from "./async-mutex.js";
 import { discoverDesigns, findHandler, parseDesign } from "./parsers/index.js";
 import { resolvePath } from "./paths.js";
 
@@ -42,6 +43,9 @@ import {
   type CadenceInstall,
   type ExportNetlistResult,
 } from "./types.js";
+
+// Serialize pstswp invocations to prevent concurrent Cadence license conflicts
+const serializePstswp = createMutex();
 
 // =============================================================================
 // Design Loading
@@ -994,55 +998,57 @@ export const exportCadenceNetlist = async (
   const dsnFile = path.basename(dsnPath);
   const { outputDir, dirName: outputDirName } = await resolveAllegroDir(dsnDir);
 
-  // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
-  const lockTempPath = await relocateLockFile(resolvedDsnPath);
+  return serializePstswp(async () => {
+    // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
+    const lockTempPath = await relocateLockFile(resolvedDsnPath);
 
-  // Convert to bash paths for command execution (GitBash compatibility)
-  const bashDsnDir = toBashPath(dsnDir);
-  const pstswp = toBashPath(cadence.pstswp);
-  const config = toBashPath(cadence.config);
+    // Convert to bash paths for command execution (GitBash compatibility)
+    const bashDsnDir = toBashPath(dsnDir);
+    const pstswp = toBashPath(cadence.pstswp);
+    const config = toBashPath(cadence.config);
 
-  const command = `cd "${bashDsnDir}" && "${pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${config}" -v 3 -l 255 -j "PCB Footprint"`;
+    const command = `cd "${bashDsnDir}" && "${pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${config}" -v 3 -l 255 -j "PCB Footprint"`;
 
-  try {
-    const { stdout, stderr } = await execAsync(command, {
-      shell: "bash",
-      timeout: 120000,
-    });
-
-    // List generated files
-    let generatedFiles: string[] | undefined;
     try {
-      const files = await fs.promises.readdir(outputDir);
-      generatedFiles = files.sort();
-    } catch {
-      // Output directory may not exist if export failed silently
-    }
+      const { stdout, stderr } = await execAsync(command, {
+        shell: "bash",
+        timeout: 120000,
+      });
 
-    return {
-      success: true,
-      outputDir,
-      log: (stdout + stderr).trim() || undefined,
-      cadenceVersion: cadence.version,
-      generatedFiles,
-    };
-  } catch (err: unknown) {
-    const execError = err as {
-      message?: string;
-      stdout?: string;
-      stderr?: string;
-    };
-    const lockNote = lockTempPath
-      ? ` A .DSNlck lock file was found and temporarily relocated — this is often the cause of pstswp failures.`
-      : "";
-    return {
-      error: `Cadence pstswp failed: ${execError.message ?? "Unknown error"}${lockNote}`,
-    };
-  } finally {
-    if (lockTempPath) {
-      await restoreLockFile(resolvedDsnPath, lockTempPath);
+      // List generated files
+      let generatedFiles: string[] | undefined;
+      try {
+        const files = await fs.promises.readdir(outputDir);
+        generatedFiles = files.sort();
+      } catch {
+        // Output directory may not exist if export failed silently
+      }
+
+      return {
+        success: true,
+        outputDir,
+        log: (stdout + stderr).trim() || undefined,
+        cadenceVersion: cadence.version,
+        generatedFiles,
+      };
+    } catch (err: unknown) {
+      const execError = err as {
+        message?: string;
+        stdout?: string;
+        stderr?: string;
+      };
+      const lockNote = lockTempPath
+        ? ` A .DSNlck lock file was found and temporarily relocated — this is often the cause of pstswp failures.`
+        : "";
+      return {
+        error: `Cadence pstswp failed: ${execError.message ?? "Unknown error"}${lockNote}`,
+      };
+    } finally {
+      if (lockTempPath) {
+        await restoreLockFile(resolvedDsnPath, lockTempPath);
+      }
     }
-  }
+  });
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add promise-chain mutex (`src/async-mutex.ts`) that serializes async operations with FIFO ordering and error isolation
- Wrap the critical section of `exportCadenceNetlist` (lock file relocation + pstswp execution) so only one `pstswp.exe` process runs at a time
- Update tool description and docs to document queuing behavior and lock file handling

## Context

When an agent calls `export_cadence_netlist` multiple times concurrently, multiple `pstswp.exe` processes spawn and compete for the same Cadence license, causing failures. Early-return guards (platform check, Cadence detection) and path resolution stay outside the mutex so invalid calls never enter the queue.

## Test plan

- [x] New unit tests for mutex: serialization proof, error isolation, distinct return values
- [x] `npm run type-check && npm run lint && npm test` — all 255 tests pass