### PR TITLE
Add subpath exports for library consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,20 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./service": {
+      "types": "./dist/service.d.ts",
+      "default": "./dist/service.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    }
+  },
   "bin": {
     "universal-netlist": "./dist/index.js"
   },

--- a/src/service.ts
+++ b/src/service.ts
@@ -1051,6 +1051,27 @@ export const exportCadenceNetlist = async (
   });
 };
 
+// Re-export types that appear in public API signatures
+export type {
+  ParsedNetlist,
+  ErrorResult,
+  ListComponentsResult,
+  ListNetsResult,
+  SearchComponentsResult,
+  SearchNetsResult,
+  QueryComponentResult,
+  AggregatedCircuitResult,
+  CadenceInstall,
+  ExportNetlistResult,
+  ComponentGroup,
+  AggregatedComponent,
+  ComponentDetails,
+  CircuitComponent,
+  PinEntry,
+} from "./types.js";
+
+export { isErrorResult } from "./types.js";
+
 // =============================================================================
 // Test Exports
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add Node.js `exports` field to `package.json` with subpath entries for `./service` and `./types`
- Re-export public API types from `service.ts` so consumers can import functions and types from a single path

Enables:
```typescript
import { listDesigns, type ErrorResult, isErrorResult } from '@intelligentelectron/universal-netlist/service'
import type { ParsedNetlist } from '@intelligentelectron/universal-netlist/types'
```

## Test plan
- [x] `npm run build` — compiles without errors
- [x] `npm run type-check` — no type errors
- [x] `npm test` — all 255 tests pass
- [x] `npm pack --dry-run` — confirms `dist/service.*` and `dist/types.*` included