### PR TITLE
fix: harden XNET ground detection and list_components prefixes (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-23
+
+### Fixed
+
+- The XNET tools (`query_xnet_by_net_name`, `query_xnet_by_pin_name`) now recognize suffixed and hierarchical ground nets. The ground guard previously matched a hardcoded exact list (`GND`, `VSS`, `AGND`, `DGND`, `PGND`, `SGND`, `CGND`), so KiCad's own default global ground `GNDREF` (and `GNDD`, `GNDS`, `GNDPWR`, …) plus sheet-path-prefixed grounds like `/GND` slipped through and the trace flooded the entire ground tree, overflowing the output token limit. Ground tokens now allow a trailing suffix and the sheet-path prefix is stripped before classification, so these nets are correctly rejected; a suffix-only signal-ground such as `SIG_GND` is still treated as a signal
+- `list_components` now reports the correct `Available prefixes` on designs with unannotated components. Refdes still carrying KiCad's `?` placeholder (e.g. `C?`, `D?`, `PS?`) were dropped from the suggestion list, so a query for an absent prefix on an otherwise-populated design wrongly reported `Available prefixes: []`. The list is now derived with the same prefix logic the matcher uses, so every suggested prefix resolves to real components
+
 ## [1.1.0] - 2026-06-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -12,7 +12,7 @@ entry lists status against the codebase as of the last review.
 |---|---|---|
 | [cloud-storage-readiness.md](./cloud-storage-readiness.md) | Decouple file I/O from parsers; add `Storage` interface + GCS adapter so `gs://` URIs work alongside local paths | Proposed |
 | [run_erc.md](./run_erc.md) | New `run_erc` MCP tool for net-level electrical rule checks (single_pin, testpoint_only, unnamed, testpoint_stub) | Proposed |
-| [xnet-depth-limit.md](./xnet-depth-limit.md) | Add `max_depth` parameter to `query_xnet_*` tools, plus `max_depth_reached` and `frontier_nets` response metadata | Proposed |
+| [xnet-depth-limit.md](./xnet-depth-limit.md) | Bound XNET output two ways: (A) `max_depth` parameter + `frontier_nets`/`max_depth_reached` metadata, and (B) automatic byte-budget output-size cap with graceful truncation. Both evaluated; recommend both | Proposed |
 | [power-net-stop-pattern.md](./power-net-stop-pattern.md) | Switch `POWER_NET_PATTERN` / `STOP_NET_PATTERN` keywords (VCC/VDD/VBAT/VBUS/VSYS) from anchored prefix to substring matching so prefixed rails like `CC1310_VDD` stop traversal | Proposed |
 | [relative_path.md](./relative_path.md) | Auto-discovery + ID-based design access: `list_designs` returns relative-path IDs that all other tools accept instead of absolute paths | Proposed |
 | [parser-quality-improvements.md](./parser-quality-improvements.md) | 10 quality gaps from the June 2026 full-fixture MCP stress test: solder-bridge traversal, Altium DNP detection, pstxnet design-name keying, DSN group value collapse, CP1251 decoding, hidden power pins, NC pseudo-net, error polish | Proposed |

--- a/plans/xnet-depth-limit.md
+++ b/plans/xnet-depth-limit.md
@@ -1,103 +1,197 @@
-# Xnet Depth Limit
+# Bounding XNET Output (depth limit + output-size cap)
 
 ## Context
 
-The xnet traversal (`traverseCircuitFromNet`) uses BFS with no depth bound. It terminates only when it hits stop nets (power/ground), skip_types, DNS filtering, or exhaustion. On designs with broad power rails that don't match the stop-net regex (e.g., `CC1310_VDD`, `USB_VBUS`), the traversal can fan out excessively.
+The xnet traversal (`traverseCircuitFromNet`) uses BFS with no bound on the
+result. It terminates only when it hits stop nets (power/ground), `skip_types`,
+DNS filtering, or exhaustion. That leaves the output unbounded along **two
+independent axes**, and either can overflow the MCP's max output token limit:
 
-Instead of expanding the stop-net regex (fragile, false-positive-prone), add a `max_depth` parameter that caps the number of series-passive hops. This gives the calling agent deterministic control over traversal scope.
+- **Depth (hops outward through series passives).** On designs with broad power
+  rails that don't match the stop-net regex (e.g. `CC1310_VDD`, `USB_VBUS`), the
+  traversal fans out hop after hop.
+- **Breadth (components on a single net).** A net with hundreds of *directly*
+  connected pins floods the result at depth 0–1. The June 2026 stress test hit
+  this: `query_xnet_by_net_name` on `VCC` (369 components, ~95 KB) and on
+  unrecognized ground rails (e.g. `GNDREF`, 238 components, ~90 KB) both exceeded
+  the token limit and errored out.
 
-## Depth Semantics
+> The *ground-name guard gap* that let `GNDREF`/`/GND` reach traversal at all was
+> fixed separately (v1.1.1: `GND\w*` + sheet-path stripping in
+> `src/circuit-traversal.ts`). That stops the **ground** floods, but a
+> legitimately huge **non-ground** net (a real power rail, a wide bus) still
+> overflows. So output bounding is still needed independent of net
+> classification.
+
+Two complementary mechanisms are proposed below. They address different axes and
+should both land; this doc records both so the trade-off is explicit.
+
+---
+
+## Approach A — `max_depth` parameter (agent-controlled scope)
+
+Add a `max_depth` parameter that caps the number of series-passive hops. This
+gives the calling agent deterministic control over traversal scope, without
+expanding the stop-net regex (fragile, false-positive-prone).
+
+### Depth semantics
 
 Depth = number of series-passive component hops from the starting net.
 
-- `max_depth=0`: No traversal. Return only components directly connected to the starting net.
-- `max_depth=1`: Traverse through one series passive. Shows components on the starting net and the next net segment.
+- `max_depth=0`: No traversal. Return only components directly connected to the
+  starting net.
+- `max_depth=1`: Traverse through one series passive. Shows components on the
+  starting net and the next net segment.
 - `max_depth=5` (default): Up to 5 hops.
 
-Ground nets (GND, AGND, DGND, etc.) are still rejected at the service layer regardless of depth. Power/ground stop-net behavior during traversal still applies within the depth limit.
+Ground nets (GND, AGND, DGND, etc.) are still rejected at the service layer
+regardless of depth. Power/ground stop-net behavior during traversal still
+applies within the depth limit.
 
-## Response Metadata
+### Response metadata
 
 Three fields, no redundancy:
 
-- `max_depth: number` - the configured depth limit (input parameter, default 5)
-- `max_depth_reached: number` - the deepest passive hop actually taken during traversal; always present, purely informational about circuit topology
-- `frontier_nets?: Array<{ net: string; depth: number }>` - nets at the depth boundary that were not traversed further; only present when non-empty; this is the authoritative truncation signal
+- `max_depth: number` — the configured depth limit (input parameter, default 5)
+- `max_depth_reached: number` — the deepest passive hop actually taken during
+  traversal; always present, purely informational about circuit topology
+- `frontier_nets?: Array<{ net: string; depth: number }>` — nets at the depth
+  boundary that were not traversed further; only present when non-empty; this is
+  the authoritative truncation signal
 
-Note: `max_depth_reached === max_depth` does NOT imply truncation. The traversal may naturally end at exactly the limit (e.g., hit an active component or stop net on the last hop). Only a non-empty `frontier_nets` means the depth limit actually cut a branch short.
+Note: `max_depth_reached === max_depth` does NOT imply truncation. The traversal
+may naturally end at exactly the limit (e.g. hit an active component or stop net
+on the last hop). Only a non-empty `frontier_nets` means the depth limit actually
+cut a branch short.
 
-## Implementation
+### Implementation
 
-### File 1: `src/circuit-traversal.ts`
+**File 1: `src/circuit-traversal.ts`**
 
-**`TraversalOptions`** (line 170): Add `maxDepth?: number` field.
+- **`TraversalOptions`**: add `maxDepth?: number`.
+- **`TraversalResult`**: add `max_depth_reached: number` and
+  `frontier_nets: Array<{ net: string; depth: number }>`.
+- **`traverseCircuitFromNet`**:
+  1. Read `maxDepth` from options, default `5`.
+  2. Change the BFS queue from `string[]` to
+     `Array<{ net: string; depth: number }>`; seed with `{ net: startNet, depth: 0 }`.
+  3. Track `maxDepthReached`, updated as each net is dequeued.
+  4. When enqueueing an other-side net through a passive, `nextDepth = currentDepth + 1`.
+  5. If `nextDepth > maxDepth`, do NOT enqueue; record `{ net, depth: nextDepth }`
+     in a `frontierNets` collector.
+  6. At `maxDepth=0`: the starting net is processed (its components collected) but
+     no passives are followed; passives on the starting net appear as leaf
+     components.
+  7. Return `max_depth_reached` and `frontier_nets`.
 
-**`TraversalResult`** (line 164): Add `max_depth_reached: number` and `frontier_nets: Array<{ net: string; depth: number }>`.
+**File 2: `src/types.ts`** — `AggregatedCircuitResult`: add `max_depth`,
+`max_depth_reached`, and `frontier_nets?` (omit when empty).
 
-**`traverseCircuitFromNet`** (line 258):
+**File 3: `src/service/tools/query-xnet.ts`** — `queryXnetByNetName` and
+`queryXnetByPinName`: add a `maxDepth` parameter, pass via options, forward the
+new fields into the result.
 
-1. Read `maxDepth` from options, default to `5`.
-2. Change BFS queue from `string[]` to `Array<{ net: string; depth: number }>`. Seed with `{ net: startNet, depth: 0 }`.
-3. Track `maxDepthReached = 0`, updated as each net is dequeued.
-4. When processing a passive and enqueueing the other-side net, compute `nextDepth = currentDepth + 1`.
-5. If `nextDepth > maxDepth`, do NOT enqueue. Instead, record `{ net, depth: nextDepth }` in a `frontierNets` collector.
-6. At `maxDepth=0`: the starting net is processed (all components on it are collected), but no passives are followed through. Passives on the starting net appear in results as leaf components (their other-side pins/nets are visible but not traversed).
-7. Return `max_depth_reached` and `frontier_nets` in the result.
+**File 4: `src/server.ts`** — both tool schemas: add
+`max_depth: z.number().int().min(0).optional().describe("Max series-passive hops to traverse (0 = direct connections only, default 5)")`,
+and pass through. Update the descriptions in `src/descriptions.ts`
+(`QUERY_XNET_BY_NET_NAME_DESCRIPTION`, `QUERY_XNET_BY_PIN_NAME_DESCRIPTION`) to
+mention depth limiting and the response metadata.
 
-### File 2: `src/types.ts`
+**File 5: `src/circuit-traversal.test.ts`** — add to the `traverseCircuitFromNet`
+block: depth-limit behavior (0/1/2/default), `max_depth_reached` (within limit,
+truncated, and 0), `frontier_nets` (populated on truncation, absent on natural
+completion, multiple on fan-out, not populated when a stop net sits at the
+boundary), and interactions with `skip_types` / stop nets / DNS filtering.
 
-**`AggregatedCircuitResult`** (line 144): Add:
-- `max_depth: number`
-- `max_depth_reached: number`
-- `frontier_nets?: Array<{ net: string; depth: number }>` (omit when empty)
+---
 
-### File 3: `src/service/tools/query-xnet.ts`
+## Approach B — automatic output-size cap (hard safety net)
 
-**`queryXnetByNetName`** (line 25): Add `maxDepth: number` parameter. Pass to `traverseCircuitFromNet` via options. Forward `max_depth_reached`, `frontier_nets`, `max_depth` into the `AggregatedCircuitResult`.
+Guarantee that *no* xnet call can exceed the output token limit, regardless of
+classification correctness, depth, or net size. Where Approach A bounds *hops*,
+this bounds the *serialized result*, catching the breadth case (a single net with
+hundreds of directly-connected components) that depth limiting cannot.
 
-**`queryXnetByPinName`** (line 83): Same changes.
+Today the harness backstops an oversized result by spilling it to a file and
+returning an **error** — a poor experience for a calling agent. Approach B makes
+the tool itself return a coherent, bounded, actionable result instead.
 
-### File 4: `src/server.ts`
+### Design — byte-budget-driven graceful degradation
 
-**Both tool schemas** (`query_xnet_by_net_name` at lines 228-249 and `query_xnet_by_pin_name` at lines 254-272): Add input parameter:
-```
-max_depth: z.number().int().min(0).optional()
-  .describe("Max series-passive hops to traverse (0 = direct connections only, default 5)")
-```
+Applied in `src/service/tools/query-xnet.ts` to both xnet tools just before
+returning:
 
-Pass `max_depth` through to the service function calls.
+1. **Run the full traversal** as usual — the counts (`total_components`,
+   `unique_configurations`, `visited_nets`) are cheap and stay accurate.
+2. **Measure** `JSON.stringify(result)` against a budget set safely under the MCP
+   max output (a constant, env-overridable like `KICAD_CLI_PATH` / `OTEL_*`,
+   e.g. `UNIVERSAL_NETLIST_XNET_MAX_BYTES`).
+3. **If over budget, degrade in tiers** — keep the cheap high-value fields, shed
+   the bulky per-pin detail:
+   - *Tier 1:* keep `starting_point`, `total_components`, `unique_configurations`,
+     `visited_nets`, `circuit_hash`; replace the detailed `components_by_mpn`
+     (which carries per-pin `connections`) with a **count-only grouping**
+     (mpn/value/count/refdes, no `connections`) if that fits.
+   - *Tier 2:* if still too big, drop to summary only (counts + `visited_nets`).
+   - Always set `truncated: true` and a `note` with remediation: *"XNET has N
+     components — likely a power/ground rail; narrow with `skip_types`, lower
+     `max_depth`, or query a more specific net/pin."*
+4. **Small nets are untouched** — byte-identical output to today.
 
-Update the tool descriptions in `src/descriptions.ts`
-(`QUERY_XNET_BY_NET_NAME_DESCRIPTION` line 103, `QUERY_XNET_BY_PIN_NAME_DESCRIPTION`
-line 107) to mention depth limiting and the response metadata
-(`max_depth_reached`, `frontier_nets`). (Descriptions were moved out of
-`src/server.ts` into `src/descriptions.ts` in v0.1.0.)
+### Why a byte budget (not a component count)
 
-### File 5: `src/circuit-traversal.test.ts`
+The real constraint is output size, and a few components with huge pin lists can
+be as large as many small ones. A component-count cap is a fine coarse pre-check,
+but measuring serialized length is what actually closes the bug.
 
-Add tests within the `traverseCircuitFromNet` describe block:
+### Implementation
 
-**depth limit behavior:**
-- `max_depth=0` returns only components on the starting net, no passive follow-through
-- `max_depth=1` follows through one passive, stops at the next
-- `max_depth=2` follows through two passives in a chain
-- Default (no maxDepth) uses 5
+**File 1: `src/service/tools/query-xnet.ts`** — add a `capResult(result)` helper
+implementing the tiered degradation; call it at the end of both
+`queryXnetByNetName` and `queryXnetByPinName`.
 
-**max_depth_reached:**
-- Reports actual depth when traversal completes within the limit
-- Reports max_depth when traversal is truncated
-- Reports 0 when `max_depth=0`
+**File 2: `src/types.ts`** — `AggregatedCircuitResult`: add `truncated?: boolean`
+and `note?: string` (omit when not truncated). Confirm the `connections` field of
+the grouped-component type is optional so the count-only form type-checks.
 
-**frontier_nets:**
-- Populated with correct net names and depths when depth limit is hit
-- Empty/absent when traversal completes naturally
-- Multiple frontier nets when traversal fans out at the boundary
-- Not populated when traversal stops due to stop nets at the boundary (stop net is not a frontier)
+**File 3: config** — define `XNET_MAX_BYTES` (default safely under the MCP limit)
+with an env override; co-locate with existing config constants.
 
-**interaction with other options:**
-- Depth limit + skip_types: both apply independently
-- Depth limit + stop nets: stop nets still stop within the depth limit
-- Depth limit + DNS filtering: both apply
+**File 4: `src/descriptions.ts`** — note in both xnet tool descriptions that
+oversized results are truncated with a `truncated` flag + `note`.
+
+**File 5: `src/service/tools/query-xnet.test.ts`** — mock `parseDesign` with a
+synthetic net carrying N directly-connected components: assert (i) the serialized
+result stays under budget, (ii) `truncated: true` and the `note` are present,
+(iii) counts remain accurate; plus a small-net case asserting no truncation and
+unchanged output shape.
+
+---
+
+## Evaluation
+
+| | A — `max_depth` | B — output-size cap |
+|---|---|---|
+| Bounds | Traversal **depth** (passive hops) | Serialized **output size** (bytes) |
+| Control | Agent-driven, opt-in parameter | Automatic, always on |
+| Guarantees output < limit? | **No** — a wide net at depth 0–1 still overflows | **Yes** — by construction |
+| Helps with | Deep fan-out through series chains; scoping a query | Broad rails / buses; any oversized result |
+| Cost to caller | Must choose/iterate `max_depth` | None (transparent; flagged when it fires) |
+| Risk | Default may truncate legitimate deep traces (mitigated by `frontier_nets`) | Loses per-pin detail on giant nets (counts + remediation retained) |
+
+**Recommendation: implement both.** They are orthogonal. B is the correctness
+guarantee — it is the only thing that makes an xnet call *unconditionally* safe
+against the token limit, and it requires no agent cooperation. A is scope control
+that produces smaller, more relevant results and gives the agent a knob
+(`max_depth`) plus topology signal (`frontier_nets`). Neither subsumes the other:
+A alone leaves the breadth case (the 369-component `VCC` rail) overflowing; B
+alone always returns *something* but can't express "I only want 1 hop."
+
+Suggested order: **B first** (closes the open stress-test bug class and removes
+the harness file-spill error path), then **A** (scope ergonomics). If shipped
+together, fold into one minor release.
+
+---
 
 ## Verification
 
@@ -106,8 +200,12 @@ npm run type-check && npm run lint && npm test
 ```
 
 Manual MCP testing on a real design:
-- `query_xnet_by_net_name` with `max_depth=0`: returns only direct connections
-- `query_xnet_by_net_name` with `max_depth=1`: returns one hop
-- `query_xnet_by_net_name` with default depth: behaves like current behavior but capped at 5
-- Verify `frontier_nets` appears only when traversal is truncated
-- Verify `max_depth_reached` reflects actual circuit depth in all cases
+
+- **A:** `query_xnet_by_net_name` with `max_depth=0` returns only direct
+  connections; `max_depth=1` returns one hop; default behaves as today, capped at
+  5; `frontier_nets` appears only when a branch is cut short; `max_depth_reached`
+  reflects actual circuit depth.
+- **B:** query a broad rail (e.g. a `VCC`/`VDD` net with hundreds of components)
+  and confirm the tool returns a bounded result with `truncated: true` + `note`
+  instead of triggering the harness oversized-output file spill; confirm a small
+  net is returned in full, unchanged.

--- a/src/circuit-traversal.test.ts
+++ b/src/circuit-traversal.test.ts
@@ -11,6 +11,7 @@ import {
   isValidRefdes,
   isDnsComponent,
   stripDnsMarkers,
+  getRefdesPrefix,
   matchesRefdesType,
   naturalSort,
   traverseCircuitFromNet,
@@ -39,9 +40,27 @@ describe("isGroundNet", () => {
     expect(isGroundNet("dgnd")).toBe(true);
   });
 
+  it("should match suffixed ground names (KiCad GNDREF and friends)", () => {
+    expect(isGroundNet("GNDREF")).toBe(true); // KiCad's default global ground
+    expect(isGroundNet("gndref")).toBe(true);
+    expect(isGroundNet("GNDPWR")).toBe(true);
+    expect(isGroundNet("GNDD")).toBe(true);
+    expect(isGroundNet("GNDS")).toBe(true);
+    expect(isGroundNet("AGND1")).toBe(true);
+    expect(isGroundNet("VSSA")).toBe(true);
+  });
+
+  it("should match hierarchical (sheet-path-prefixed) ground nets", () => {
+    expect(isGroundNet("/GND")).toBe(true); // GND on the root sheet
+    expect(isGroundNet("/Power/AGND")).toBe(true); // AGND on a sub-sheet
+    expect(isGroundNet("/Analog/GNDREF")).toBe(true);
+  });
+
   it("should not match signal nets", () => {
-    expect(isGroundNet("SIG_GND")).toBe(false);
+    expect(isGroundNet("SIG_GND")).toBe(false); // suffix GND, not a global ground
     expect(isGroundNet("SIGNAL")).toBe(false);
+    expect(isGroundNet("GROUND_LOOP")).toBe(false); // starts with G-R-O, not GND
+    expect(isGroundNet("/Sheet/DATA")).toBe(false); // hierarchical signal
   });
 });
 
@@ -103,10 +122,16 @@ describe("isPowerNet", () => {
     expect(isPowerNet("-VBIAS")).toBe(true);
   });
 
+  it("should match hierarchical (sheet-path-prefixed) power rails", () => {
+    expect(isPowerNet("/+3V3")).toBe(true);
+    expect(isPowerNet("/Power/VCC")).toBe(true);
+  });
+
   it("should not match signal nets", () => {
     expect(isPowerNet("I2C_SDA")).toBe(false);
     expect(isPowerNet("SPI_CLK")).toBe(false);
     expect(isPowerNet("SIGNAL")).toBe(false);
+    expect(isPowerNet("/Sheet/I2C_SDA")).toBe(false); // hierarchical signal stays a signal
   });
 });
 
@@ -116,6 +141,15 @@ describe("isStopNet", () => {
     expect(isStopNet("VSS")).toBe(true);
     expect(isStopNet("AGND")).toBe(true);
     expect(isStopNet("DGND")).toBe(true);
+  });
+
+  it("should halt on suffixed and hierarchical ground nets", () => {
+    // These previously slipped through, so xnet traversal flooded the whole
+    // ground tree (token-limit blowups). They must now register as stop nets.
+    expect(isStopNet("GNDREF")).toBe(true);
+    expect(isStopNet("GNDPWR")).toBe(true);
+    expect(isStopNet("/GND")).toBe(true);
+    expect(isStopNet("/Power/GNDREF")).toBe(true);
   });
 
   it("should match power nets", () => {
@@ -313,6 +347,30 @@ describe("isValidRefdes", () => {
     expect(isValidRefdes("")).toBe(false);
     expect(isValidRefdes("123")).toBe(false);
   });
+
+  it("rejects unannotated refdes (annotation placeholder) — intentional", () => {
+    // The "?" placeholder fails whole-string validation by design. This guards
+    // the deliberate divergence from getRefdesPrefix: callers needing a prefix
+    // from a possibly-unannotated refdes must use getRefdesPrefix, not this.
+    // (Relaxing this would alter the Cadence parsers that depend on it.)
+    expect(isValidRefdes("C?")).toBe(false);
+    expect(isValidRefdes("PS?")).toBe(false);
+  });
+});
+
+describe("getRefdesPrefix", () => {
+  it("extracts the leading-letter prefix from annotated refdes", () => {
+    expect(getRefdesPrefix("U1")).toBe("U");
+    expect(getRefdesPrefix("R100")).toBe("R");
+    expect(getRefdesPrefix("FB3")).toBe("FB");
+    expect(getRefdesPrefix("U1_A")).toBe("U");
+  });
+
+  it("extracts the prefix from unannotated refdes (ignores the '?' placeholder)", () => {
+    expect(getRefdesPrefix("C?")).toBe("C");
+    expect(getRefdesPrefix("D?")).toBe("D");
+    expect(getRefdesPrefix("PS?")).toBe("PS");
+  });
 });
 
 describe("matchesRefdesType", () => {
@@ -320,6 +378,12 @@ describe("matchesRefdesType", () => {
     expect(matchesRefdesType("R1", "R")).toBe(true);
     expect(matchesRefdesType("FB1", "FB")).toBe(true);
     expect(matchesRefdesType("C100", "C")).toBe(true);
+  });
+
+  it("matches unannotated refdes by their letter prefix", () => {
+    expect(matchesRefdesType("C?", "C")).toBe(true);
+    expect(matchesRefdesType("D?", "D")).toBe(true);
+    expect(matchesRefdesType("PS?", "PS")).toBe(true);
   });
 
   it("should not match when type is a substring of the prefix", () => {

--- a/src/circuit-traversal.test.ts
+++ b/src/circuit-traversal.test.ts
@@ -50,6 +50,14 @@ describe("isGroundNet", () => {
     expect(isGroundNet("VSSA")).toBe(true);
   });
 
+  it("should match underscore-suffixed ground domains (intentional)", () => {
+    // `\w` includes `_`, so GND_* names classify as ground. Almost always a real
+    // ground domain; a missed ground that floods traversal is worse than this.
+    expect(isGroundNet("GND_SENSE")).toBe(true);
+    expect(isGroundNet("GND_RETURN")).toBe(true);
+    expect(isGroundNet("GND_DIGITAL")).toBe(true);
+  });
+
   it("should match hierarchical (sheet-path-prefixed) ground nets", () => {
     expect(isGroundNet("/GND")).toBe(true); // GND on the root sheet
     expect(isGroundNet("/Power/AGND")).toBe(true); // AGND on a sub-sheet

--- a/src/circuit-traversal.ts
+++ b/src/circuit-traversal.ts
@@ -15,6 +15,10 @@ import type { NetConnections, ComponentDetails, CircuitComponent } from "./types
 // way the power rails are (e.g. KiCad's default `GNDREF`, plus `GNDD`, `GNDS`,
 // `GNDPWR`, `AGND1`). The leading `^` anchor keeps this a prefix match, so a
 // signal-ground like `SIG_GND` is still NOT classified as ground.
+// Trade-off: because `\w` includes `_`, names like `GND_SENSE`/`GND_RETURN` now
+// classify as ground. This is intentional — such names are almost always real
+// ground domains (`GND_DIGITAL`, `GND_ANALOG`, `GND_CHASSIS`), and a missed
+// ground that floods traversal is far worse than a false positive here.
 const GROUND_NET_ALTERNATIVES = "GND\\w*|VSS\\w*|AGND\\w*|DGND\\w*|PGND\\w*|SGND\\w*|CGND\\w*";
 const POWER_NET_ALTERNATIVES =
   "VCC\\w*|VDD\\w*|VIN\\w*|VOUT\\w*|VBAT\\w*|VBUS\\w*|VSYS\\w*|VREG\\w*|PWR_\\w+|RAIL_\\w+|PP\\w*|PN\\w*|LD_PP\\w*|LD_PN\\w*|[+-]?\\d+V\\d*\\w*|[+-].+";

--- a/src/circuit-traversal.ts
+++ b/src/circuit-traversal.ts
@@ -11,7 +11,11 @@ import type { NetConnections, ComponentDetails, CircuitComponent } from "./types
 // A "stop" net is any power or ground rail, so the three patterns below are
 // derived from these shared alternation fragments to keep them in sync — adding
 // a rail to POWER_NET_ALTERNATIVES automatically extends STOP_NET_PATTERN too.
-const GROUND_NET_ALTERNATIVES = "GND|VSS|AGND|DGND|PGND|SGND|CGND";
+// Ground tokens allow a trailing `\w*` so suffixed grounds are caught the same
+// way the power rails are (e.g. KiCad's default `GNDREF`, plus `GNDD`, `GNDS`,
+// `GNDPWR`, `AGND1`). The leading `^` anchor keeps this a prefix match, so a
+// signal-ground like `SIG_GND` is still NOT classified as ground.
+const GROUND_NET_ALTERNATIVES = "GND\\w*|VSS\\w*|AGND\\w*|DGND\\w*|PGND\\w*|SGND\\w*|CGND\\w*";
 const POWER_NET_ALTERNATIVES =
   "VCC\\w*|VDD\\w*|VIN\\w*|VOUT\\w*|VBAT\\w*|VBUS\\w*|VSYS\\w*|VREG\\w*|PWR_\\w+|RAIL_\\w+|PP\\w*|PN\\w*|LD_PP\\w*|LD_PN\\w*|[+-]?\\d+V\\d*\\w*|[+-].+";
 
@@ -25,19 +29,34 @@ const DNS_PATTERN =
   /(?:^|[_,\s])(DNS|DNP|DNF|DNI|DNM|NF|NC)(?:$|[_,\s])|DO\s*NOT\s*(STUFF|POPULATE|INSTALL|FIT|MOUNT)|NOT\s*(POPULATED|FITTED|CONNECTED|MOUNTED)|NO\s*POP/i;
 
 /**
+ * KiCad prefixes nets declared in a sub-sheet with their sheet path
+ * (`/Sheet/GND`, or `/GND` for a net on the root sheet). Net classification
+ * keys off the base name, so reduce to the final path segment before matching;
+ * otherwise the leading slash defeats the `^`-anchored patterns and a ground
+ * like `/GND` is treated as an ordinary signal.
+ */
+const stripSheetPath = (netName: string): string => {
+  const slash = netName.lastIndexOf("/");
+  return slash === -1 ? netName : netName.slice(slash + 1);
+};
+
+/**
  * Check if a net name matches the ground pattern.
  */
-export const isGroundNet = (netName: string): boolean => GROUND_NET_PATTERN.test(netName);
+export const isGroundNet = (netName: string): boolean =>
+  GROUND_NET_PATTERN.test(stripSheetPath(netName));
 
 /**
  * Check if a net name matches the power pattern.
  */
-export const isPowerNet = (netName: string): boolean => POWER_NET_PATTERN.test(netName);
+export const isPowerNet = (netName: string): boolean =>
+  POWER_NET_PATTERN.test(stripSheetPath(netName));
 
 /**
  * Check if a net name matches the stop pattern (power or ground).
  */
-export const isStopNet = (netName: string): boolean => STOP_NET_PATTERN.test(netName);
+export const isStopNet = (netName: string): boolean =>
+  STOP_NET_PATTERN.test(stripSheetPath(netName));
 
 /**
  * Determine if a component is a traversable passive (R/RS, L, C, FB).

--- a/src/service/tools/list-components.test.ts
+++ b/src/service/tools/list-components.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { listComponents } from "./list-components.js";
+import type { ParsedNetlist, ErrorResult, ListComponentsResult } from "../../types.js";
+import * as parsersModule from "../../parsers/index.js";
+
+const isErrorResult = (result: unknown): result is ErrorResult =>
+  typeof result === "object" && result !== null && "error" in result;
+
+const mockParse = (netlist: ParsedNetlist) => {
+  vi.spyOn(parsersModule, "findHandler").mockReturnValue({
+    name: "mock",
+    extensions: [".dsn"],
+    canHandle: () => true,
+    discoverDesigns: vi.fn(),
+    parse: vi.fn(),
+  });
+  vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(netlist);
+};
+
+const DESIGN = "/mock/design.dsn";
+
+describe("listComponents - available prefixes suggestion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Regression for the "Available prefixes: []" bug on unannotated designs.
+  // The refdes still carry KiCad's "?" annotation placeholder (C?, D?, PS?).
+  describe("unannotated-only design", () => {
+    const netlist: ParsedNetlist = {
+      nets: { VPP: { "C?": "1", "D?": "2", "PS?": "3" }, GND: { "C?": "2" } },
+      components: {
+        "C?": { value: "220uF", description: "Polarized capacitor", pins: { "1": "VPP", "2": "GND" } },
+        "D?": { value: "PMEG6020ER", description: "Schottky diode", pins: { "2": "VPP" } },
+        "PS?": { value: "ROF-78E3.3", pins: { "3": "VPP" } },
+      },
+    };
+
+    beforeEach(() => mockParse(netlist));
+
+    it("matches an unannotated refdes by its letter prefix", async () => {
+      const result = await listComponents(DESIGN, "C");
+      expect(isErrorResult(result)).toBe(false);
+      const refdes = (result as ListComponentsResult).components.map((c) => c.refdes);
+      expect(refdes).toContain("C?");
+    });
+
+    it("lists real prefixes (not []) when the queried prefix is absent", async () => {
+      const result = await listComponents(DESIGN, "U");
+      expect(isErrorResult(result)).toBe(true);
+      const msg = (result as ErrorResult).error;
+      expect(msg).toContain("Available prefixes: [C, D, PS]");
+      expect(msg).not.toContain("Available prefixes: []");
+    });
+  });
+
+  it("dedupes and sorts prefixes across annotated and unannotated refdes", async () => {
+    mockParse({
+      nets: { N1: { U1: "1" } },
+      components: {
+        U1: { pins: { "1": "N1" } },
+        "C?": { pins: { "1": "N1" } },
+        R10: { pins: { "1": "N1" } },
+      },
+    });
+    const result = await listComponents(DESIGN, "Q");
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("Available prefixes: [C, R, U]");
+  });
+
+  it("excludes Cadence-path and numeric-only keys from the suggestion list", async () => {
+    mockParse({
+      nets: { N1: { U1: "1" } },
+      components: {
+        U1: { pins: { "1": "N1" } },
+        "@DESIGN.SH:INS1@PART": { pins: { "1": "N1" } },
+        "123": { pins: { "1": "N1" } },
+      },
+    });
+    const result = await listComponents(DESIGN, "Z");
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("Available prefixes: [U]");
+  });
+
+  it("reports an empty prefix list for a genuinely empty design", async () => {
+    mockParse({ nets: {}, components: {} });
+    const result = await listComponents(DESIGN, "U");
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("Available prefixes: []");
+  });
+
+  it("returns grouped components for an annotated design (happy path)", async () => {
+    mockParse({
+      nets: { VDD: { U1: "1" } },
+      components: { U1: { mpn: "TPS62088", description: "Buck Converter", pins: { "1": "VDD" } } },
+    });
+    const result = await listComponents(DESIGN, "U");
+    expect(isErrorResult(result)).toBe(false);
+    expect((result as ListComponentsResult).components.map((c) => c.refdes)).toContain("U1");
+  });
+});

--- a/src/service/tools/list-components.ts
+++ b/src/service/tools/list-components.ts
@@ -1,7 +1,7 @@
 import { getDesignName } from "../../paths.js";
 import { loadNetlist } from "../load-netlist.js";
 import { groupComponentsByMpn } from "../component-grouping.js";
-import { matchesRefdesType, getRefdesPrefix, isValidRefdes } from "../../circuit-traversal.js";
+import { matchesRefdesType, getRefdesPrefix } from "../../circuit-traversal.js";
 import { isErrorResult, type ListComponentsResult, type ErrorResult } from "../../types.js";
 
 /**
@@ -31,8 +31,16 @@ export const listComponents = async (
   );
 
   if (entries.length === 0) {
+    // Derive the suggestion list with the same prefix logic the matcher uses
+    // (getRefdesPrefix), so it can never contradict a query. Filtering to
+    // purely-alphabetic prefixes drops Cadence-path junk ("@DESIGN…") and
+    // numeric-only keys, while keeping unannotated refdes ("C?" -> "C").
     const availablePrefixes = Array.from(
-      new Set(Object.keys(netlist.components).filter(isValidRefdes).map(getRefdesPrefix))
+      new Set(
+        Object.keys(netlist.components)
+          .map(getRefdesPrefix)
+          .filter((p) => /^[A-Z]+$/.test(p))
+      )
     ).sort((a, b) => a.localeCompare(b));
 
     const designName = getDesignName(design);

--- a/src/service/tools/query-xnet.test.ts
+++ b/src/service/tools/query-xnet.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { ParsedNetlist, ErrorResult } from "../../types.js";
 import * as parsersModule from "../../parsers/index.js";
 
 const isErrorResult = (result: unknown): result is ErrorResult =>
   typeof result === "object" && result !== null && "error" in result;
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const KICAD_FIXTURES = path.resolve(HERE, "../../../test/fixtures/kicad");
+// OpenMD's committed .net declares its ground as the hierarchical "/GND", so it
+// parses without kicad-cli and exercises the real classify+reject path in CI.
+const OPENMD = path.join(KICAD_FIXTURES, "openmd-motordriver", "OpenMD.kicad_pro");
+const hasOpenMd = existsSync(OPENMD);
 
 describe("queryXnetByNetName - ground net blocking", () => {
   let queryXnetByNetName: typeof import("./query-xnet.js").queryXnetByNetName;
@@ -47,6 +57,36 @@ describe("queryXnetByNetName - ground net blocking", () => {
     vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
 
     const result = await queryXnetByNetName("/mock/design.dsn", "DGND");
+
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("ground net");
+    expect((result as ErrorResult).error).toContain("cannot be queried");
+  });
+
+  it("should return error for GNDREF (KiCad's default global ground)", async () => {
+    // Regression: GNDREF previously slipped the guard and the trace flooded the
+    // whole ground tree, overflowing the token limit.
+    const mockNetlist: ParsedNetlist = {
+      nets: { GNDREF: { U1: "1" } },
+      components: { U1: { pins: { "1": "GNDREF" }, mpn: "IC" } },
+    };
+    vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
+
+    const result = await queryXnetByNetName("/mock/design.dsn", "GNDREF");
+
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("ground net");
+    expect((result as ErrorResult).error).toContain("cannot be queried");
+  });
+
+  it("should return error for a hierarchical (sheet-path-prefixed) ground net", async () => {
+    const mockNetlist: ParsedNetlist = {
+      nets: { "/GND": { U1: "1" } },
+      components: { U1: { pins: { "1": "/GND" }, mpn: "IC" } },
+    };
+    vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
+
+    const result = await queryXnetByNetName("/mock/design.dsn", "/GND");
 
     expect(isErrorResult(result)).toBe(true);
     expect((result as ErrorResult).error).toContain("ground net");
@@ -101,6 +141,20 @@ describe("queryXnetByPinName - ground net blocking", () => {
     expect((result as ErrorResult).error).toContain("R1.2");
   });
 
+  it("should return error when pin is connected to GNDREF", async () => {
+    const mockNetlist: ParsedNetlist = {
+      nets: { GNDREF: { R1: "2" }, SIGNAL: { R1: "1" } },
+      components: { R1: { pins: { "1": "SIGNAL", "2": "GNDREF" }, mpn: "10k" } },
+    };
+    vi.spyOn(parsersModule, "parseDesign").mockResolvedValue(mockNetlist);
+
+    const result = await queryXnetByPinName("/mock/design.dsn", "R1.2");
+
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("(ground)");
+    expect((result as ErrorResult).error).toContain("cannot be queried");
+  });
+
   it("should allow non-ground pin queries", async () => {
     const mockNetlist: ParsedNetlist = {
       nets: { GND: { R1: "2" }, SIGNAL: { R1: "1" } },
@@ -124,5 +178,20 @@ describe("queryXnetByPinName - ground net blocking", () => {
 
     expect(isErrorResult(result)).toBe(false);
     expect("net" in result && result.net).toBe("NC");
+  });
+});
+
+// End-to-end against a real committed fixture (no mocks): OpenMD's ground net is
+// the hierarchical "/GND", which previously slipped the guard and flooded the
+// trace. This drives the real parser + classifier through the public tool.
+describe.skipIf(!hasOpenMd)("queryXnetByNetName - real fixture (OpenMD /GND)", () => {
+  it("rejects the hierarchical /GND ground net", async () => {
+    const { queryXnetByNetName } = await import("./query-xnet.js");
+
+    const result = await queryXnetByNetName(OPENMD, "/GND");
+
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toContain("ground net");
+    expect((result as ErrorResult).error).toContain("cannot be queried");
   });
 });


### PR DESCRIPTION
## Summary
- **XNET ground detection (HIGH):** the ground guard matched a hardcoded exact list (`GND|VSS|AGND|DGND|PGND|SGND|CGND`), so KiCad's own default ground `GNDREF` (plus `GNDD`/`GNDS`/`GNDPWR`) and hierarchical `/GND` slipped through — the trace then walked the entire ground tree and overflowed the output token limit. Ground tokens now allow a trailing `\w*` and the sheet-path prefix is stripped before classification, so these nets are correctly rejected; a suffix-only signal-ground like `SIG_GND` is still treated as a signal.
- **`list_components` Available prefixes (LOW):** unannotated designs (refdes still carrying KiCad's `?` placeholder, e.g. `C?`/`D?`/`PS?`) wrongly reported `Available prefixes: []`. The suggestion list is now derived with the same prefix logic the matcher uses, so every suggested prefix resolves to real components.
- **Plans:** records XNET output-bounding options (`max_depth` + an automatic output-size cap), evaluated as complementary, in `plans/xnet-depth-limit.md`.

Both fixes were surfaced by a 100-design stress test of the corpus. Version bumped to `1.1.1`; CHANGELOG updated.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm test` green (521 tests; new unit + tool-level + real-fixture coverage)
- [x] New `query-xnet` tests cover `GNDREF` / `/GND` rejection (mock + real `OpenMD.net` fixture)
- [x] New `list-components` tests cover unannotated-prefix suggestions
- [x] Pre-existing classification negatives preserved (`SIG_GND`, signal nets, standalone `+`/`-`)