### PR TITLE
docs: remove dsn.xsd references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ npm publishing uses OIDC trusted publishing (configured on npmjs.com) - no token
 
 1. **Read `docs/dsn-format.md`** for the binary format spec
 2. **Read the corresponding C++ file** in `references/OpenOrCadParser/` before writing any code
-3. Cross-reference `docs/dsn.xsd` / `docs/olb.xsd` for structure/field names if needed
+3. Cross-reference `docs/olb.xsd` for structure/field names if needed
 
 ### C++ reference mapping
 
@@ -126,7 +126,7 @@ The TypeScript files in `src/parsers/cadence/dsn/` map to C++ files in `referenc
 
 ### Additional resources
 
-- **Cadence schemas**: `docs/dsn.xsd`, `docs/olb.xsd`
+- **Cadence schemas**: `docs/olb.xsd`
 - **Coverage scripts**: `scripts/dsn-coverage-report.ts`, `scripts/dsn-inspect.ts` (see `scripts/AGENTS.md`)
 
 ## Git Guidelines

--- a/docs/dsn-format.md
+++ b/docs/dsn-format.md
@@ -1036,7 +1036,7 @@ Matching is case-insensitive. This cleanup improved BBxM value coverage from 90.
 ### 12.8 Reference material
 
 - [OpenOrCadParser](https://github.com/Werni2A/OpenOrCadParser) - C++ reference implementation (local copy at `references/OpenOrCadParser/`, gitignored)
-- `docs/dsn.xsd` - Cadence DSN XML schema (structure/field reference, gitignored)
+
 
 Key C++ source files for cross-referencing unknown bytes or new structure types:
 


### PR DESCRIPTION
## Summary
- Remove all references to `docs/dsn.xsd` from `CLAUDE.md` and `docs/dsn-format.md`

## Test plan
- [x] Docs-only change, no code affected