### PR TITLE
Fix scoped regex test for Node v25+, housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ npm-debug.log*
 .claude/settings.local.json
 *.swp
 *.swo
+opencode.json
 
 # OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - Universal Netlist MCP Server
+# Universal Netlist MCP Server
 
 ## Overview
 
@@ -73,64 +73,6 @@ The tag push triggers the release workflow, which automatically:
 - Builds signed binaries for all platforms
 - Creates GitHub Release with binaries
 - Publishes to npm via OIDC (no tokens)
-
-## Project Structure
-
-```bash
-src/
-  index.ts              # Entry point, CLI handling
-  server.ts             # MCP server setup, tool registration
-  service.ts            # Tool implementations (query logic)
-  types.ts              # TypeScript types and interfaces
-  version.ts            # Version constant
-  circuit-traversal.ts  # XNET traversal algorithm
-  cli/
-    commands.ts         # CLI command handlers
-  parsers/
-    index.ts            # Parser registry
-    cadence/            # Cadence CIS/HDL parser
-    altium/             # Altium Designer parser
-docs/
-  README.md             # API documentation
-  tools/                # Per-tool documentation
-  schemas/              # Type documentation
-```
-
-## Adding New Features
-
-### Adding a New Tool
-
-1. Add the service function in `src/service.ts`
-2. Register the tool in `src/server.ts` using `server.registerTool()`
-3. Add documentation in `docs/tools/`
-4. Add tests in `src/service.test.ts`
-
-## Key Concepts
-
-### ParsedNetlist
-
-The core data structure returned by parsers:
-
-```typescript
-interface ParsedNetlist {
-  components: { [refdes: string]: ComponentData };
-  nets: { [netName: string]: Array<{ refdes: string; pin: string }> };
-}
-```
-
-### XNET Traversal
-
-The `query_xnet_*` tools trace connectivity through series components (resistors, capacitors, inductors). The algorithm:
-
-1. Start from a net or pin
-2. Find all components connected to the net
-3. For 2-pin passive components, traverse to the net on the other pin
-4. Continue until reaching power/ground nets or components with >2 pins
-5. Return all visited components and nets
-
-### DNS (Do Not Stuff)
-
-Components marked as DNS are excluded by default. The `include_dns` parameter includes them.
 
 ## Testing
 

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -439,7 +439,15 @@ describe("parseRegexPattern", () => {
 
   it("does not strip scoped group (?i:...)", () => {
     const result = parseRegexPattern("(?i:foo)bar");
-    expect("error" in result).toBe(true);
+    // On Node v25+ the scoped modifier (?i:...) is valid RegExp syntax.
+    // On older engines it throws. Either way, the prefix must NOT be stripped.
+    if ("regex" in result) {
+      expect(result.regex.source).toContain("(?i:foo)");
+      expect(result.regex.test("FOObar")).toBe(true);
+      expect(result.regex.test("fooBAR")).toBe(false);
+    } else {
+      expect(result.error).toContain("Invalid regex pattern");
+    }
   });
 
   it("returns error for invalid regex after flag stripping", () => {


### PR DESCRIPTION
## Summary
- Fix `parseRegexPattern` test that fails on Node v25+ where `(?i:foo)` is valid RegExp syntax (TC39 RegExp Modifiers proposal)
- Trim redundant sections from CLAUDE.md (project structure, key concepts, adding new features)
- Add `opencode.json` to .gitignore

## Test plan
- [x] All 286 tests pass on Node v22
- [ ] Verify test passes on Node v25 environment