### PR TITLE
Eliminate null values from MPN fields in JSON output

### DIFF
--- a/docs/schemas/shared-types.md
+++ b/docs/schemas/shared-types.md
@@ -25,11 +25,8 @@ Used in `list_components` and `search_components_by_*` results. Groups component
       "description": "Number of components in group"
     },
     "mpn": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "null" }
-      ],
-      "description": "Manufacturer Part Number (null if missing)"
+      "type": "string",
+      "description": "Manufacturer Part Number (omitted if missing)"
     },
     "description": {
       "type": "string",
@@ -53,7 +50,7 @@ Used in `list_components` and `search_components_by_*` results. Groups component
       "description": "Informational notes (e.g., missing MPN warning)"
     }
   },
-  "required": ["refdes", "count", "mpn"]
+  "required": ["refdes", "count"]
 }
 ```
 
@@ -79,10 +76,8 @@ Used in `query_xnet_*` results. Groups components by MPN with orientation tracki
   "type": "object",
   "properties": {
     "mpn": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "null" }
-      ]
+      "type": "string",
+      "description": "Manufacturer Part Number (omitted if missing)"
     },
     "description": { "type": "string" },
     "comment": { "type": "string" },
@@ -114,7 +109,7 @@ Used in `query_xnet_*` results. Groups components by MPN with orientation tracki
       "items": { "type": "string" }
     }
   },
-  "required": ["mpn", "total_count"]
+  "required": ["total_count"]
 }
 ```
 

--- a/docs/schemas/universal-netlist.md
+++ b/docs/schemas/universal-netlist.md
@@ -119,11 +119,8 @@ Maps reference designators to component information including pin-to-net mapping
     "type": "object",
     "properties": {
       "mpn": {
-        "oneOf": [
-          { "type": "string" },
-          { "type": "null" }
-        ],
-        "description": "Manufacturer Part Number"
+        "type": "string",
+        "description": "Manufacturer Part Number (omitted if missing)"
       },
       "description": {
         "type": "string",

--- a/docs/tools/list_components.md
+++ b/docs/tools/list_components.md
@@ -56,7 +56,6 @@ Response:
       "refdes": "U5"
     },
     {
-      "mpn": null,
       "description": "IC GENERIC",
       "count": 1,
       "refdes": "U3",
@@ -78,7 +77,7 @@ Response:
 - The `type` parameter is case-insensitive (`u` and `U` both work)
 - Components are grouped by MPN; components without MPN are listed individually
 - Single-element `refdes` arrays are compacted to strings
-- Components with `mpn: null` include a `notes` field suggesting next steps
+- Components without MPN include a `notes` field suggesting next steps
 - Use `include_dns: true` to see DNS components (marked with `dns: true`)
 
 ## See Also

--- a/docs/tools/query_component.md
+++ b/docs/tools/query_component.md
@@ -20,7 +20,7 @@ Returns component details with pin-to-net mappings using [`PinEntry`](../schemas
 ```json
 {
   "refdes": "string",
-  "mpn": "string | null",
+  "mpn": "string",              // optional
   "description": "string",       // optional
   "comment": "string",           // optional
   "value": "string",             // optional
@@ -85,7 +85,6 @@ Response:
 ```json
 {
   "refdes": "C5",
-  "mpn": null,
   "description": "CAP CER 10UF 0402",
   "value": "10uF",
   "pins": {
@@ -121,5 +120,5 @@ Pins use two formats:
 
 - Reference designator lookup is **case-insensitive** (`u1` matches `U1`)
 - The `NC` net indicates an unconnected pin (No Connect)
-- Components with `mpn: null` include a `notes` field
+- Components without MPN omit the `mpn` field and include a `notes` field
 - Pin numbers are string keys (may be alphanumeric like `A1`, `B2` for BGAs)

--- a/src/circuit-traversal.ts
+++ b/src/circuit-traversal.ts
@@ -5,11 +5,7 @@
 
 import { createHash } from "crypto";
 import { getPinNet } from "./types.js";
-import type {
-  NetConnections,
-  ComponentDetails,
-  CircuitComponent,
-} from "./types.js";
+import type { NetConnections, ComponentDetails, CircuitComponent } from "./types.js";
 
 // Regex patterns for net classification
 const GROUND_NET_PATTERN = /^(GND|VSS|AGND|DGND|PGND|SGND|CGND)$/i;
@@ -23,20 +19,17 @@ const DNS_PATTERN =
 /**
  * Check if a net name matches the ground pattern.
  */
-export const isGroundNet = (netName: string): boolean =>
-  GROUND_NET_PATTERN.test(netName);
+export const isGroundNet = (netName: string): boolean => GROUND_NET_PATTERN.test(netName);
 
 /**
  * Check if a net name matches the power pattern.
  */
-export const isPowerNet = (netName: string): boolean =>
-  POWER_NET_PATTERN.test(netName);
+export const isPowerNet = (netName: string): boolean => POWER_NET_PATTERN.test(netName);
 
 /**
  * Check if a net name matches the stop pattern (power or ground).
  */
-export const isStopNet = (netName: string): boolean =>
-  STOP_NET_PATTERN.test(netName);
+export const isStopNet = (netName: string): boolean => STOP_NET_PATTERN.test(netName);
 
 /**
  * Determine if a component is a traversable passive (R/RS, L, C, FB).
@@ -57,8 +50,7 @@ export const isPassive = (refdes: string): boolean => {
  * Check if a string is a valid refdes (letters followed by alphanumerics).
  * Filters out Cadence instance paths like "@DESIGN.SHEET:INS123@PART".
  */
-export const isValidRefdes = (refdes: string): boolean =>
-  /^[A-Z][A-Z0-9_]*$/i.test(refdes);
+export const isValidRefdes = (refdes: string): boolean => /^[A-Z][A-Z0-9_]*$/i.test(refdes);
 
 /**
  * Extract a refdes prefix (letters only).
@@ -131,9 +123,7 @@ export const computeCircuitHash = (components: CircuitComponent[]): string => {
     return "0".repeat(16);
   }
 
-  const sortedComponents = [...components].sort((a, b) =>
-    naturalSort(a.refdes, b.refdes),
-  );
+  const sortedComponents = [...components].sort((a, b) => naturalSort(a.refdes, b.refdes));
 
   const canonicalForm = sortedComponents.map((comp) => ({
     refdes: comp.refdes,
@@ -155,7 +145,7 @@ interface FlatCircuitEntry {
   refdes: string;
   pin: string;
   net: string;
-  mpn?: string | null;
+  mpn?: string;
   description?: string;
   comment?: string;
   value?: string;
@@ -181,13 +171,13 @@ export interface TraversalOptions {
 const groupCircuitPins = (
   flat: FlatCircuitEntry[],
   visitedNets: string[],
-  skipped: Record<string, number>,
+  skipped: Record<string, number>
 ): TraversalResult => {
   const byRefdes = new Map<
     string,
     {
       refdes: string;
-      mpn?: string | null;
+      mpn?: string;
       description?: string;
       comment?: string;
       value?: string;
@@ -260,15 +250,13 @@ export const traverseCircuitFromNet = (
   startNet: string,
   nets: NetConnections,
   components: ComponentDetails,
-  options: TraversalOptions = {},
+  options: TraversalOptions = {}
 ): TraversalResult => {
   if (!startNet || !nets[startNet]) {
     return { components: [], visited_nets: [], skipped: {} };
   }
 
-  const skipTypes = (options.skipTypes ?? []).map((type) =>
-    type.trim().toUpperCase(),
-  );
+  const skipTypes = (options.skipTypes ?? []).map((type) => type.trim().toUpperCase());
   const includeDns = options.includeDns ?? false;
   const skipped: Record<string, number> = {};
   const skippedComponents = new Set<string>();
@@ -276,7 +264,7 @@ export const traverseCircuitFromNet = (
   const shouldSkipComponent = (
     refdes: string,
     _component: ComponentDetails[string] | undefined,
-    isDns: boolean,
+    isDns: boolean
   ): boolean => {
     if (!includeDns && isDns) {
       return true;
@@ -373,9 +361,7 @@ export const traverseCircuitFromNet = (
                 hasPassiveToFollow = true;
               } else {
                 const pinsOnNet = otherNetConns[otherRefdes];
-                const pinsArray = Array.isArray(pinsOnNet)
-                  ? pinsOnNet
-                  : [pinsOnNet];
+                const pinsArray = Array.isArray(pinsOnNet) ? pinsOnNet : [pinsOnNet];
                 for (const activePin of pinsArray) {
                   const activePinId = `${otherRefdes}:${activePin}`;
                   if (!visitedPins.has(activePinId)) {

--- a/src/parsers/cadence/pstxprt-parser.ts
+++ b/src/parsers/cadence/pstxprt-parser.ts
@@ -3,8 +3,8 @@
  * Extracts component details (MPN, description)
  */
 
-import { readFile } from 'fs/promises';
-import type { ComponentDetails } from '../../types.js';
+import { readFile } from "fs/promises";
+import type { ComponentDetails } from "../../types.js";
 
 /**
  * Result from parsing pstxprt.dat
@@ -21,7 +21,7 @@ export interface PstxprtResult {
  * Returns both components and a partNames map for cross-referencing.
  */
 export const parsePstxprt = async (filePath: string): Promise<PstxprtResult> => {
-  const content = await readFile(filePath, 'utf-8');
+  const content = await readFile(filePath, "utf-8");
   return parsePstxprtContent(content);
 };
 
@@ -29,7 +29,7 @@ export const parsePstxprt = async (filePath: string): Promise<PstxprtResult> => 
  * Parse pstxprt file content (pure function for testing).
  */
 export const parsePstxprtContent = (content: string): PstxprtResult => {
-  const lines = content.split('\n').map((line) => line.trim());
+  const lines = content.split("\n").map((line) => line.trim());
 
   const componentDetails: ComponentDetails = {};
   const partNames = new Map<string, string>();
@@ -42,10 +42,12 @@ export const parsePstxprtContent = (content: string): PstxprtResult => {
       const component: ComponentDetails[string] = { pins: {} };
 
       // MPN: use MFGR_PN if available, otherwise fall back to part name string
-      const mpn = currentProperties['MFGR_PN'] || currentPartName || null;
-      component.mpn = mpn;
+      const mpn = currentProperties["MFGR_PN"] || currentPartName || undefined;
+      if (mpn) {
+        component.mpn = mpn;
+      }
 
-      const description = currentProperties['DESCR'];
+      const description = currentProperties["DESCR"];
       if (description) {
         component.description = description;
       }
@@ -61,29 +63,29 @@ export const parsePstxprtContent = (content: string): PstxprtResult => {
 
   for (const line of lines) {
     // PART_NAME alone is a section header; PART_NAME='...' is a property
-    if (line === 'PART_NAME') {
+    if (line === "PART_NAME") {
       saveCurrentComponent();
       currentRefdes = null;
       currentPartName = null;
       currentProperties = {};
     } else if (currentRefdes === null && line) {
       // Component line ends with ':' or ':;'
-      if (line.includes(' ') && (line.endsWith(':') || line.endsWith(':;'))) {
+      if (line.includes(" ") && (line.endsWith(":") || line.endsWith(":;"))) {
         const match = line.match(/^(\S+)\s+'([^']+)'/);
         if (match) {
           currentRefdes = match[1];
           currentPartName = match[2];
         } else {
-          const [refdes] = line.split(' ', 1);
+          const [refdes] = line.split(" ", 1);
           currentRefdes = refdes;
         }
       }
-    } else if (line.includes('=')) {
-      const [key, ...valueParts] = line.split('=');
+    } else if (line.includes("=")) {
+      const [key, ...valueParts] = line.split("=");
       const value = valueParts
-        .join('=')
+        .join("=")
         .trim()
-        .replace(/^['"]|['";,]+$/g, '');
+        .replace(/^['"]|['";,]+$/g, "");
       currentProperties[key.trim()] = value;
     }
   }

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -39,7 +39,7 @@ describe("MPN_MISSING_NOTE", () => {
 });
 
 describe("groupComponentsByMpn", () => {
-  it("should set mpn to null and add notes when MPN is missing", () => {
+  it("should omit mpn and add notes when MPN is missing", () => {
     const components: ComponentDetails = {
       U1: { pins: { "1": "VCC", "2": "GND" } },
     };
@@ -48,7 +48,7 @@ describe("groupComponentsByMpn", () => {
     const result = groupComponentsByMpn(entries, false);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toBeDefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
     expect(result[0].refdes).toBe("U1");
@@ -67,7 +67,7 @@ describe("groupComponentsByMpn", () => {
     expect(result[0].notes).toBeUndefined();
   });
 
-  it("should set mpn to null when MPN is empty string", () => {
+  it("should omit mpn when MPN is empty string", () => {
     const components: ComponentDetails = {
       U1: { mpn: "", pins: { "1": "VCC", "2": "GND" } },
     };
@@ -76,11 +76,11 @@ describe("groupComponentsByMpn", () => {
     const result = groupComponentsByMpn(entries, false);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
   });
 
-  it("should set mpn to null when MPN is whitespace only", () => {
+  it("should omit mpn when MPN is whitespace only", () => {
     const components: ComponentDetails = {
       U1: { mpn: "   ", pins: { "1": "VCC", "2": "GND" } },
     };
@@ -89,7 +89,7 @@ describe("groupComponentsByMpn", () => {
     const result = groupComponentsByMpn(entries, false);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
   });
 
@@ -179,13 +179,13 @@ describe("groupComponentsByMpn", () => {
     const result = groupComponentsByMpn(entries, false);
 
     expect(result).toHaveLength(2);
-    expect(result.every((r) => r.mpn === null)).toBe(true);
+    expect(result.every((r) => r.mpn === undefined)).toBe(true);
     expect(result.every((r) => r.notes?.includes(MPN_MISSING_NOTE))).toBe(true);
   });
 });
 
 describe("aggregateCircuitByMpn", () => {
-  it("should set mpn to null and add notes for components without MPN", () => {
+  it("should omit mpn and add notes for components without MPN", () => {
     const components: CircuitComponent[] = [
       {
         refdes: "U1",
@@ -200,7 +200,7 @@ describe("aggregateCircuitByMpn", () => {
     const result = aggregateCircuitByMpn(components);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toBeDefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
   });
@@ -239,12 +239,12 @@ describe("aggregateCircuitByMpn", () => {
     const result = aggregateCircuitByMpn(components);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
     expect(result[0].refdes).toBe("X1");
   });
 
-  it("should set mpn to null when MPN is empty string", () => {
+  it("should omit mpn when MPN is empty string", () => {
     const components: CircuitComponent[] = [
       {
         refdes: "U1",
@@ -257,7 +257,7 @@ describe("aggregateCircuitByMpn", () => {
     const result = aggregateCircuitByMpn(components);
 
     expect(result).toHaveLength(1);
-    expect(result[0].mpn).toBeNull();
+    expect(result[0].mpn).toBeUndefined();
     expect(result[0].notes).toContain(MPN_MISSING_NOTE);
   });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -112,7 +112,7 @@ const groupComponentsByMpn = (
   const groups = new Map<
     string,
     {
-      mpn: string | null;
+      mpn?: string;
       description?: string;
       comment?: string;
       value?: string;
@@ -128,7 +128,7 @@ const groupComponentsByMpn = (
       continue;
     }
 
-    const mpnTrimmed = component.mpn?.trim() || null;
+    const mpnTrimmed = component.mpn?.trim() || undefined;
     const descriptionValue = component.description?.trim() || undefined;
     const commentValue = component.comment?.trim() || undefined;
     const valueValue = component.value?.trim() || undefined;
@@ -138,7 +138,7 @@ const groupComponentsByMpn = (
 
     if (!groups.has(groupKey)) {
       groups.set(groupKey, {
-        mpn: mpnTrimmed,
+        ...(mpnTrimmed && { mpn: mpnTrimmed }),
         description: descriptionValue,
         comment: commentValue,
         value: valueValue,
@@ -156,10 +156,13 @@ const groupComponentsByMpn = (
   return Array.from(groups.values())
     .map((group) => {
       const entry: ComponentGroup = {
-        mpn: group.mpn,
         count: group.refdes.length,
         refdes: compactArray(group.refdes.sort(naturalSort)),
       };
+
+      if (group.mpn !== undefined) {
+        entry.mpn = group.mpn;
+      }
 
       if (group.description !== undefined) {
         entry.description = group.description;
@@ -195,7 +198,7 @@ const aggregateCircuitByMpn = (
   const groups = new Map<
     string,
     {
-      mpn: string | null;
+      mpn?: string;
       description?: string;
       comment?: string;
       value?: string;
@@ -215,7 +218,7 @@ const aggregateCircuitByMpn = (
   const unaggregatable: typeof components = [];
 
   for (const comp of components) {
-    const mpn = comp.mpn?.trim() || null;
+    const mpn = comp.mpn?.trim() || undefined;
     const description = comp.description?.trim() || "";
     const value = comp.value?.trim() || undefined;
     const dnsFlag = comp.dns ? true : undefined;
@@ -236,7 +239,7 @@ const aggregateCircuitByMpn = (
 
     if (!groups.has(groupKey)) {
       groups.set(groupKey, {
-        mpn,
+        ...(mpn && { mpn }),
         description: description || undefined,
         comment: comp.comment,
         value,
@@ -279,9 +282,12 @@ const aggregateCircuitByMpn = (
     const totalCount = orientationsList.reduce((sum, o) => sum + o.count, 0);
 
     const aggregated: AggregatedComponent = {
-      mpn: group.mpn,
       total_count: totalCount,
     };
+
+    if (group.mpn !== undefined) {
+      aggregated.mpn = group.mpn;
+    }
 
     if (group.description !== undefined) {
       aggregated.description = group.description;
@@ -316,7 +322,6 @@ const aggregateCircuitByMpn = (
   for (const comp of unaggregatable) {
     const unagg: AggregatedComponent = {
       refdes: comp.refdes,
-      mpn: null,
       notes: [MPN_MISSING_NOTE],
       total_count: 1,
       connections: compactConnections(comp.connections),
@@ -699,14 +704,17 @@ export const queryComponent = async (
   }
 
   const [resolvedRefdes, component] = componentEntry;
-  const mpn = component.mpn?.trim() || null;
+  const mpn = component.mpn?.trim() || undefined;
   const dns = isDnsComponent(component);
 
   const result: QueryComponentResult = {
     refdes: resolvedRefdes,
-    mpn,
     pins: component.pins,
   };
+
+  if (mpn !== undefined) {
+    result.mpn = mpn;
+  }
 
   if (component.description !== undefined) {
     result.description = component.description;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,7 @@ import type { AltiumDiscoveredDesign } from "./parsers/altium/discovery.js";
  * Compact single-element arrays to scalar values for token savings.
  * Returns the single element if array has length 1, otherwise returns the array.
  */
-export const compactArray = <T>(arr: T[]): T | T[] =>
-  arr.length === 1 ? arr[0] : arr;
+export const compactArray = <T>(arr: T[]): T | T[] => (arr.length === 1 ? arr[0] : arr);
 
 /**
  * Net connections from netlist
@@ -36,7 +35,7 @@ export type PinEntry = string | { name: string; net: string };
 export const createPinEntry = (
   pinNumber: string,
   pinName: string | undefined,
-  netName: string,
+  netName: string
 ): PinEntry => {
   const normalizedName = pinName?.trim();
   if (normalizedName && normalizedName !== pinNumber) {
@@ -56,7 +55,7 @@ export const getPinNet = (entry: PinEntry): string =>
  */
 export interface ComponentDetails {
   [refdes: string]: {
-    mpn?: string | null;
+    mpn?: string;
     description?: string;
     comment?: string;
     value?: string;
@@ -78,7 +77,7 @@ export interface ParsedNetlist {
 export interface CircuitComponent {
   refdes: string;
   type?: string;
-  mpn?: string | null;
+  mpn?: string;
   description?: string;
   comment?: string;
   value?: string;
@@ -126,7 +125,7 @@ export interface OrientationVariant {
  * Aggregated component group (grouped by MPN or description)
  */
 export interface AggregatedComponent {
-  mpn: string | null;
+  mpn?: string;
   description?: string;
   comment?: string;
   value?: string;
@@ -175,7 +174,7 @@ export interface DesignInfo {
 export interface ComponentGroup {
   refdes: string | string[];
   count: number;
-  mpn: string | null;
+  mpn?: string;
   description?: string;
   comment?: string;
   value?: string;
@@ -218,7 +217,7 @@ export interface SearchNetsResult {
  */
 export interface QueryComponentResult {
   refdes: string;
-  mpn: string | null;
+  mpn?: string;
   description?: string;
   comment?: string;
   value?: string;


### PR DESCRIPTION
## Summary

- Omit the `mpn` key entirely when MPN data is missing instead of emitting `"mpn": null`
- The `notes` field already explains why MPN is unavailable, so null values add no information and waste tokens
- Updated schemas, tool docs, types, service layer, parser, and tests

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (299/299)
- [x] MCP-level validation across all 4 test fixtures confirms no null values in output