### PR TITLE
refactor(cli): extract duplicated getCurrentExecutablePath helper

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -21,6 +21,7 @@ import { analyzeCoverage, formatCoverageReport, type CoverageResult } from "../c
 import { checkForUpdate, performUpdate, isNpmInstall } from "./updater.js";
 import { confirm } from "./prompts.js";
 import { removeFromPath } from "./shell.js";
+import { getCurrentExecutablePath } from "./executable.js";
 
 /**
  * Print version information.
@@ -120,16 +121,6 @@ export const handleUpdateCommand = async (): Promise<void> => {
 
   console.log(`Updated from ${result.previousVersion} to ${result.newVersion}`);
   console.log("Please restart to use the new version.");
-};
-
-/**
- * Get the path to the current executable.
- */
-const getCurrentExecutablePath = (): string => {
-  if (process.execPath.includes("node") || process.execPath.includes("bun")) {
-    return process.argv[1];
-  }
-  return process.execPath;
 };
 
 /**

--- a/src/cli/executable.ts
+++ b/src/cli/executable.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared helpers for locating the running CLI executable.
+ */
+
+/**
+ * Get the path to the current executable.
+ *
+ * For Bun-compiled binaries, `process.execPath` points to the binary itself.
+ * For Node.js, `process.argv[1]` is the script path.
+ */
+export const getCurrentExecutablePath = (): string => {
+  if (process.execPath.includes("node") || process.execPath.includes("bun")) {
+    // Running via node/bun interpreter - use argv[1]
+    return process.argv[1];
+  }
+  // Compiled binary - use execPath
+  return process.execPath;
+};

--- a/src/cli/updater.ts
+++ b/src/cli/updater.ts
@@ -17,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "../version.js";
+import { getCurrentExecutablePath } from "./executable.js";
 
 /** GitHub release information. */
 interface GitHubRelease {
@@ -196,20 +197,6 @@ const downloadFile = async (url: string, destPath: string): Promise<void> => {
 
     pump().catch(reject);
   });
-};
-
-/**
- * Get the path to the current executable.
- */
-const getCurrentExecutablePath = (): string => {
-  // For Bun-compiled binaries, process.execPath points to the binary itself
-  // For Node.js, process.argv[1] is the script path
-  if (process.execPath.includes("node") || process.execPath.includes("bun")) {
-    // Running via node/bun interpreter - use argv[1]
-    return process.argv[1];
-  }
-  // Compiled binary - use execPath
-  return process.execPath;
 };
 
 /**


### PR DESCRIPTION
## Summary

`getCurrentExecutablePath()` was copy-pasted **verbatim** in two CLI files:
- `src/cli/commands.ts:128`
- `src/cli/updater.ts:204`

This extracts it into a shared `src/cli/executable.ts` and imports it in both. No behavior change — the body is identical to the originals (which were byte-for-byte the same logic).

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm test` ✅ (404/404)

## Context

Found during a codebase audit. Low-risk dedupe; the two copies were a refactoring hazard (fixing a bug in one would miss the other).

https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED)_