### PR TITLE
docs(plans): refresh stale file/line references for post-0.1.0 layout

### DIFF
--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -3,6 +3,11 @@
 Living docs for upcoming or in-flight work, plus reference audits. Each
 entry lists status against the codebase as of the last review.
 
+> **Last reviewed: 2026-06-07.** File and line references in the Proposed
+> plans were refreshed for the post-0.1.0 layout (the monolithic
+> `src/service.ts` was split into `src/service/` per-tool modules, and tool
+> descriptions moved to `src/descriptions.ts`).
+
 | Plan | Topic | Status |
 |---|---|---|
 | [cloud-storage-readiness.md](./cloud-storage-readiness.md) | Decouple file I/O from parsers; add `Storage` interface + GCS adapter so `gs://` URIs work alongside local paths | Proposed |

--- a/plans/power-net-stop-pattern.md
+++ b/plans/power-net-stop-pattern.md
@@ -14,9 +14,10 @@ Change the power keyword patterns (VCC, VDD, VIN, VOUT, VBAT, VBUS, VSYS) from a
 
 Keep the other patterns (PP\w*, RAIL_\w+, PWR_\w+, voltage patterns like `+5V`) as-is since they work correctly with anchored matching.
 
-### File: `src/circuit-traversal.ts` (lines 10-15)
+### File: `src/circuit-traversal.ts` (lines 11-15)
 
-Change `POWER_NET_PATTERN` from:
+`POWER_NET_PATTERN` is defined at lines 12-13 and `STOP_NET_PATTERN` at
+lines 14-15. Change `POWER_NET_PATTERN` from:
 ```
 /^(VCC\w*|VDD\w*|VIN\w*|VOUT\w*|VBAT\w*|VBUS\w*|VSYS\w*|PWR_\w+|RAIL_\w+|PP\w*|PN\w*|LD_PP\w*|LD_PN\w*|[+-]?\d+V\d*\w*|[+-].+)$/i
 ```
@@ -40,9 +41,12 @@ Add tests for:
 - `isStopNet('CC1310_VDD')` returns true
 - Signal nets like `CC1310_TXD`, `USB_DP`, `DIO4_SCL` are NOT matched
 
-### File: `src/server.ts` (lines 271, 295)
+### File: `src/descriptions.ts` (lines 103, 107)
 
-Update tool descriptions for `query_xnet_by_net_name` and `query_xnet_by_pin_name` to mention that traversal stops at power nets too, not just ground.
+Update the `QUERY_XNET_BY_NET_NAME_DESCRIPTION` (line 103) and
+`QUERY_XNET_BY_PIN_NAME_DESCRIPTION` (line 107) constants to mention that
+traversal stops at power nets too, not just ground. (Tool descriptions were
+moved out of `src/server.ts` into `src/descriptions.ts` in v0.1.0.)
 
 ## Verification
 

--- a/plans/relative_path.md
+++ b/plans/relative_path.md
@@ -22,6 +22,22 @@ Found files:
   /Users/valentino/Developer/project-b/rev1/board.PrjPcb → id: "project-b/rev1/board"
   /Users/valentino/Developer/project-b/rev2/board.PrjPcb → id: "project-b/rev2/board"
 This ensures every design has a unique identifier.
+
+Implementation note (current layout, post-0.1.0)
+The pseudocode below predates the `service.ts` -> `src/service/` split and
+uses `.js` sketches. Map it onto the current structure when implementing:
+- The registry belongs in a new module (e.g. `src/service/registry.ts`),
+  not a root `registry.js`.
+- Path normalization already exists in `src/paths.ts` (`resolvePath`); reuse
+  it rather than re-resolving paths ad hoc.
+- The per-tool entrypoints live under `src/service/tools/*.ts` (e.g.
+  `query-component.ts`, `list-nets.ts`); add the `getDesignPath(id)` lookup
+  at the top of each. Design-name derivation is centralized in `src/paths.ts`
+  (`getDesignName`).
+- `computeDesignId`'s extension strip should match the formats we actually
+  support today (`.PrjPcb`, `.SchDoc`, `.dsn`, `.dat`). `.cpm` and
+  `.kicad_pro` from the original sketch are not currently parsed.
+
 Implementation Tasks
 Task 1: Add Design Registry
 Create an in-memory registry that maps design IDs to their full paths:

--- a/plans/run_erc.md
+++ b/plans/run_erc.md
@@ -65,7 +65,11 @@ Implementation Steps
 1. Server Wiring
    - Register `run_erc` in `src/server.ts` with v1 input schema.
 2. Service Entrypoint
-   - Add `runErc(...)` in `src/service.ts`.
+   - Add `runErc(...)` as a new `src/service/tools/run-erc.ts` module and
+     export it from `src/service/index.ts`. (The monolithic `src/service.ts`
+     was split into `src/service/` per-tool modules in v0.1.0.)
+   - Register the tool description constant in `src/descriptions.ts` and wire
+     it into the schema in `src/server.ts`, following the existing tool pattern.
 3. ERC Engine Skeleton
    - Build shared scan context from parsed netlist.
    - Add rule runner framework (filtering via include/exclude lists).

--- a/plans/xnet-depth-limit.md
+++ b/plans/xnet-depth-limit.md
@@ -30,11 +30,11 @@ Note: `max_depth_reached === max_depth` does NOT imply truncation. The traversal
 
 ### File 1: `src/circuit-traversal.ts`
 
-**`TraversalOptions`** (line 181-184): Add `maxDepth?: number` field.
+**`TraversalOptions`** (line 170): Add `maxDepth?: number` field.
 
-**`TraversalResult`** (line 175-179): Add `max_depth_reached: number` and `frontier_nets: Array<{ net: string; depth: number }>`.
+**`TraversalResult`** (line 164): Add `max_depth_reached: number` and `frontier_nets: Array<{ net: string; depth: number }>`.
 
-**`traverseCircuitFromNet`** (line 269-413):
+**`traverseCircuitFromNet`** (line 258):
 
 1. Read `maxDepth` from options, default to `5`.
 2. Change BFS queue from `string[]` to `Array<{ net: string; depth: number }>`. Seed with `{ net: startNet, depth: 0 }`.
@@ -46,20 +46,20 @@ Note: `max_depth_reached === max_depth` does NOT imply truncation. The traversal
 
 ### File 2: `src/types.ts`
 
-**`AggregatedCircuitResult`** (line 144-153): Add:
+**`AggregatedCircuitResult`** (line 144): Add:
 - `max_depth: number`
 - `max_depth_reached: number`
 - `frontier_nets?: Array<{ net: string; depth: number }>` (omit when empty)
 
-### File 3: `src/service.ts`
+### File 3: `src/service/tools/query-xnet.ts`
 
-**`queryXnetByNetName`** (line 745-793): Add `maxDepth: number` parameter. Pass to `traverseCircuitFromNet` via options. Forward `max_depth_reached`, `frontier_nets`, `max_depth` into the `AggregatedCircuitResult`.
+**`queryXnetByNetName`** (line 25): Add `maxDepth: number` parameter. Pass to `traverseCircuitFromNet` via options. Forward `max_depth_reached`, `frontier_nets`, `max_depth` into the `AggregatedCircuitResult`.
 
-**`queryXnetByPinName`** (line 803-889): Same changes.
+**`queryXnetByPinName`** (line 83): Same changes.
 
 ### File 4: `src/server.ts`
 
-**Both tool schemas** (lines 265-290 and 292-314): Add input parameter:
+**Both tool schemas** (`query_xnet_by_net_name` at lines 228-249 and `query_xnet_by_pin_name` at lines 254-272): Add input parameter:
 ```
 max_depth: z.number().int().min(0).optional()
   .describe("Max series-passive hops to traverse (0 = direct connections only, default 5)")
@@ -67,7 +67,11 @@ max_depth: z.number().int().min(0).optional()
 
 Pass `max_depth` through to the service function calls.
 
-Update tool descriptions to mention depth limiting and the response metadata (`max_depth_reached`, `frontier_nets`).
+Update the tool descriptions in `src/descriptions.ts`
+(`QUERY_XNET_BY_NET_NAME_DESCRIPTION` line 103, `QUERY_XNET_BY_PIN_NAME_DESCRIPTION`
+line 107) to mention depth limiting and the response metadata
+(`max_depth_reached`, `frontier_nets`). (Descriptions were moved out of
+`src/server.ts` into `src/descriptions.ts` in v0.1.0.)
 
 ### File 5: `src/circuit-traversal.test.ts`
 


### PR DESCRIPTION
## Summary

Several `plans/` docs were written before the v0.1.0 refactor that split the monolithic `src/service.ts` into `src/service/` per-tool modules and moved tool descriptions into `src/descriptions.ts`. Their file paths and line numbers had drifted, making them not directly implementable. This refreshes the references so the plans are actionable again. **Docs only — no code changes.**

## Changes

- **`xnet-depth-limit.md`** — `src/service.ts` → `src/service/tools/query-xnet.ts`; refreshed `circuit-traversal.ts` line refs (`TraversalOptions` 170, `TraversalResult` 164, `traverseCircuitFromNet` 258); refreshed `server.ts` schema line refs; pointed the description edits at `src/descriptions.ts`.
- **`run_erc.md`** — `runErc(...)` now lands in a new `src/service/tools/run-erc.ts` exported from `src/service/index.ts`, with description in `src/descriptions.ts`.
- **`power-net-stop-pattern.md`** — refreshed `circuit-traversal.ts` line refs (11–15); tool-description edits moved from `src/server.ts` to `src/descriptions.ts`.
- **`relative_path.md`** — added a "current layout" implementation note mapping the pre-split pseudocode onto `src/service/registry.ts` / `src/service/tools/*.ts` / `src/paths.ts`, and corrected the supported-extension list.
- **`INDEX.md`** — added a "Last reviewed 2026-06-07" note describing the layout shift.

## Context

Part of a codebase audit. The underlying plans remain **Proposed** (unimplemented) — this only fixes their references so they can be picked up. Verified against the current tree that the new line numbers are accurate.

https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED)_