### PR TITLE
test: assert net name in ground-pin rejection error

### DIFF
--- a/src/service/tools/query-xnet.test.ts
+++ b/src/service/tools/query-xnet.test.ts
@@ -153,6 +153,8 @@ describe("queryXnetByPinName - ground net blocking", () => {
     expect(isErrorResult(result)).toBe(true);
     expect((result as ErrorResult).error).toContain("(ground)");
     expect((result as ErrorResult).error).toContain("cannot be queried");
+    // The offending net name must appear, so a future regression can't blame the wrong net.
+    expect((result as ErrorResult).error).toContain("GNDREF");
   });
 
   it("should allow non-ground pin queries", async () => {


### PR DESCRIPTION
## Summary
- Follow-up to PR #76 review: the `query_xnet_by_pin_name` ground rejection already names the offending net (`query-xnet.ts:129`); this pins the `GNDREF` case so a future regression can't blame the wrong net.
- Test-only change. No behavior change.

## Test plan
- [x] `npm run type-check && npm run lint && npm test` (527 pass locally)