### PR TITLE
Clarify supported file formats in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 The **Universal Netlist MCP Server** gives AI agents the tools to understand and analyze your electrical schematics, for powerful and comprehensive design reviews through natural conversations.
 
-It is compatible with Altium and Cadence, with plans to integrate more EDAs in the future. Note that you must already own a license of these EDAs to unleash the full capabilities of this MCP server.
+It is compatible with Cadence and Altium, with plans to integrate more EDAs in the future. Note that you must already own a license of these EDAs to unleash the full capabilities of this MCP server.
 
 ## Supported Formats
 
-| Format | Extension | Description |
-|--------|-----------|-------------|
-| Cadence CIS | `.dsn` | Cadence Capture CIS schematic designs |
-| Cadence HDL | `.cpm` | Cadence HDL schematic designs |
-| Altium Designer | `.PrjPcb` | Altium Designer PCB projects |
+| Format | Input Files | Description |
+|--------|------------|-------------|
+| Cadence (CIS / HDL) | `.dat` netlist files | Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) from Cadence Capture CIS or HDL designs |
+| Altium Designer | `.SchDoc` | Altium schematic documents (discovered via `.PrjPcb` project files) |
 
 ## Native Install (Recommended)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,10 @@ The Universal Netlist MCP Server provides tools for querying electronic design n
 
 ## Supported Formats
 
-| Format | File Extension | Description |
-|--------|---------------|-------------|
-| Cadence CIS | `.dsn` | Cadence Capture CIS schematic designs |
-| Cadence HDL | `.cpm` | Cadence HDL schematic designs |
-| Altium Designer | `.PrjPcb` | Altium Designer PCB projects |
+| Format | Input Files | Description |
+|--------|------------|-------------|
+| Cadence (CIS / HDL) | `.dat` netlist files | Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) from Cadence Capture CIS or HDL designs |
+| Altium Designer | `.SchDoc` | Altium schematic documents (discovered via `.PrjPcb` project files) |
 
 ## Design Philosophy
 


### PR DESCRIPTION
## Summary

- Updated Supported Formats tables in `README.md` and `docs/README.md` to show the actual input files the server reads (`.dat` netlist files for Cadence, `.SchDoc` for Altium) instead of the project file types (`.dsn`, `.cpm`, `.PrjPcb`)
- Consolidated Cadence CIS and HDL into a single row since both produce the same `.dat` netlist files

## Test plan

- [x] `npm run lint` passes
- [ ] Verify tables render correctly in GitHub markdown preview