### PR TITLE
Document OpenTelemetry integration under docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ codex mcp add universal-netlist -- universal-netlist
 
 ## Observability (OpenTelemetry)
 
-The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can integrate your own Otel service and see which tools are used, how long they take, and what fails. It is vendor-neutral and works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can integrate your own OTel service and see which tools are used, how long they take, and what fails. It is vendor-neutral and works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
 
 Telemetry is **disabled by default** with zero overhead, and is enabled and configured entirely through the standard `OTEL_*` environment variables — no code changes.
 

--- a/README.md
+++ b/README.md
@@ -115,47 +115,11 @@ codex mcp add universal-netlist -- universal-netlist
 
 ## Observability (OpenTelemetry)
 
-The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral: it works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can integrate your own Otel service and see which tools are used, how long they take, and what fails. It is vendor-neutral and works with any OTLP-compatible backend (an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, a managed cloud tracing service, etc.).
 
-**Disabled by default.** Telemetry is a no-op with zero overhead unless you set an OTLP endpoint. Turn it on purely with the standard `OTEL_*` environment variables; no code changes and no bespoke config.
+Telemetry is **disabled by default** with zero overhead, and is enabled and configured entirely through the standard `OTEL_*` environment variables — no code changes.
 
-Each tool call emits:
-
-- a span `tool/<tool_name>` with `tool.name`, `tool.outcome` (`success`/`error`), `tool.duration_ms`, and `error.type` on failure;
-- metrics `tool.calls` (counter), `tool.duration` (ms histogram), and `tool.errors` (counter), labeled by `tool` and `outcome`;
-- a structured log record carrying the active trace/span IDs for trace-to-log correlation.
-
-All telemetry is tagged with `enduser.id`, the host OS account name of whoever is running the server, as a resource attribute (so it appears on traces, metrics, and logs). This attributes usage to the per-session user without any configuration.
-
-### Quick start with a local Collector / Jaeger
-
-Run an all-in-one Jaeger (which accepts OTLP and renders traces) and point the server at it:
-
-```bash
-docker run --rm -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
-
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-export OTEL_SERVICE_NAME=universal-netlist
-# then start the MCP server as usual; open http://localhost:16686 to view traces
-```
-
-### Configuration
-
-Only standard OpenTelemetry environment variables are used:
-
-| Variable | Purpose |
-|----------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint to export to. **Setting this enables telemetry.** |
-| `OTEL_EXPORTER_OTLP_HEADERS` | Headers for the exporter, e.g. `Authorization=Bearer <token>` for a managed backend. |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is not bundled in the standalone binaries and falls back to `http/protobuf`. |
-| `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` | Resource identity. |
-| `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, ... | Standard OTel SDK knobs. |
-
-Additional, clearly-scoped options:
-
-- `OTEL_CAPTURE_TOOL_ARGS=1`: also record raw tool arguments on the span (off by default; arguments may be sensitive).
-
-Telemetry never affects tool results: exporter failures, misconfiguration, or an unreachable backend degrade to "no telemetry", and pending data is flushed on shutdown.
+See **[docs/observability.md](docs/observability.md)** for setup, configuration, and the full list of emitted spans, metrics, and logs.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics
 
 Telemetry is **disabled by default** with zero overhead, and is enabled and configured entirely through the standard `OTEL_*` environment variables — no code changes.
 
-See **[docs/observability.md](docs/observability.md)** for setup, configuration, and the full list of emitted spans, metrics, and logs.
+See **[Observability (OpenTelemetry)](docs/observability.md)** for setup, configuration, and the full list of emitted spans, metrics, and logs.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,10 @@ The schema captures identification (MPN, description) but not electrical specifi
 
 To get the most out of this MCP, follow the recommended [Net Naming Conventions](net-naming-conventions.md) when naming nets and marking DNS components in your schematics. Net names drive power/ground detection, circuit traversal stop behavior, and `search_nets` pattern matching.
 
+## Observability
+
+The server can emit OpenTelemetry traces, metrics, and logs for every tool call, so you can integrate your own Otel service. It is disabled by default and configured entirely through standard `OTEL_*` environment variables. See [Observability (OpenTelemetry)](observability.md) for setup and the full list of emitted spans, metrics, and logs.
+
 ## Example Queries
 
 Once configured, you can ask your AI assistant questions like:

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ To get the most out of this MCP, follow the recommended [Net Naming Conventions]
 
 ## Observability
 
-The server can emit OpenTelemetry traces, metrics, and logs for every tool call, so you can integrate your own Otel service. It is disabled by default and configured entirely through standard `OTEL_*` environment variables. See [Observability (OpenTelemetry)](observability.md) for setup and the full list of emitted spans, metrics, and logs.
+The server can emit OpenTelemetry traces, metrics, and logs for every tool call, so you can integrate your own OTel service. It is disabled by default and configured entirely through standard `OTEL_*` environment variables. See [Observability (OpenTelemetry)](observability.md) for setup and the full list of emitted spans, metrics, and logs.
 
 ## Example Queries
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,146 @@
+# Observability (OpenTelemetry)
+
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, so it works with any OTLP-compatible backend — an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, or a managed cloud tracing service — letting you integrate your own Otel service without any code changes.
+
+## Overview
+
+- **Disabled by default.** Telemetry is a no-op with zero overhead unless you point it at an OTLP endpoint. The OpenTelemetry SDK is not even imported until it is configured.
+- **Configured purely through standard `OTEL_*` environment variables.** No bespoke config and no code changes.
+- **Never affects tool results.** Every span, metric, and log operation is wrapped so that an exporter fault, misconfiguration, or unreachable backend degrades to "no telemetry" rather than an error. Pending data is flushed on shutdown.
+- **stdio-safe.** The MCP stdio transport owns stdout, so all diagnostics are written to stderr only; no console/stdout exporter is ever used.
+
+## Enabling and disabling
+
+Telemetry turns on as soon as you set an OTLP endpoint — either the general endpoint or any per-signal endpoint:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
+
+Setting `OTEL_SDK_DISABLED=1` (or `true`) forces telemetry off even when an endpoint is present. With no endpoint configured, telemetry stays off.
+
+## Quick start with a local Collector / Jaeger
+
+Run an all-in-one Jaeger (which accepts OTLP and renders traces) and point the server at it:
+
+```bash
+docker run --rm -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
+
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_SERVICE_NAME=universal-netlist
+# then start the MCP server as usual; open http://localhost:16686 to view traces
+```
+
+## Plug in your own Otel service
+
+To export to your own backend or a managed provider:
+
+1. **Point at your endpoint:**
+
+   ```bash
+   export OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.your-backend.example
+   ```
+
+2. **Add authentication** if your backend requires it, via headers:
+
+   ```bash
+   export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>"
+   ```
+
+3. **Optionally set the service name** (otherwise it defaults to `universal-netlist`):
+
+   ```bash
+   export OTEL_SERVICE_NAME=my-netlist-server
+   ```
+
+4. **Start the MCP server as usual.** Instrumentation is automatic — every tool call emits a span, metrics, and a log record.
+
+The default wire protocol is `http/protobuf`. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` if your backend prefers JSON. `grpc` is **not** bundled in the standalone binaries and falls back to `http/protobuf` with a warning.
+
+## Configuration reference
+
+Only standard OpenTelemetry environment variables are used.
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint to export to. **Setting this (or any per-signal endpoint) enables telemetry.** |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal endpoint override for traces. |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Per-signal endpoint override for metrics. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Per-signal endpoint override for logs. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers for the exporter, e.g. `Authorization=Bearer <token>` for a managed backend. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (default) or `http/json`. `grpc` is not bundled in the standalone binaries and falls back to `http/protobuf`. |
+| `OTEL_SERVICE_NAME` | Service name on the resource. Defaults to `universal-netlist`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Additional resource identity attributes. |
+| `OTEL_SDK_DISABLED` | Set to `1`/`true` to force telemetry off. |
+| `OTEL_TRACES_SAMPLER` | Standard trace sampler configuration. |
+| `OTEL_BSP_SCHEDULE_DELAY` | Batch span processor export interval (ms). |
+| `OTEL_BLRP_SCHEDULE_DELAY` | Batch log record processor export interval (ms). |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval (ms). Default `60000`. |
+
+One additional, clearly-scoped option is specific to this server:
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments on the span as `tool.args`. Off by default, since arguments may be sensitive. |
+
+## What gets emitted
+
+Each tool call produces a span, three metric updates, and one log record.
+
+### Spans
+
+One span per call, named `tool/<tool_name>`.
+
+| Attribute | Description |
+|-----------|-------------|
+| `tool.name` | The tool that was invoked. |
+| `tool.outcome` | `success` or `error`. |
+| `tool.duration_ms` | Wall-clock duration of the call in milliseconds. |
+| `error.type` | Present on failure; the error class name (or `tool_error` for an error result). |
+| `tool.args` | Full tool arguments as JSON. Only present when `OTEL_CAPTURE_TOOL_ARGS` is enabled. |
+
+The span status is set to `ERROR` on failure and `OK` otherwise; exceptions are recorded on the span.
+
+### Metrics
+
+| Instrument | Type | Unit | Labels |
+|------------|------|------|--------|
+| `tool.calls` | Counter | — | `tool`, `outcome` |
+| `tool.duration` | Histogram | ms | `tool`, `outcome` |
+| `tool.errors` | Counter | — | `tool`, `error_type` |
+
+### Logs
+
+One structured log record per call, with body `tool/<tool_name> <outcome>` and severity `INFO` on success or `ERROR` on failure. Each record carries:
+
+| Attribute | Description |
+|-----------|-------------|
+| `tool.name` | The tool that was invoked. |
+| `tool.outcome` | `success` or `error`. |
+| `tool.duration_ms` | Duration in milliseconds. |
+| `error.type` | Present on failure. |
+| `trace_id`, `span_id` | The active trace/span IDs, for trace-to-log correlation. |
+
+### Resource attributes
+
+All telemetry — traces, metrics, and logs alike — is tagged with:
+
+| Attribute | Description |
+|-----------|-------------|
+| `service.name` | `OTEL_SERVICE_NAME` if set, otherwise `universal-netlist`. |
+| `service.version` | The server version. |
+| `enduser.id` | The host OS account name of whoever is running the server, attributing usage to the per-session user. Best-effort; omitted if it can't be read. |
+
+## Reliability
+
+Telemetry is designed to be invisible to callers:
+
+- Instrumentation never alters a tool's result and never throws on its own; a failing exporter or SDK degrades to "no telemetry".
+- When unconfigured, the instrumentation path is a pure pass-through with zero overhead, and the SDK is never imported.
+- Pending, batched exports are flushed on process shutdown (including on `SIGINT`/`SIGTERM`), so short-lived invocations don't lose data.
+
+## See Also
+
+- [Tool Documentation](tools/) — the tools that generate this telemetry
+- [API Documentation](README.md) — overview and response schemas

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,7 +4,7 @@ The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics
 
 ## Overview
 
-- **Disabled by default.** Telemetry is a no-op with zero overhead unless you point it at an OTLP endpoint. The OpenTelemetry SDK is not even imported until it is configured.
+- **Disabled by default.** Telemetry is a no-op with zero overhead unless you point it at an OTLP endpoint. The heavy SDK packages are not imported until telemetry is configured; only the lightweight OpenTelemetry API stubs are always present, and they are no-ops when telemetry is off.
 - **Configured purely through standard `OTEL_*` environment variables.** No bespoke config and no code changes.
 - **Never affects tool results.** Every span, metric, and log operation is wrapped so that an exporter fault, misconfiguration, or unreachable backend degrades to "no telemetry" rather than an error. Pending data is flushed on shutdown.
 - **stdio-safe.** The MCP stdio transport owns stdout, so all diagnostics are written to stderr only; no console/stdout exporter is ever used.
@@ -131,6 +131,8 @@ All telemetry — traces, metrics, and logs alike — is tagged with:
 | `service.name` | `OTEL_SERVICE_NAME` if set, otherwise `universal-netlist`. |
 | `service.version` | The server version. |
 | `enduser.id` | The host OS account name of whoever is running the server, attributing usage to the per-session user. Best-effort; omitted if it can't be read. |
+
+> **Privacy note:** `enduser.id` is your host OS account name and is emitted unconditionally whenever telemetry is enabled, including to any third-party or managed backend you export to. If that is undesirable, leave telemetry disabled (the default).
 
 ## Reliability
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,6 @@
 # Observability (OpenTelemetry)
 
-The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, so it works with any OTLP-compatible backend — an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, or a managed cloud tracing service — letting you integrate your own Otel service without any code changes.
+The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics, and logs** for every tool call, so you can see which tools are used, how long they take, and what fails. It is vendor-neutral and speaks OTLP, so it works with any OTLP-compatible backend — an OpenTelemetry Collector, Jaeger, Tempo, Prometheus, Honeycomb, Datadog, or a managed cloud tracing service — letting you integrate your own OTel service without any code changes.
 
 ## Overview
 
@@ -32,7 +32,7 @@ export OTEL_SERVICE_NAME=universal-netlist
 # then start the MCP server as usual; open http://localhost:16686 to view traces
 ```
 
-## Plug in your own Otel service
+## Plug in your own OTel service
 
 To export to your own backend or a managed provider:
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -76,7 +76,7 @@ Only standard OpenTelemetry environment variables are used.
 | `OTEL_TRACES_SAMPLER` | Standard trace sampler configuration. |
 | `OTEL_BSP_SCHEDULE_DELAY` | Batch span processor export interval (ms). |
 | `OTEL_BLRP_SCHEDULE_DELAY` | Batch log record processor export interval (ms). |
-| `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval (ms). Default `60000`. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Metric export interval (ms). Default `60000`. Also drives the periodic metric flush used by the compiled Bun binaries, where the SDK's own timer doesn't fire. |
 
 One additional, clearly-scoped option is specific to this server:
 
@@ -132,7 +132,7 @@ All telemetry — traces, metrics, and logs alike — is tagged with:
 | `service.version` | The server version. |
 | `enduser.id` | The host OS account name of whoever is running the server, attributing usage to the per-session user. Best-effort; omitted if it can't be read. |
 
-> **Privacy note:** `enduser.id` is your host OS account name and is emitted unconditionally whenever telemetry is enabled, including to any third-party or managed backend you export to. If that is undesirable, leave telemetry disabled (the default).
+> **Privacy note:** `enduser.id` is your host OS account name. Whenever telemetry is enabled it is included in exported telemetry by default (best-effort — see above), including to any third-party or managed backend you export to. If that is undesirable, leave telemetry disabled (the default).
 
 ## Reliability
 


### PR DESCRIPTION
## Summary

The server already exposes a complete, vendor-neutral OpenTelemetry integration (`src/telemetry/otel.ts`), but it was only documented in the root `README.md` — the `docs/` developer reference had no mention of it, so a developer reading `docs/` wouldn't know they can integrate their own Otel service.

This PR makes the OTel API discoverable in `docs/`:

- **New `docs/observability.md`** — a standalone reference covering enabling/disabling, a "plug in your own Otel service" walkthrough, a local Jaeger/Collector quickstart, the full `OTEL_*` configuration table, and every span / metric / log / resource attribute emitted per tool call. All facts grounded in `src/telemetry/otel.ts`.
- **`docs/README.md`** — adds an Observability section linking to the new page.
- **Root `README.md`** — slims the Observability section to a short summary that defers to `docs/observability.md`, keeping a single source of truth so the two copies don't drift.

Documentation only — no code changes to `src/telemetry/*`.

## Verification

- `npm run type-check` and `npm run lint` pass.
- All env var and attribute names cross-checked against `src/telemetry/otel.ts`.
- Relative markdown links verified (`docs/README.md` → `observability.md`, root `README.md` → `docs/observability.md`, `observability.md` → `tools/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxrU7bifhBtbfhHsWsT9gY)_