### PR TITLE
refactor(service): extract getDesignName helper

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -27,3 +27,12 @@ export const resolvePath = (inputPath: string): string => {
   // On Unix, convert backslashes to forward slashes before normalizing
   return path.resolve(path.normalize(inputPath.replace(/\\/g, "/")));
 };
+
+/**
+ * Derive a human-readable design name from a design path by stripping the
+ * directory and file extension.
+ *
+ * Example: "/projects/board-rev-c/top.dsn" -> "top"
+ */
+export const getDesignName = (design: string): string =>
+  path.basename(design, path.extname(design));

--- a/src/service/tools/list-components.ts
+++ b/src/service/tools/list-components.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { groupComponentsByMpn } from "../component-grouping.js";
 import { matchesRefdesType, getRefdesPrefix, isValidRefdes } from "../../circuit-traversal.js";
@@ -35,7 +35,7 @@ export const listComponents = async (
       new Set(Object.keys(netlist.components).filter(isValidRefdes).map(getRefdesPrefix))
     ).sort((a, b) => a.localeCompare(b));
 
-    const designName = path.basename(design, path.extname(design));
+    const designName = getDesignName(design);
     return {
       error: `No components with prefix '${prefix}' found in design '${designName}'. Available prefixes: [${availablePrefixes.join(", ")}]`,
     };

--- a/src/service/tools/query-component.ts
+++ b/src/service/tools/query-component.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { MPN_MISSING_NOTE } from "../component-grouping.js";
 import { isErrorResult, type QueryComponentResult, type ErrorResult } from "../../types.js";
@@ -24,7 +24,7 @@ export const queryComponent = async (
   );
 
   if (!componentEntry) {
-    const designName = path.basename(design, path.extname(design));
+    const designName = getDesignName(design);
     return {
       error: `Component '${refdes}' not found in design '${designName}'. Use list_components() or search_components_by_refdes() to find available components.`,
     };

--- a/src/service/tools/query-xnet.ts
+++ b/src/service/tools/query-xnet.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { aggregateCircuitByMpn } from "../component-grouping.js";
 import {
@@ -36,7 +36,7 @@ export const queryXnetByNetName = async (
   const { nets, components } = netlist;
 
   if (!nets[netName]) {
-    const designName = path.basename(design, path.extname(design));
+    const designName = getDesignName(design);
     return {
       error: `Net '${netName}' not found in design '${designName}'. Use search_nets() to find available nets.`,
     };
@@ -104,7 +104,7 @@ export const queryXnetByPinName = async (
   );
 
   if (!refdesEntry) {
-    const designName = path.basename(design, path.extname(design));
+    const designName = getDesignName(design);
     return {
       error: `Component '${refdesInput}' not found in design '${designName}'. Use list_components() or search_components_by_refdes() to find available components.`,
     };

--- a/src/service/tools/search-components.ts
+++ b/src/service/tools/search-components.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { groupComponentsByMpn } from "../component-grouping.js";
 import { parseRegexPattern, tooManyMatchesError } from "../regex-helpers.js";
@@ -25,7 +25,7 @@ export const searchComponentsByRefdes = async (
     return netlist;
   }
 
-  const designName = path.basename(design, path.extname(design));
+  const designName = getDesignName(design);
   const allEntries = Object.entries(netlist.components);
   const entries = allEntries.filter(([refdes]) => regex.test(refdes));
 
@@ -66,7 +66,7 @@ export const searchComponentsByMpn = async (
     return netlist;
   }
 
-  const designName = path.basename(design, path.extname(design));
+  const designName = getDesignName(design);
   const allComponents = Object.entries(netlist.components);
   const componentsWithMpn = allComponents.filter(([, c]) => c.mpn?.trim());
   const entries = componentsWithMpn.filter(([, component]) => regex.test(component.mpn!));
@@ -119,7 +119,7 @@ export const searchComponentsByDescription = async (
     return netlist;
   }
 
-  const designName = path.basename(design, path.extname(design));
+  const designName = getDesignName(design);
   const allComponents = Object.entries(netlist.components);
   const componentsWithDescription = allComponents.filter(([, c]) => c.description?.trim());
   const entries = componentsWithDescription.filter(([, component]) =>

--- a/src/service/tools/search-nets.ts
+++ b/src/service/tools/search-nets.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { parseRegexPattern, tooManyMatchesError } from "../regex-helpers.js";
 import { isErrorResult, type SearchNetsResult, type ErrorResult } from "../../types.js";
@@ -22,7 +22,7 @@ export const searchNets = async (
     return netlist;
   }
 
-  const designName = path.basename(design, path.extname(design));
+  const designName = getDesignName(design);
   const allNets = Object.keys(netlist.nets);
   const nets = allNets.filter((net) => regex.test(net));
 


### PR DESCRIPTION
## Summary

`path.basename(design, path.extname(design))` was duplicated across 5 service tool files (8 call sites). Add a `getDesignName()` helper to `src/paths.ts` and use it everywhere, dropping the now-unused `path` imports.

Touched files:
- `src/paths.ts` — new `getDesignName(design)` helper
- `src/service/tools/query-component.ts`
- `src/service/tools/list-components.ts`
- `src/service/tools/query-xnet.ts` (2 sites)
- `src/service/tools/search-nets.ts`
- `src/service/tools/search-components.ts` (3 sites)

`cadence-export.ts` keeps its `path` import (uses `path.join`/`dirname` for real path work — out of scope).

## Scope note

Per request, the **three search functions in `search-components.ts` were left structurally intact** — only the design-name expression was swapped, no collapsing/merging of those functions.

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm test` ✅ (404/404)

## Context

Found during a codebase audit. No behavior change.

https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGUEJTmg3MJDiCSZqzL5ED)_