### PR TITLE
Add .plans/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ coverage/
 # Private files and plans
 private/
 plans/
+.plans/


### PR DESCRIPTION
## Summary
- Add `.plans/` to `.gitignore` so local planning documents stay out of version control