### PR TITLE
fix: use cmd.exe for pstswp.exe on Windows

### DIFF
--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -13,15 +13,6 @@ const serializePstswp = createMutex();
 const execAsync = promisify(exec);
 
 /**
- * Convert Windows path to bash-compatible path for GitBash/WSL compatibility.
- * Example: C:\foo\bar -> /c/foo/bar
- */
-const toBashPath = (winPath: string): string =>
-  winPath
-    .replace(/\\/g, "/")
-    .replace(/^([A-Za-z]):/, (_, drive: string) => `/${drive.toLowerCase()}`);
-
-/**
  * Detect installed Cadence SPB versions from the standard installation directory.
  *
  * @param cadenceBase - Base Cadence installation directory (default: C:/Cadence)
@@ -158,16 +149,11 @@ export const exportCadenceNetlist = async (
     // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
     const lockTempPath = await relocateLockFile(resolvedDsnPath);
 
-    // Convert to bash paths for command execution (GitBash compatibility)
-    const bashDsnDir = toBashPath(dsnDir);
-    const pstswp = toBashPath(cadence.pstswp);
-    const config = toBashPath(cadence.config);
-
-    const command = `cd "${bashDsnDir}" && "${pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${config}" -v 3 -l 255 -j "PCB Footprint"`;
+    const command = `cd /d "${dsnDir}" && "${cadence.pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${cadence.config}" -v 3 -l 255 -j "PCB Footprint"`;
 
     try {
       const { stdout, stderr } = await execAsync(command, {
-        shell: "bash",
+        shell: "cmd.exe",
         timeout: 120000,
       });
 


### PR DESCRIPTION
## Summary
- Replace `bash` shell with `cmd.exe` for invoking `pstswp.exe`, since bash (Git Bash) is not available on all Windows systems
- Remove `toBashPath()` MSYS path conversion; use native Windows paths directly
- Use `cd /d` to handle cross-drive directory changes in cmd.exe

## Test plan
- [x] All 404 tests pass (no regressions)
- [x] Type-check and lint clean
- [ ] Manual verification on Windows with Cadence SPB installed

Closes #42