### PR TITLE
Add tools directory README

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,15 @@
+# Tools
+
+| Tool | Description |
+|------|-------------|
+| [`list_designs`](list_designs.md) | List all design projects in a directory |
+| [`list_components`](list_components.md) | List components of a specific type in a design |
+| [`list_nets`](list_nets.md) | List all net names in a design |
+| [`search_nets`](search_nets.md) | Search for nets matching a regex pattern |
+| [`search_components_by_refdes`](search_components_by_refdes.md) | Search for components by reference designator pattern |
+| [`search_components_by_mpn`](search_components_by_mpn.md) | Search for components by Manufacturer Part Number (MPN) pattern |
+| [`search_components_by_description`](search_components_by_description.md) | Search for components by description pattern |
+| [`query_component`](query_component.md) | Get full component details including all pin connections |
+| [`query_xnet_by_net_name`](query_xnet_by_net_name.md) | Get full XNET (Extended Net) connectivity for a net |
+| [`query_xnet_by_pin_name`](query_xnet_by_pin_name.md) | Get full XNET connectivity starting from a component pin |
+| [`export_cadence_netlist`](export_cadence_netlist.md) | Export Cadence schematic netlist to Allegro PCB format (Windows only) |


### PR DESCRIPTION
## Summary
- Add `docs/tools/README.md` with an index table listing all 11 tools and linking to their individual doc files
- Ensures a page renders when users browse to the `docs/tools/` directory on GitHub

## Test plan
- [x] Verify all 11 tool links resolve to existing `.md` files