### PR TITLE
v0.0.20

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "universal-netlist": {
+      "command": "npx",
+      "args": ["tsx", "src/index.ts"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discover standalone `.SchDoc` files when no `.PrjPcb` project file is present ([#26](https://github.com/IntelligentElectron/universal-netlist/issues/26))
 - `.mcp.json` for local MCP server development with `npx tsx`
 
+### Changed
+
+- Remove `--no-update` flag and `UNIVERSAL_NETLIST_MCP_NO_UPDATE` env var; auto-update is always enabled
+- Remove confirmation prompt from `--update` command; updates proceed immediately
+
 ### Fixed
 
 - Reject overly broad search patterns that match all items, directing users to `list_nets` or `list_components` instead ([#27](https://github.com/IntelligentElectron/universal-netlist/issues/27))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.20] - 2026-02-24
+
+### Added
+
+- Discover standalone `.SchDoc` files when no `.PrjPcb` project file is present ([#26](https://github.com/IntelligentElectron/universal-netlist/issues/26))
+- `.mcp.json` for local MCP server development with `npx tsx`
+
+### Fixed
+
+- Reject overly broad search patterns that match all items, directing users to `list_nets` or `list_components` instead ([#27](https://github.com/IntelligentElectron/universal-netlist/issues/27))
+
 ## [0.0.19] - 2026-02-21
 
 ### Added
@@ -183,23 +194,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `query_xnet_by_net_name` - Trace connectivity from a net
 - `query_xnet_by_pin_name` - Trace connectivity from a pin
 - `export_cadence_netlist` - Export to Allegro format
-
-[0.0.19]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.19
-[0.0.18]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.18
-[0.0.17]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.17
-[0.0.16]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.16
-[0.0.15]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.15
-[0.0.14]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.14
-[0.0.13]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.13
-[0.0.12]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.12
-[0.0.11]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.11
-[0.0.10]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.10
-[0.0.9]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.9
-[0.0.8]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.8
-[0.0.7]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.7
-[0.0.6]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.6
-[0.0.5]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.5
-[0.0.4]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.4
-[0.0.3]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.3
-[0.0.2]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.2
-[0.0.1]: https://github.com/IntelligentElectron/universal-netlist/releases/tag/v0.0.1

--- a/docs/tools/search_nets.md
+++ b/docs/tools/search_nets.md
@@ -93,12 +93,12 @@ Response:
 | `_[PN]$` | Nets ending with "_P" or "_N" (differential pairs) |
 | `SPI.*MOSI` | SPI MOSI signals |
 | `CLK\|CLOCK` | Nets containing "CLK" or "CLOCK" |
-| `(?i)vdd` | Case-insensitive: matches "VDD", "vdd", "Vdd" |
+| `vdd` | Case-insensitive: matches "VDD", "vdd", "Vdd" |
 
 ## Notes
 
-- Pattern matching is case-sensitive by default
-- Inline flags like `(?i)` are supported for case-insensitive matching
+- Pattern matching is **case-insensitive** by default
+- Inline flags like `(?i)` are accepted (matching is already case-insensitive by default)
 - Results are sorted alphabetically
 - The design name (without extension) is used as the results key
 - Empty results include a `notes` field explaining the empty match

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -34,17 +34,13 @@ OPTIONS:
   --help, -h       Show this help message
   --update         Check for and install updates
   --uninstall      Remove binary and PATH entries
-  --no-update      Disable auto-update check on startup
 
 INSTALLATION:
   curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/install.sh | bash
 
-ENVIRONMENT:
-  UNIVERSAL_NETLIST_MCP_NO_UPDATE=1    Disable auto-updates
-
 MORE INFO:
   https://github.com/${GITHUB_REPO}
-`.trim(),
+`.trim()
   );
 };
 
@@ -98,12 +94,6 @@ export const handleUpdateCommand = async (): Promise<void> => {
     process.exit(1);
   }
 
-  const confirmed = await confirm("Install update?");
-  if (!confirmed) {
-    console.log("Update cancelled");
-    return;
-  }
-
   console.log("Downloading update...");
   const result = await performUpdate(check.downloadUrl, check.latestVersion!);
 
@@ -131,9 +121,7 @@ const getCurrentExecutablePath = (): string => {
  * Removes the binary and PATH entries from shell rc files.
  */
 export const handleUninstallCommand = async (): Promise<void> => {
-  const confirmed = await confirm(
-    `This will remove ${BINARY_NAME} from your system. Continue?`,
-  );
+  const confirmed = await confirm(`This will remove ${BINARY_NAME} from your system. Continue?`);
   if (!confirmed) {
     console.log("Uninstall cancelled");
     return;
@@ -157,7 +145,7 @@ export const handleUninstallCommand = async (): Promise<void> => {
       rmSync(installDir, { recursive: true });
     } catch (error) {
       console.error(
-        `Failed to remove directory: ${error instanceof Error ? error.message : error}`,
+        `Failed to remove directory: ${error instanceof Error ? error.message : error}`
       );
       console.log("You may need to remove it manually.");
     }

--- a/src/cli/updater.ts
+++ b/src/cli/updater.ts
@@ -2,7 +2,7 @@
  * Auto-updater for universal-netlist server.
  *
  * Checks GitHub Releases for newer versions and self-updates on startup.
- * Can be disabled via UNIVERSAL_NETLIST_MCP_NO_UPDATE=1 environment variable.
+ * Always runs on startup for compiled binaries. Skipped for npm installs.
  */
 
 import {
@@ -354,11 +354,6 @@ export const reexec = (): never => {
  * @returns true if an update was applied and process should restart
  */
 export const autoUpdate = async (): Promise<boolean> => {
-  // Check if updates are disabled
-  if (process.env.UNIVERSAL_NETLIST_MCP_NO_UPDATE === "1") {
-    return false;
-  }
-
   // Skip auto-update for npm installs - use npm update instead
   if (isNpmInstall()) {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@
  *   --help, -h       Show help
  *   --update         Check for and install updates
  *   --uninstall      Remove binary and PATH entries
- *   --no-update      Disable auto-update check on startup
  */
 
 import {
@@ -53,20 +52,19 @@ const main = async (): Promise<void> => {
   // If running in a TTY (interactive terminal), show help instead of starting server
   if (process.stdin.isTTY) {
     console.log("This is an MCP server that communicates via stdio.");
-    console.log("It should be run by an MCP client (e.g., Claude Desktop), not directly.\n");
+    console.log("It should be run by an MCP client, not directly.\n");
     console.log("For setup instructions, see:");
-    console.log("  https://github.com/IntelligentElectron/universal-netlist?tab=readme-ov-file#connect-the-mcp-with-your-favorite-ai-tool\n");
+    console.log(
+      "  https://github.com/IntelligentElectron/universal-netlist?tab=readme-ov-file#connect-the-mcp-with-your-favorite-ai-tool\n"
+    );
     console.log("Run with --help for available options.");
     return;
   }
 
-  // Auto-update on startup (unless --no-update flag is present)
-  if (!args.includes("--no-update")) {
-    const updated = await autoUpdate();
-    if (updated) {
-      // Re-execute with the new binary
-      reexec();
-    }
+  // Auto-update on startup
+  const updated = await autoUpdate();
+  if (updated) {
+    reexec();
   }
 
   await runServer();

--- a/src/parsers/altium/discovery.test.ts
+++ b/src/parsers/altium/discovery.test.ts
@@ -5,13 +5,13 @@
  * These tests focus on parsing edge cases specific to Altium project files.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { writeFile, mkdir, rm } from 'fs/promises';
-import { join } from 'path';
-import { discoverAltiumDesigns, findAltiumSchDocs } from './discovery.js';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm } from "fs/promises";
+import { join } from "path";
+import { discoverAltiumDesigns, findAltiumSchDocs } from "./discovery.js";
 
-describe('Altium Discovery - Project File Parsing', () => {
-  const testDir = join(__dirname, '__test-altium-discovery__');
+describe("Altium Discovery - Project File Parsing", () => {
+  const testDir = join(__dirname, "__test-altium-discovery__");
   const oleStub = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
 
   async function writeOleSchDoc(filePath: string): Promise<void> {
@@ -26,44 +26,39 @@ describe('Altium Discovery - Project File Parsing', () => {
     try {
       await rm(testDir, { recursive: true, force: true, maxRetries: 3 });
     } catch (error) {
-      console.warn('Test cleanup warning:', error);
+      console.warn("Test cleanup warning:", error);
     }
   });
 
-  describe('DocumentPath parsing', () => {
-    it('should handle quoted paths in project file', async () => {
-      const projectDir = join(testDir, 'project');
+  describe("DocumentPath parsing", () => {
+    it("should handle quoted paths in project file", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath="Schematics\\sheet1.SchDoc"'].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", 'DocumentPath="Schematics\\sheet1.SchDoc"'].join("\n")
       );
-      await mkdir(join(projectDir, 'Schematics'), { recursive: true });
-      await writeOleSchDoc(join(projectDir, 'Schematics', 'sheet1.SchDoc'));
+      await mkdir(join(projectDir, "Schematics"), { recursive: true });
+      await writeOleSchDoc(join(projectDir, "Schematics", "sheet1.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       expect(designs[0].schdocPaths).toHaveLength(1);
-      expect(designs[0].schdocPaths[0]).toBe(
-        join(projectDir, 'Schematics', 'sheet1.SchDoc')
-      );
+      expect(designs[0].schdocPaths[0]).toBe(join(projectDir, "Schematics", "sheet1.SchDoc"));
     });
 
-    it('should extract path before pipe metadata separator', async () => {
+    it("should extract path before pipe metadata separator", async () => {
       // Altium project files can have metadata after the path: DocumentPath=path|metadata
-      const projectDir = join(testDir, 'project');
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        [
-          '[Document1]',
-          'DocumentPath=sheet1.SchDoc|DocumentState=Editor',
-        ].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=sheet1.SchDoc|DocumentState=Editor"].join("\n")
       );
-      await writeOleSchDoc(join(projectDir, 'sheet1.SchDoc'));
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
@@ -71,88 +66,86 @@ describe('Altium Discovery - Project File Parsing', () => {
       expect(designs[0].schdocPaths).toHaveLength(1);
     });
 
-    it('should skip absolute Windows paths', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should skip absolute Windows paths", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
+        join(projectDir, "board.PrjPcb"),
         [
-          '[Document1]',
-          'DocumentPath=C:\\Users\\dev\\old_project\\sheet1.SchDoc',
-          '[Document2]',
-          'DocumentPath=relative\\sheet2.SchDoc',
-        ].join('\n')
+          "[Document1]",
+          "DocumentPath=C:\\Users\\dev\\old_project\\sheet1.SchDoc",
+          "[Document2]",
+          "DocumentPath=relative\\sheet2.SchDoc",
+        ].join("\n")
       );
-      await mkdir(join(projectDir, 'relative'), { recursive: true });
-      await writeOleSchDoc(join(projectDir, 'relative', 'sheet2.SchDoc'));
+      await mkdir(join(projectDir, "relative"), { recursive: true });
+      await writeOleSchDoc(join(projectDir, "relative", "sheet2.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       // Should only have the relative path, not the absolute one
       expect(designs[0].schdocPaths).toHaveLength(1);
-      expect(designs[0].schdocPaths[0]).toContain('sheet2.SchDoc');
+      expect(designs[0].schdocPaths[0]).toContain("sheet2.SchDoc");
     });
 
-    it('should skip absolute Unix paths', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should skip absolute Unix paths", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
+        join(projectDir, "board.PrjPcb"),
         [
-          '[Document1]',
-          'DocumentPath=/home/dev/old_project/sheet1.SchDoc',
-          '[Document2]',
-          'DocumentPath=local/sheet2.SchDoc',
-        ].join('\n')
+          "[Document1]",
+          "DocumentPath=/home/dev/old_project/sheet1.SchDoc",
+          "[Document2]",
+          "DocumentPath=local/sheet2.SchDoc",
+        ].join("\n")
       );
-      await mkdir(join(projectDir, 'local'), { recursive: true });
-      await writeOleSchDoc(join(projectDir, 'local', 'sheet2.SchDoc'));
+      await mkdir(join(projectDir, "local"), { recursive: true });
+      await writeOleSchDoc(join(projectDir, "local", "sheet2.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       expect(designs[0].schdocPaths).toHaveLength(1);
-      expect(designs[0].schdocPaths[0]).toContain('sheet2.SchDoc');
+      expect(designs[0].schdocPaths[0]).toContain("sheet2.SchDoc");
     });
 
-    it('should convert Windows backslashes to forward slashes', async () => {
-      const projectDir = join(testDir, 'project');
-      const schDir = join(projectDir, 'Hardware', 'Schematics');
+    it("should convert Windows backslashes to forward slashes", async () => {
+      const projectDir = join(testDir, "project");
+      const schDir = join(projectDir, "Hardware", "Schematics");
       await mkdir(schDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath=Hardware\\Schematics\\main.SchDoc'].join(
-          '\n'
-        )
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=Hardware\\Schematics\\main.SchDoc"].join("\n")
       );
-      await writeOleSchDoc(join(schDir, 'main.SchDoc'));
+      await writeOleSchDoc(join(schDir, "main.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       expect(designs[0].schdocPaths).toHaveLength(1);
-      expect(designs[0].schdocPaths[0]).toBe(join(schDir, 'main.SchDoc'));
+      expect(designs[0].schdocPaths[0]).toBe(join(schDir, "main.SchDoc"));
     });
 
-    it('should deduplicate SchDoc paths listed multiple times', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should deduplicate SchDoc paths listed multiple times", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       // Same file listed twice (can happen with project file edits)
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
+        join(projectDir, "board.PrjPcb"),
         [
-          '[Document1]',
-          'DocumentPath=sheet1.SchDoc',
-          '[Document2]',
-          'DocumentPath=sheet1.SchDoc',
-        ].join('\n')
+          "[Document1]",
+          "DocumentPath=sheet1.SchDoc",
+          "[Document2]",
+          "DocumentPath=sheet1.SchDoc",
+        ].join("\n")
       );
-      await writeOleSchDoc(join(projectDir, 'sheet1.SchDoc'));
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
@@ -160,128 +153,212 @@ describe('Altium Discovery - Project File Parsing', () => {
       expect(designs[0].schdocPaths).toHaveLength(1);
     });
 
-    it('should sort SchDoc paths alphabetically', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should sort SchDoc paths alphabetically", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
+        join(projectDir, "board.PrjPcb"),
         [
-          '[Document1]',
-          'DocumentPath=zpower.SchDoc',
-          '[Document2]',
-          'DocumentPath=amain.SchDoc',
-          '[Document3]',
-          'DocumentPath=mcontrol.SchDoc',
-        ].join('\n')
+          "[Document1]",
+          "DocumentPath=zpower.SchDoc",
+          "[Document2]",
+          "DocumentPath=amain.SchDoc",
+          "[Document3]",
+          "DocumentPath=mcontrol.SchDoc",
+        ].join("\n")
       );
-      await writeOleSchDoc(join(projectDir, 'zpower.SchDoc'));
-      await writeOleSchDoc(join(projectDir, 'amain.SchDoc'));
-      await writeOleSchDoc(join(projectDir, 'mcontrol.SchDoc'));
+      await writeOleSchDoc(join(projectDir, "zpower.SchDoc"));
+      await writeOleSchDoc(join(projectDir, "amain.SchDoc"));
+      await writeOleSchDoc(join(projectDir, "mcontrol.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       expect(designs[0].schdocPaths).toHaveLength(3);
-      expect(designs[0].schdocPaths[0]).toContain('amain.SchDoc');
-      expect(designs[0].schdocPaths[1]).toContain('mcontrol.SchDoc');
-      expect(designs[0].schdocPaths[2]).toContain('zpower.SchDoc');
+      expect(designs[0].schdocPaths[0]).toContain("amain.SchDoc");
+      expect(designs[0].schdocPaths[1]).toContain("mcontrol.SchDoc");
+      expect(designs[0].schdocPaths[2]).toContain("zpower.SchDoc");
     });
   });
 
-  describe('Fallback SchDoc discovery', () => {
-    it('should NOT fallback when multiple SchDocs exist in project directory', async () => {
-      // Fallback is ambiguous with multiple candidates - should return error
-      const projectDir = join(testDir, 'project');
+  describe("Fallback SchDoc discovery", () => {
+    it("should NOT fallback when multiple SchDocs exist in project directory", async () => {
+      // Fallback is ambiguous with multiple candidates - should return error on project
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       // Project file references a non-existent SchDoc
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath=missing.SchDoc'].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=missing.SchDoc"].join("\n")
       );
       // But two valid SchDocs exist in the directory
-      await writeOleSchDoc(join(projectDir, 'sheet1.SchDoc'));
-      await writeOleSchDoc(join(projectDir, 'sheet2.SchDoc'));
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
+      await writeOleSchDoc(join(projectDir, "sheet2.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
-      expect(designs).toHaveLength(1);
-      // Should have error because fallback is ambiguous
-      expect(designs[0].error).toBeDefined();
-      expect(designs[0].schdocPaths).toHaveLength(0);
+      // Project + 2 orphaned SchDocs
+      expect(designs).toHaveLength(3);
+
+      const projectDesign = designs.find((d) => d.name === "board");
+      expect(projectDesign).toBeDefined();
+      expect(projectDesign!.error).toBeDefined();
+      expect(projectDesign!.schdocPaths).toHaveLength(0);
+
+      // The unclaimed SchDocs appear as standalone entries
+      const orphans = designs.filter((d) => d.error?.includes("Standalone"));
+      expect(orphans).toHaveLength(2);
     });
 
-    it('should fallback to single SchDoc in subdirectory of project', async () => {
-      const projectDir = join(testDir, 'project');
-      const schDir = join(projectDir, 'Schematics');
+    it("should fallback to single SchDoc in subdirectory of project", async () => {
+      const projectDir = join(testDir, "project");
+      const schDir = join(projectDir, "Schematics");
       await mkdir(schDir, { recursive: true });
 
       // Project file references non-existent SchDoc
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath=wrong_path.SchDoc'].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=wrong_path.SchDoc"].join("\n")
       );
       // Single valid SchDoc in subdirectory
-      await writeOleSchDoc(join(schDir, 'main.SchDoc'));
+      await writeOleSchDoc(join(schDir, "main.SchDoc"));
 
       const designs = await discoverAltiumDesigns(testDir);
 
       expect(designs).toHaveLength(1);
       expect(designs[0].schdocPaths).toHaveLength(1);
-      expect(designs[0].schdocPaths[0]).toBe(join(schDir, 'main.SchDoc'));
+      expect(designs[0].schdocPaths[0]).toBe(join(schDir, "main.SchDoc"));
       expect(designs[0].error).toBeUndefined();
     });
   });
 
-  describe('findAltiumSchDocs function', () => {
-    it('should find SchDocs for a specific project file', async () => {
-      const projectDir = join(testDir, 'project');
+  describe("findAltiumSchDocs function", () => {
+    it("should find SchDocs for a specific project file", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
-      const projectPath = join(projectDir, 'board.PrjPcb');
-      await writeFile(projectPath, [
-        '[Document1]',
-        'DocumentPath=sheet1.SchDoc',
-      ].join('\n'));
-      await writeOleSchDoc(join(projectDir, 'sheet1.SchDoc'));
+      const projectPath = join(projectDir, "board.PrjPcb");
+      await writeFile(projectPath, ["[Document1]", "DocumentPath=sheet1.SchDoc"].join("\n"));
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
 
       const schdocs = await findAltiumSchDocs(projectPath);
 
       expect(schdocs).toHaveLength(1);
-      expect(schdocs[0]).toBe(join(projectDir, 'sheet1.SchDoc'));
+      expect(schdocs[0]).toBe(join(projectDir, "sheet1.SchDoc"));
     });
 
-    it('should use fallback when project file has no valid SchDoc references', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should use fallback when project file has no valid SchDoc references", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
-      const projectPath = join(projectDir, 'board.PrjPcb');
+      const projectPath = join(projectDir, "board.PrjPcb");
       // Empty project file
-      await writeFile(projectPath, '[Design Info]');
+      await writeFile(projectPath, "[Design Info]");
       // Single SchDoc in directory
-      await writeOleSchDoc(join(projectDir, 'only.SchDoc'));
+      await writeOleSchDoc(join(projectDir, "only.SchDoc"));
 
       const schdocs = await findAltiumSchDocs(projectPath);
 
       expect(schdocs).toHaveLength(1);
-      expect(schdocs[0]).toBe(join(projectDir, 'only.SchDoc'));
+      expect(schdocs[0]).toBe(join(projectDir, "only.SchDoc"));
     });
   });
 
-  describe('OLE format validation', () => {
-    it('should reject text-based SchDoc files (ASCII format)', async () => {
-      const projectDir = join(testDir, 'project');
+  describe("Standalone SchDoc discovery", () => {
+    it("should discover orphaned SchDoc with no project file in tree", async () => {
+      const orphanDir = join(testDir, "loose");
+      await mkdir(orphanDir, { recursive: true });
+      await writeOleSchDoc(join(orphanDir, "standalone.SchDoc"));
+
+      const designs = await discoverAltiumDesigns(testDir);
+
+      expect(designs).toHaveLength(1);
+      expect(designs[0].name).toBe("standalone");
+      expect(designs[0].sourcePath).toBe(join(orphanDir, "standalone.SchDoc"));
+      expect(designs[0].schdocPaths).toEqual([join(orphanDir, "standalone.SchDoc")]);
+      expect(designs[0].error).toContain("Standalone");
+    });
+
+    it("should NOT duplicate SchDoc referenced by a project", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath=sheet1.SchDoc'].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=sheet1.SchDoc"].join("\n")
+      );
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
+
+      const designs = await discoverAltiumDesigns(testDir);
+
+      expect(designs).toHaveLength(1);
+      expect(designs[0].name).toBe("board");
+      expect(designs[0].error).toBeUndefined();
+    });
+
+    it("should handle mixed scenario: project + orphaned SchDoc", async () => {
+      const projectDir = join(testDir, "project");
+      const looseDir = join(testDir, "loose");
+      await mkdir(projectDir, { recursive: true });
+      await mkdir(looseDir, { recursive: true });
+
+      await writeFile(
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=sheet1.SchDoc"].join("\n")
+      );
+      await writeOleSchDoc(join(projectDir, "sheet1.SchDoc"));
+      await writeOleSchDoc(join(looseDir, "orphan.SchDoc"));
+
+      const designs = await discoverAltiumDesigns(testDir);
+
+      expect(designs).toHaveLength(2);
+
+      const projectDesign = designs.find((d) => d.name === "board");
+      const orphanDesign = designs.find((d) => d.name === "orphan");
+
+      expect(projectDesign).toBeDefined();
+      expect(projectDesign!.error).toBeUndefined();
+      expect(orphanDesign).toBeDefined();
+      expect(orphanDesign!.error).toContain("Standalone");
+    });
+
+    it("should NOT list SchDoc claimed via fallback as orphan", async () => {
+      const projectDir = join(testDir, "project");
+      await mkdir(projectDir, { recursive: true });
+
+      // Project references a missing file, but a single SchDoc in the dir triggers fallback
+      await writeFile(
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=missing.SchDoc"].join("\n")
+      );
+      await writeOleSchDoc(join(projectDir, "actual.SchDoc"));
+
+      const designs = await discoverAltiumDesigns(testDir);
+
+      expect(designs).toHaveLength(1);
+      expect(designs[0].name).toBe("board");
+      expect(designs[0].schdocPaths).toHaveLength(1);
+      expect(designs[0].schdocPaths[0]).toContain("actual.SchDoc");
+      // Should NOT have a standalone error since it was claimed by fallback
+      expect(designs[0].error).toBeUndefined();
+    });
+  });
+
+  describe("OLE format validation", () => {
+    it("should reject text-based SchDoc files (ASCII format)", async () => {
+      const projectDir = join(testDir, "project");
+      await mkdir(projectDir, { recursive: true });
+
+      await writeFile(
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=sheet1.SchDoc"].join("\n")
       );
       // Write ASCII-format SchDoc (older Altium format)
       await writeFile(
-        join(projectDir, 'sheet1.SchDoc'),
-        '|HEADER=Protel for Windows - Schematic Capture Binary File Version 5.0|'
+        join(projectDir, "sheet1.SchDoc"),
+        "|HEADER=Protel for Windows - Schematic Capture Binary File Version 5.0|"
       );
 
       const designs = await discoverAltiumDesigns(testDir);
@@ -291,16 +368,16 @@ describe('Altium Discovery - Project File Parsing', () => {
       expect(designs[0].error).toBeDefined();
     });
 
-    it('should reject truncated files that are too small for OLE header', async () => {
-      const projectDir = join(testDir, 'project');
+    it("should reject truncated files that are too small for OLE header", async () => {
+      const projectDir = join(testDir, "project");
       await mkdir(projectDir, { recursive: true });
 
       await writeFile(
-        join(projectDir, 'board.PrjPcb'),
-        ['[Document1]', 'DocumentPath=sheet1.SchDoc'].join('\n')
+        join(projectDir, "board.PrjPcb"),
+        ["[Document1]", "DocumentPath=sheet1.SchDoc"].join("\n")
       );
       // Write truncated file (less than 8 bytes)
-      await writeFile(join(projectDir, 'sheet1.SchDoc'), 'tiny');
+      await writeFile(join(projectDir, "sheet1.SchDoc"), "tiny");
 
       const designs = await discoverAltiumDesigns(testDir);
 

--- a/src/parsers/altium/discovery.ts
+++ b/src/parsers/altium/discovery.ts
@@ -6,7 +6,7 @@
 import { open, readFile, readdir } from "fs/promises";
 import path from "path";
 
-const ALTIUM_EXTENSIONS = [".prjpcb"] as const;
+const ALTIUM_EXTENSIONS = [".prjpcb", ".schdoc"] as const;
 
 /**
  * Altium-specific discovered design with schematic document paths.
@@ -74,10 +74,7 @@ const readProjectSchDocs = async (projectPath: string): Promise<string[]> => {
     }
 
     // Skip absolute paths from the project file
-    if (
-      path.win32.isAbsolute(normalized) ||
-      path.posix.isAbsolute(normalized)
-    ) {
+    if (path.win32.isAbsolute(normalized) || path.posix.isAbsolute(normalized)) {
       continue;
     }
 
@@ -100,7 +97,7 @@ const readProjectSchDocs = async (projectPath: string): Promise<string[]> => {
  */
 const walkForAltiumFiles = async (
   rootDir: string,
-  maxDepth?: number,
+  maxDepth?: number
 ): Promise<{ projects: string[]; schdocs: string[] }> => {
   const projects: string[] = [];
   const schdocs: string[] = [];
@@ -110,11 +107,7 @@ const walkForAltiumFiles = async (
     try {
       entries = await readdir(currentDir, { withFileTypes: true });
     } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !("code" in error) ||
-        error.code !== "EACCES"
-      ) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EACCES") {
         throw error;
       }
       return;
@@ -150,10 +143,7 @@ const walkForAltiumFiles = async (
 /**
  * Fallback: find SchDoc files in the project directory if none found in project file.
  */
-const fallbackProjectSchDocs = (
-  projectDir: string,
-  schdocs: string[],
-): string[] => {
+const fallbackProjectSchDocs = (projectDir: string, schdocs: string[]): string[] => {
   const candidates = schdocs.filter((schdoc) => {
     const schdocDir = path.dirname(schdoc);
     return schdocDir === projectDir || schdoc.startsWith(projectDir + path.sep);
@@ -167,12 +157,13 @@ const fallbackProjectSchDocs = (
  */
 export const discoverAltiumDesigns = async (
   rootDir: string,
-  options?: { maxDepth?: number },
+  options?: { maxDepth?: number }
 ): Promise<AltiumDiscoveredDesign[]> => {
   const absoluteRootDir = path.resolve(rootDir);
   const { projects, schdocs } = await walkForAltiumFiles(absoluteRootDir, options?.maxDepth);
 
   const designs: AltiumDiscoveredDesign[] = [];
+  const claimedSchDocs = new Set<string>();
 
   for (const projectPath of projects) {
     const name = path.basename(projectPath, path.extname(projectPath));
@@ -181,6 +172,10 @@ export const discoverAltiumDesigns = async (
     if (schdocPaths.length === 0) {
       const projectDir = path.dirname(projectPath);
       schdocPaths = fallbackProjectSchDocs(projectDir, schdocs);
+    }
+
+    for (const s of schdocPaths) {
+      claimedSchDocs.add(s);
     }
 
     const design: AltiumDiscoveredDesign = {
@@ -197,15 +192,27 @@ export const discoverAltiumDesigns = async (
     designs.push(design);
   }
 
+  // Create entries for orphaned SchDoc files not claimed by any project
+  for (const schdocPath of schdocs) {
+    if (claimedSchDocs.has(schdocPath)) continue;
+
+    designs.push({
+      name: path.basename(schdocPath, path.extname(schdocPath)),
+      format: "altium",
+      sourcePath: schdocPath,
+      schdocPaths: [schdocPath],
+      error:
+        "Standalone schematic (no .PrjPcb project file found). Multi-sheet designs may be incomplete.",
+    });
+  }
+
   return designs;
 };
 
 /**
  * Find SchDoc files for a specific Altium project file.
  */
-export const findAltiumSchDocs = async (
-  projectPath: string,
-): Promise<string[]> => {
+export const findAltiumSchDocs = async (projectPath: string): Promise<string[]> => {
   const schdocPaths = await readProjectSchDocs(projectPath);
 
   if (schdocPaths.length === 0) {

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -12,19 +12,10 @@
  * - net-list: Nets with connected devices
  */
 
-import type {
-  ParsedNetlist,
-  NetConnections,
-  ComponentDetails,
-  PinEntry,
-} from "../../types.js";
+import path from "path";
+import type { ParsedNetlist, NetConnections, ComponentDetails, PinEntry } from "../../types.js";
 import { createPinEntry } from "../../types.js";
-import type {
-  AltiumSchematic,
-  AltiumNet,
-  AltiumRecord,
-  OutputFormat,
-} from "./types.js";
+import type { AltiumSchematic, AltiumNet, AltiumRecord, OutputFormat } from "./types.js";
 import {
   RECORD_TYPES,
   RECORD_TYPE_NAMES,
@@ -33,22 +24,12 @@ import {
 } from "./types.js";
 import { OleReader, readOleStream } from "./ole-reader.js";
 import { parseRecords, findRecords } from "./record-parser.js";
-import {
-  buildHierarchy,
-  getPartsList,
-  flattenHierarchy,
-  findRecordByIndex,
-} from "./hierarchy.js";
+import { buildHierarchy, getPartsList, flattenHierarchy, findRecordByIndex } from "./hierarchy.js";
 import { extractNets, determineNetList } from "./net-extractor.js";
 
 // Re-export types and utilities for external use
 export type { AltiumSchematic, AltiumNet, AltiumRecord, OutputFormat };
-export {
-  RECORD_TYPES,
-  RECORD_TYPE_NAMES,
-  PIN_ELECTRICAL_TYPES,
-  POWER_PORT_STYLES,
-};
+export { RECORD_TYPES, RECORD_TYPE_NAMES, PIN_ELECTRICAL_TYPES, POWER_PORT_STYLES };
 export { OleReader };
 export { parseRecords, findRecords };
 export { buildHierarchy, getPartsList, flattenHierarchy };
@@ -60,35 +41,22 @@ export * from "./schemas.js";
 /**
  * Get component designator from a pin's parent.
  */
-const getDesignatorFromPin = (
-  pin: AltiumRecord,
-  schematic: AltiumSchematic,
-): string | null => {
+const getDesignatorFromPin = (pin: AltiumRecord, schematic: AltiumSchematic): string | null => {
   // Look up the parent component using OwnerIndex
   const ownerIndexValue = pin.OwnerIndex ?? pin.OWNERINDEX;
-  if (
-    ownerIndexValue !== undefined &&
-    ownerIndexValue !== null &&
-    ownerIndexValue !== ""
-  ) {
+  if (ownerIndexValue !== undefined && ownerIndexValue !== null && ownerIndexValue !== "") {
     const ownerIndex = parseInt(String(ownerIndexValue), 10);
     const parent = findRecordByIndex(schematic, ownerIndex);
 
     if (parent?.children) {
       // Find the designator child (RECORD=34 with Text field)
-      const designatorChild = parent.children.find(
-        (c) => c.RECORD === RECORD_TYPES.DESIGNATOR,
-      );
+      const designatorChild = parent.children.find((c) => c.RECORD === RECORD_TYPES.DESIGNATOR);
       const designatorText =
         designatorChild?.Text ??
         designatorChild?.TEXT ??
         designatorChild?.Name ??
         designatorChild?.NAME;
-      if (
-        designatorText !== undefined &&
-        designatorText !== null &&
-        designatorText !== ""
-      ) {
+      if (designatorText !== undefined && designatorText !== null && designatorText !== "") {
         return String(designatorText);
       }
     }
@@ -105,18 +73,10 @@ const getDesignatorFromPin = (
  */
 const getPinNumber = (pin: AltiumRecord): string | null => {
   // Try Designator first (pin number)
-  if (
-    pin.Designator !== undefined &&
-    pin.Designator !== null &&
-    pin.Designator !== ""
-  ) {
+  if (pin.Designator !== undefined && pin.Designator !== null && pin.Designator !== "") {
     return String(pin.Designator);
   }
-  if (
-    pin.DESIGNATOR !== undefined &&
-    pin.DESIGNATOR !== null &&
-    pin.DESIGNATOR !== ""
-  ) {
+  if (pin.DESIGNATOR !== undefined && pin.DESIGNATOR !== null && pin.DESIGNATOR !== "") {
     return String(pin.DESIGNATOR);
   }
   // Fallback to Name (pin function name)
@@ -135,20 +95,13 @@ const getPinNumber = (pin: AltiumRecord): string | null => {
  *
  * Transform: AltiumNet[] -> { netName: { refdes: [pinNumbers] } }
  */
-const convertNets = (
-  nets: AltiumNet[],
-  schematic: AltiumSchematic,
-): NetConnections => {
+const convertNets = (nets: AltiumNet[], schematic: AltiumSchematic): NetConnections => {
   const result: NetConnections = {};
   let unnamedNetCounter = 1;
 
   for (const net of nets) {
-    const pinDevices = net.devices.filter(
-      (device) => device.RECORD === RECORD_TYPES.PIN,
-    );
-    const hasNonPinDevices = net.devices.some(
-      (device) => device.RECORD !== RECORD_TYPES.PIN,
-    );
+    const pinDevices = net.devices.filter((device) => device.RECORD === RECORD_TYPES.PIN);
+    const hasNonPinDevices = net.devices.some((device) => device.RECORD !== RECORD_TYPES.PIN);
 
     if (pinDevices.length === 1 && !hasNonPinDevices) {
       continue;
@@ -192,10 +145,7 @@ const convertNets = (
  * The nets structure is: { netName: { refdes: [pinNumbers] } }
  * We need to reverse this to populate: components[refdes].pins[pin] = netName
  */
-const populatePinNets = (
-  components: ComponentDetails,
-  nets: NetConnections,
-): void => {
+const populatePinNets = (components: ComponentDetails, nets: NetConnections): void => {
   for (const [netName, connections] of Object.entries(nets)) {
     for (const [refdes, pins] of Object.entries(connections)) {
       const component = components[refdes];
@@ -219,7 +169,7 @@ const populatePinNets = (
 
 const resolveComment = (
   comment: string | undefined,
-  parameters: Record<string, string>,
+  parameters: Record<string, string>
 ): string | undefined => {
   if (!comment) {
     return undefined;
@@ -247,10 +197,7 @@ const resolveComment = (
   return trimmed;
 };
 
-const pinMatchesCurrentPart = (
-  pin: AltiumRecord,
-  part: AltiumRecord,
-): boolean => {
+const pinMatchesCurrentPart = (pin: AltiumRecord, part: AltiumRecord): boolean => {
   const partId = part.CURRENTPARTID ?? part.CurrentPartId ?? part.CurrentPartID;
   const pinPartId = pin.OwnerPartId ?? pin.OWNERPARTID;
   if (
@@ -278,9 +225,7 @@ const getPinName = (pin: AltiumRecord): string | undefined => {
 /**
  * Extract component details from a hierarchical schematic.
  */
-export const extractComponents = (
-  schematic: AltiumSchematic,
-): ComponentDetails => {
+export const extractComponents = (schematic: AltiumSchematic): ComponentDetails => {
   const components: ComponentDetails = {};
 
   // Get all parts (RECORD=1)
@@ -290,19 +235,13 @@ export const extractComponents = (
     // Designator is in a child record with RECORD=34 and Text field
     let refdes: string | undefined;
     if (part.children) {
-      const designatorChild = part.children.find(
-        (c) => c.RECORD === RECORD_TYPES.DESIGNATOR,
-      );
+      const designatorChild = part.children.find((c) => c.RECORD === RECORD_TYPES.DESIGNATOR);
       const designatorText =
         designatorChild?.Text ??
         designatorChild?.TEXT ??
         designatorChild?.Name ??
         designatorChild?.NAME;
-      if (
-        designatorText !== undefined &&
-        designatorText !== null &&
-        designatorText !== ""
-      ) {
+      if (designatorText !== undefined && designatorText !== null && designatorText !== "") {
         refdes = String(designatorText);
       }
     }
@@ -417,9 +356,7 @@ export const extractComponents = (
  *
  * This is the main entry point for integration with NetlistService.
  */
-export const parseAltium = async (
-  schdocPath: string,
-): Promise<ParsedNetlist> => {
+export const parseAltium = async (schdocPath: string): Promise<ParsedNetlist> => {
   // 1. Read OLE file and extract FileHeader stream
   const buffer = readOleStream(schdocPath);
 
@@ -450,11 +387,8 @@ export const parseAltium = async (
  */
 export const parse = (
   schdocPath: string,
-  format: OutputFormat = "all-hierarchy",
-):
-  | AltiumSchematic
-  | { records: AltiumRecord[] }
-  | (AltiumSchematic & { nets: AltiumNet[] }) => {
+  format: OutputFormat = "all-hierarchy"
+): AltiumSchematic | { records: AltiumRecord[] } | (AltiumSchematic & { nets: AltiumNet[] }) => {
   // Read and parse the file
   const buffer = readOleStream(schdocPath);
   const schematic = parseRecords(buffer);
@@ -488,18 +422,12 @@ import {
 } from "./discovery.js";
 import type { EDAProjectFormatHandler } from "../../types.js";
 
-export {
-  discoverAltiumDesigns,
-  findAltiumSchDocs,
-  isAltiumFile,
-} from "./discovery.js";
+export { discoverAltiumDesigns, findAltiumSchDocs, isAltiumFile } from "./discovery.js";
 
 /**
  * Parse an Altium project by parsing all its SchDoc files and merging the results.
  */
-const parseAltiumProject = async (
-  projectPath: string,
-): Promise<ParsedNetlist> => {
+const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> => {
   const schdocPaths = await findAltiumSchDocs(projectPath);
 
   if (schdocPaths.length === 0) {
@@ -525,9 +453,7 @@ const parseAltiumProject = async (
           const existing = allNets[netName][refdes];
           const existingArray = Array.isArray(existing) ? existing : [existing];
           const newPins = Array.isArray(pins) ? pins : [pins];
-          allNets[netName][refdes] = [
-            ...new Set([...existingArray, ...newPins]),
-          ];
+          allNets[netName][refdes] = [...new Set([...existingArray, ...newPins])];
         }
       }
     }
@@ -558,5 +484,11 @@ export const altiumHandler: EDAProjectFormatHandler = {
 
   discoverDesigns: discoverAltiumDesigns,
 
-  parse: parseAltiumProject,
+  parse: async (designPath: string): Promise<ParsedNetlist> => {
+    const ext = path.extname(designPath).toLowerCase();
+    if (ext === ".schdoc") {
+      return parseAltium(designPath);
+    }
+    return parseAltiumProject(designPath);
+  },
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,8 +30,11 @@ import {
 const SERVER_INSTRUCTIONS = `
 # Netlist MCP Server
 
-This server provides tools to query EDA (Electronic Design Automation) netlists for circuit design review.
-Supports Cadence (CIS, HDL) and Altium Designer formats.
+This server provides tools to query EDA netlists for circuit design review.
+
+Supported formats:
+- **Cadence CIS/HDL**: Reads exported Allegro netlist files: pstxnet.dat, pstxprt.dat, pstchip.dat. Use \`export_cadence_netlist\` to generate these from .DSN schematics.
+- **Altium Designer**: Reads .SchDoc schematic documents within .PrjPcb projects.
 
 ## Workflow Guidance
 
@@ -104,7 +107,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_designs",
     {
-      description: "List all design projects in the given directory",
+      description:
+        "List all design projects in the given directory. Returns absolute paths to schematic files (.DSN for Cadence, .SchDoc/.PrjPcb for Altium). Always use this tool to discover designs instead of searching the filesystem manually. Each result may include an error field; notably, Cadence designs that have not been exported will show this error, and all queries against them will fail until you run export_cadence_netlist.",
       inputSchema: {
         path: z.string().optional().describe("Path to directory to search for designs"),
         pattern: z.string().optional().describe("Regex pattern to filter design names"),
@@ -140,7 +144,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_components",
     {
-      description: "List components of a specific type in a design",
+      description:
+        'List components of a specific type in a design. The type prefix is case-insensitive, so "u" matches U1, U2, etc. Components are grouped by MPN for compact output. If no components match, the error lists the available prefixes in the design.',
       inputSchema: {
         design: z.string().describe("Path to design file (e.g., ./Design.PrjPcb)"),
         type: z.string().describe("Component prefix: U, C, R, L, etc."),
@@ -163,7 +168,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_nets",
     {
-      description: "List all net names in a design",
+      description:
+        "List all net names in a design, sorted alphabetically. The result can be large. Prefer search_nets for targeted queries.",
       inputSchema: {
         design: z.string().describe("Path to design file"),
       },
@@ -180,7 +186,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_nets",
     {
-      description: "Search for nets matching a regex pattern",
+      description:
+        "Search for nets matching a regex pattern. Matching is case-insensitive by default. Returns sorted results keyed by design name, with a notes field when nothing matches. Rejects patterns that match all items; use list_nets for full results.",
       inputSchema: {
         pattern: z.string().describe("Regex pattern"),
         design: z.string().describe("Path to design file"),
@@ -198,7 +205,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_refdes",
     {
-      description: "Search for components by refdes pattern",
+      description:
+        "Search for components by refdes pattern. Matching is case-insensitive. Results are grouped by MPN for compact output, with a notes field when nothing matches. Rejects patterns that match all items; use list_components for full results.",
       inputSchema: {
         pattern: z.string().describe("Regex pattern for refdes"),
         design: z.string().describe("Path to design file"),
@@ -217,7 +225,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_mpn",
     {
-      description: "Search for components by MPN (Manufacturer Part Number) pattern",
+      description:
+        "Search for components by MPN (Manufacturer Part Number) pattern. Not all netlists include MPN data; if unavailable, fall back to search_components_by_refdes or search_components_by_description, or ask the user for a BOM. Rejects patterns that match all items; use list_components for full results.",
       inputSchema: {
         pattern: z.string().describe("Regex pattern for MPN"),
         design: z.string().describe("Path to design file"),
@@ -236,7 +245,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_description",
     {
-      description: "Search for components by description pattern",
+      description:
+        "Search for components by description pattern. Not all netlists include description data; if unavailable, fall back to search_components_by_refdes or search_components_by_mpn, or ask the user for a BOM. Rejects patterns that match all items; use list_components for full results.",
       inputSchema: {
         pattern: z.string().describe("Regex pattern for description"),
         design: z.string().describe("Path to design file"),
@@ -255,7 +265,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_xnet_by_net_name",
     {
-      description: "Get full XNET (Extended Net) connectivity for a net",
+      description:
+        "Get full XNET (Extended Net) connectivity for a net. Rejects ground nets (GND, AGND, DGND, etc.) with an error.",
       inputSchema: {
         design: z.string().describe("Path to design file"),
         net_name: z.string().describe("Exact net name"),
@@ -278,7 +289,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_xnet_by_pin_name",
     {
-      description: "Get full XNET connectivity starting from a component pin",
+      description:
+        "Get full XNET connectivity starting from a component pin. Rejects pins connected to ground nets (GND, AGND, DGND, etc.) with an error.",
       inputSchema: {
         design: z.string().describe("Path to design file"),
         pin_name: z.string().describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
@@ -298,7 +310,8 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_component",
     {
-      description: "Get full component details including all pin connections",
+      description:
+        "Get full component details including all pin connections. Refdes lookup is case-insensitive. Returns MPN, description, value, and pin-to-net mappings when available. Errors include guidance and suggestions.",
       inputSchema: {
         design: z.string().describe("Path to design file"),
         refdes: z.string().describe("Component reference designator"),

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -8,6 +8,10 @@ import {
   groupComponentsByMpn,
   aggregateCircuitByMpn,
   parseRegexPattern,
+  searchNets,
+  searchComponentsByRefdes,
+  searchComponentsByMpn,
+  searchComponentsByDescription,
   detectCadenceVersions,
   exportCadenceNetlist,
   relocateLockFile,
@@ -794,5 +798,160 @@ describe("resolveAllegroDir", () => {
     expect(result.outputDir).toBe(path.join(tmpDir, "allegro"));
     const stat = await fs.promises.stat(result.outputDir);
     expect(stat.isDirectory()).toBe(true);
+  });
+});
+
+describe("searchNets - case insensitive by default", () => {
+  beforeEach(() => {
+    const mockNetlist: ParsedNetlist = {
+      nets: {
+        VDD_1V8: { U1: "1" },
+        VDD_3V3: { U2: "1" },
+        GND: { U1: "2", U2: "2" },
+      },
+      components: {
+        U1: { pins: { "1": "VDD_1V8", "2": "GND" } },
+        U2: { pins: { "1": "VDD_3V3", "2": "GND" } },
+      },
+    };
+    vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lowercase pattern matches uppercase net names", async () => {
+    const result = await searchNets("vdd", "/mock/design.dsn");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      const nets = Object.values(result.results).flat();
+      expect(nets).toContain("VDD_1V8");
+      expect(nets).toContain("VDD_3V3");
+    }
+  });
+
+  it("uppercase pattern still works", async () => {
+    const result = await searchNets("VDD", "/mock/design.dsn");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      const nets = Object.values(result.results).flat();
+      expect(nets).toContain("VDD_1V8");
+      expect(nets).toContain("VDD_3V3");
+    }
+  });
+
+  it("explicit (?i) flag also works", async () => {
+    const result = await searchNets("(?i)gnd", "/mock/design.dsn");
+    expect(isErrorResult(result)).toBe(false);
+    if (!isErrorResult(result)) {
+      const nets = Object.values(result.results).flat();
+      expect(nets).toContain("GND");
+    }
+  });
+});
+
+describe("search tools - broad pattern rejection", () => {
+  const mockNetlist: ParsedNetlist = {
+    nets: {
+      VDD_1V8: { U1: "1" },
+      GND: { U1: "2", R1: "2" },
+      SIG_A: { R1: "1" },
+    },
+    components: {
+      U1: {
+        mpn: "TPS62088",
+        description: "Buck Converter",
+        pins: { "1": "VDD_1V8", "2": "GND" },
+      },
+      R1: {
+        mpn: "RC0402FR-0710KL",
+        description: "10K Resistor",
+        pins: { "1": "SIG_A", "2": "GND" },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.spyOn(parsersModule, "findHandler").mockReturnValue({
+      name: "mock",
+      extensions: [".dsn"],
+      canHandle: () => true,
+      discoverDesigns: vi.fn(),
+      parse: vi.fn(),
+    });
+    vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("searchNets", () => {
+    it("rejects .* pattern that matches all nets", async () => {
+      const result = await searchNets(".*", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_nets");
+      expect((result as ErrorResult).error).toContain("all 3 items");
+    });
+
+    it("rejects .+ pattern that matches all nets", async () => {
+      const result = await searchNets(".+", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_nets");
+    });
+
+    it("rejects ^ pattern that matches all nets", async () => {
+      const result = await searchNets("^", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_nets");
+    });
+
+    it("allows specific pattern that matches subset", async () => {
+      const result = await searchNets("VDD", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(false);
+    });
+  });
+
+  describe("searchComponentsByRefdes", () => {
+    it("rejects .* pattern that matches all components", async () => {
+      const result = await searchComponentsByRefdes(".*", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_components");
+      expect((result as ErrorResult).error).toContain("all 2 items");
+    });
+
+    it("allows specific pattern that matches subset", async () => {
+      const result = await searchComponentsByRefdes("^U", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(false);
+    });
+  });
+
+  describe("searchComponentsByMpn", () => {
+    it("rejects .* pattern that matches all components with MPN", async () => {
+      const result = await searchComponentsByMpn(".*", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_components");
+      expect((result as ErrorResult).error).toContain("all 2 items");
+    });
+
+    it("allows specific pattern that matches subset", async () => {
+      const result = await searchComponentsByMpn("TPS", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(false);
+    });
+  });
+
+  describe("searchComponentsByDescription", () => {
+    it("rejects .* pattern that matches all components with description", async () => {
+      const result = await searchComponentsByDescription(".*", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(true);
+      expect((result as ErrorResult).error).toContain("list_components");
+      expect((result as ErrorResult).error).toContain("all 2 items");
+    });
+
+    it("allows specific pattern that matches subset", async () => {
+      const result = await searchComponentsByDescription("Buck", "/mock/design.dsn");
+      expect(isErrorResult(result)).toBe(false);
+    });
   });
 });

--- a/src/service.ts
+++ b/src/service.ts
@@ -81,7 +81,7 @@ export const loadNetlist = async (designPath: string): Promise<ParsedNetlist | E
   if (!handler) {
     const ext = path.extname(normalizedPath);
     return {
-      error: `Unsupported design file format '${ext}'. Supported: .dsn, .cpm (Cadence), .PrjPcb (Altium)`,
+      error: `Unsupported design file format '${ext}'. Supported: .dsn, .cpm (Cadence), .PrjPcb, .SchDoc (Altium)`,
     };
   }
 
@@ -370,6 +370,18 @@ const parseRegexPattern = (
   }
 };
 
+/**
+ * Return an error when a search pattern matches every item in the dataset.
+ * This prevents wildcard patterns (e.g. `.*`) from dumping the full list.
+ */
+const tooManyMatchesError = (
+  pattern: string,
+  matchCount: number,
+  toolSuggestion: string
+): ErrorResult => ({
+  error: `Pattern '${pattern}' matched all ${matchCount} items. Use ${toolSuggestion} to retrieve the full list, or use a more specific pattern.`,
+});
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -481,7 +493,7 @@ export const searchNets = async (
   pattern: string,
   design: string
 ): Promise<SearchNetsResult | ErrorResult> => {
-  const parsed = parseRegexPattern(pattern);
+  const parsed = parseRegexPattern(pattern, "i");
   if ("error" in parsed) return parsed;
   const regex = parsed.regex;
 
@@ -491,7 +503,13 @@ export const searchNets = async (
   }
 
   const designName = path.basename(design, path.extname(design));
-  const nets = Object.keys(netlist.nets).filter((net) => regex.test(net));
+  const allNets = Object.keys(netlist.nets);
+  const nets = allNets.filter((net) => regex.test(net));
+
+  if (nets.length > 0 && nets.length === allNets.length) {
+    return tooManyMatchesError(pattern, nets.length, "list_nets");
+  }
+
   const sorted = nets.sort((a, b) => a.localeCompare(b));
 
   if (sorted.length === 0) {
@@ -526,7 +544,12 @@ export const searchComponentsByRefdes = async (
   }
 
   const designName = path.basename(design, path.extname(design));
-  const entries = Object.entries(netlist.components).filter(([refdes]) => regex.test(refdes));
+  const allEntries = Object.entries(netlist.components);
+  const entries = allEntries.filter(([refdes]) => regex.test(refdes));
+
+  if (entries.length > 0 && entries.length === allEntries.length) {
+    return tooManyMatchesError(pattern, entries.length, "list_components");
+  }
 
   const grouped = groupComponentsByMpn(entries, includeDns);
 
@@ -566,8 +589,6 @@ export const searchComponentsByMpn = async (
   const componentsWithMpn = allComponents.filter(([, c]) => c.mpn?.trim());
   const entries = componentsWithMpn.filter(([, component]) => regex.test(component.mpn!));
 
-  const grouped = groupComponentsByMpn(entries, includeDns);
-
   // Case 1: No MPN data exists at all
   if (componentsWithMpn.length === 0) {
     return {
@@ -575,6 +596,12 @@ export const searchComponentsByMpn = async (
       notes: ["This netlist has no MPN data. Ask user for BOM or schematic PDF"],
     };
   }
+
+  if (entries.length > 0 && entries.length === componentsWithMpn.length) {
+    return tooManyMatchesError(pattern, entries.length, "list_components");
+  }
+
+  const grouped = groupComponentsByMpn(entries, includeDns);
 
   // Case 2: MPN data exists but pattern didn't match
   if (grouped.length === 0) {
@@ -617,8 +644,6 @@ export const searchComponentsByDescription = async (
     regex.test(component.description!)
   );
 
-  const grouped = groupComponentsByMpn(entries, includeDns);
-
   // Case 1: No description data exists at all
   if (componentsWithDescription.length === 0) {
     return {
@@ -626,6 +651,12 @@ export const searchComponentsByDescription = async (
       notes: ["This netlist has no description data. Ask user for BOM or schematic PDF"],
     };
   }
+
+  if (entries.length > 0 && entries.length === componentsWithDescription.length) {
+    return tooManyMatchesError(pattern, entries.length, "list_components");
+  }
+
+  const grouped = groupComponentsByMpn(entries, includeDns);
 
   // Case 2: Description data exists but pattern didn't match
   if (grouped.length === 0) {


### PR DESCRIPTION
## Summary

- Discover standalone `.SchDoc` files when no `.PrjPcb` project file is present (#26)
- Reject overly broad search patterns (`.*`, `.+`, `^`) that match all items, directing to `list_nets`/`list_components` instead (#27)
- Add `.mcp.json` for local MCP server development
- Remove `--no-update` flag and `UNIVERSAL_NETLIST_MCP_NO_UPDATE` env var; auto-update always enabled
- Remove confirmation prompt from `--update`; updates proceed immediately
- Remove Claude Desktop mention from TTY message

## Test plan

- [x] 272 tests passing
- [x] Type-check and lint clean
- [x] MCP stress tested across all 8 fixtures (Cadence + Altium)
- [x] Standalone SchDoc manually tested: single-sheet (STM32) and multi-sheet (pca10056, 6 sheets)
- [x] Broad pattern rejection verified on all 4 search tools