### PR TITLE
feat(otel): mirror enduser.id and captured tool args onto per-call log records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-16
+
+### Added
+
+- The per-call OpenTelemetry log record now also carries `enduser.id` (mirroring the resource attribute) and, when `OTEL_CAPTURE_TOOL_ARGS` is enabled, `tool.args` (the same JSON already recorded on the span) as log-record attributes. Log/label-based backends index only log-record attributes (resource attributes are dropped and span attributes are never carried), so per-user and per-input analytics are now possible from logs alone. Args stay opt-in behind the existing `OTEL_CAPTURE_TOOL_ARGS` flag; `enduser.id` mirrors a value already exported on every signal (#82)
+
 ## [1.3.0] - 2026-06-24
 
 ### Added

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -82,7 +82,7 @@ One additional, clearly-scoped option is specific to this server:
 
 | Variable | Purpose |
 |----------|---------|
-| `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments on the span as `tool.args`. Off by default, since arguments may be sensitive. |
+| `OTEL_CAPTURE_TOOL_ARGS` | Set to `1`/`true` to also record raw tool arguments as `tool.args`, on both the span and the per-call log record. Off by default, since arguments may be sensitive. |
 
 ## What gets emitted
 
@@ -120,7 +120,11 @@ One structured log record per call, with body `tool/<tool_name> <outcome>` and s
 | `tool.outcome` | `success` or `error`. |
 | `tool.duration_ms` | Duration in milliseconds. |
 | `error.type` | Present on failure. |
+| `enduser.id` | The host OS account name, mirroring the resource attribute below. Best-effort; omitted if it can't be read. |
+| `tool.args` | Full tool arguments as JSON, mirroring the span attribute. Only present when `OTEL_CAPTURE_TOOL_ARGS` is enabled. |
 | `trace_id`, `span_id` | The active trace/span IDs, for trace-to-log correlation. |
+
+Log/label-based backends typically index only log-record attributes (resource attributes are dropped and span attributes are never carried), so `enduser.id` and the captured arguments are set directly on each record to keep per-user and per-input analytics possible from logs alone.
 
 ### Resource attributes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/telemetry/otel.test.ts
+++ b/src/telemetry/otel.test.ts
@@ -1,0 +1,114 @@
+/**
+ * OpenTelemetry per-call log record tests.
+ *
+ * The SDK is initialized against a closed local port, so telemetry is enabled
+ * but background exports fail fast and nothing leaves the machine. The global
+ * logger provider is then swapped for an in-memory capture, letting the tests
+ * assert on the exact log records `instrumentTool` emits.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { userInfo } from "node:os";
+import { logs, type LogRecord, type LoggerProvider } from "@opentelemetry/api-logs";
+import { initOtel, instrumentTool, shutdownOtel } from "./otel.js";
+
+const captured: LogRecord[] = [];
+const captureProvider: LoggerProvider = {
+  getLogger: () => ({
+    emit: (record: LogRecord) => {
+      captured.push(record);
+    },
+    enabled: () => true,
+  }),
+};
+
+beforeAll(async () => {
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:1";
+  // Keep the batch exporters from firing (and failing) mid-test; shutdown
+  // still flushes once at the end.
+  process.env.OTEL_BSP_SCHEDULE_DELAY = "600000";
+  process.env.OTEL_BLRP_SCHEDULE_DELAY = "600000";
+  process.env.OTEL_METRIC_EXPORT_INTERVAL = "600000";
+  await initOtel({ serviceName: "otel-test", serviceVersion: "0.0.0" });
+  // Swap the SDK's registered global logger provider for the capture.
+  logs.disable();
+  logs.setGlobalLoggerProvider(captureProvider);
+});
+
+afterAll(async () => {
+  logs.disable();
+  delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  delete process.env.OTEL_BSP_SCHEDULE_DELAY;
+  delete process.env.OTEL_BLRP_SCHEDULE_DELAY;
+  delete process.env.OTEL_METRIC_EXPORT_INTERVAL;
+  delete process.env.OTEL_CAPTURE_TOOL_ARGS;
+  await shutdownOtel();
+});
+
+beforeEach(() => {
+  captured.length = 0;
+  delete process.env.OTEL_CAPTURE_TOOL_ARGS;
+});
+
+const lastRecord = (): LogRecord => {
+  expect(captured).toHaveLength(1);
+  return captured[0];
+};
+
+describe("instrumentTool log records", () => {
+  it("emits one record per call with the standard attributes", async () => {
+    const result = await instrumentTool("demo_tool", { a: 1 }, async () => "ok");
+
+    expect(result).toBe("ok");
+    const record = lastRecord();
+    expect(record.body).toBe("tool/demo_tool success");
+    expect(record.severityText).toBe("INFO");
+    expect(record.attributes).toMatchObject({
+      "tool.name": "demo_tool",
+      "tool.outcome": "success",
+    });
+    expect(record.attributes?.["tool.duration_ms"]).toBeTypeOf("number");
+    expect(record.attributes?.trace_id).toBeTypeOf("string");
+    expect(record.attributes?.span_id).toBeTypeOf("string");
+  });
+
+  it("mirrors enduser.id onto the record", async () => {
+    await instrumentTool("demo_tool", {}, async () => "ok");
+
+    expect(lastRecord().attributes?.["enduser.id"]).toBe(userInfo().username);
+  });
+
+  it("captures tool.args on the record when OTEL_CAPTURE_TOOL_ARGS is set", async () => {
+    process.env.OTEL_CAPTURE_TOOL_ARGS = "1";
+    const args = { design: "board.kicad_pro", pattern: "^VCC" };
+
+    await instrumentTool("demo_tool", args, async () => "ok");
+
+    expect(lastRecord().attributes?.["tool.args"]).toBe(JSON.stringify(args));
+  });
+
+  it("omits tool.args when OTEL_CAPTURE_TOOL_ARGS is unset", async () => {
+    await instrumentTool("demo_tool", { design: "board.kicad_pro" }, async () => "ok");
+
+    expect(lastRecord().attributes ?? {}).not.toHaveProperty("tool.args");
+  });
+
+  it("keeps enduser.id and args on error records", async () => {
+    process.env.OTEL_CAPTURE_TOOL_ARGS = "true";
+
+    await expect(
+      instrumentTool("demo_tool", { a: 1 }, async () => {
+        throw new TypeError("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    const record = lastRecord();
+    expect(record.severityText).toBe("ERROR");
+    expect(record.attributes).toMatchObject({
+      "tool.outcome": "error",
+      "error.type": "TypeError",
+      "enduser.id": userInfo().username,
+      "tool.args": JSON.stringify({ a: 1 }),
+    });
+  });
+});

--- a/src/telemetry/otel.ts
+++ b/src/telemetry/otel.ts
@@ -121,7 +121,8 @@ export const initOtel = async (opts: {
     // service.name from env wins; our value is only a fallback default.
     // enduser.id is the host OS account, attributing this per-session process to
     // whoever is running it. Set at the resource level so it tags traces,
-    // metrics, and logs alike.
+    // metrics, and logs alike; also mirrored onto each per-call log record's
+    // own attributes for log backends that drop resource attributes (emitLog).
     const resource = resourceFromAttributes({
       "service.name": process.env.OTEL_SERVICE_NAME || opts.serviceName,
       "service.version": opts.serviceVersion,
@@ -268,13 +269,14 @@ export const instrumentTool = async <R>(
   const tracer = trace.getTracer(INSTRUMENTATION_NAME);
   return tracer.startActiveSpan(`tool/${toolName}`, async (span) => {
     const start = Date.now();
+    // Full args, untruncated: tool-call arguments are inherently small.
+    // Serialized once, then attached to the span here and mirrored onto the
+    // per-call log record (span attributes never reach log-based backends).
+    const capturedArgs = isTruthy(process.env.OTEL_CAPTURE_TOOL_ARGS) ? safeJson(args) : undefined;
     try {
       safely(() => {
         span.setAttribute("tool.name", toolName);
-        if (isTruthy(process.env.OTEL_CAPTURE_TOOL_ARGS)) {
-          // Full args, untruncated: tool-call arguments are inherently small.
-          span.setAttribute("tool.args", safeJson(args));
-        }
+        if (capturedArgs !== undefined) span.setAttribute("tool.args", capturedArgs);
       });
 
       const result = await run();
@@ -285,13 +287,14 @@ export const instrumentTool = async <R>(
         toolName,
         isError ? "error" : "success",
         isError ? "tool_error" : undefined,
-        Date.now() - start
+        Date.now() - start,
+        capturedArgs
       );
       return result;
     } catch (err) {
       const errorType = err instanceof Error ? err.name : "Error";
       safely(() => span.recordException(err instanceof Error ? err : new Error(String(err))));
-      finishSpan(span, toolName, "error", errorType, Date.now() - start);
+      finishSpan(span, toolName, "error", errorType, Date.now() - start, capturedArgs);
       throw err;
     }
   });
@@ -302,7 +305,8 @@ const finishSpan = (
   toolName: string,
   outcome: "success" | "error",
   errorType: string | undefined,
-  durationMs: number
+  durationMs: number,
+  capturedArgs: string | undefined
 ): void => {
   safely(() => {
     span.setAttribute("tool.outcome", outcome);
@@ -321,17 +325,25 @@ const finishSpan = (
     }
   });
 
-  safely(() => emitLog(span, toolName, outcome, errorType, durationMs));
+  safely(() => emitLog(span, toolName, outcome, errorType, durationMs, capturedArgs));
 
   safely(() => span.end());
 };
 
+/**
+ * Emit the per-call log record. Log/label-based backends index only log-record
+ * attributes (resource attributes are dropped and span attributes are never
+ * carried), so `enduser.id` is mirrored here from the resource and the
+ * captured args from the span, keeping per-user and per-input analytics
+ * possible from logs alone.
+ */
 const emitLog = (
   span: Span,
   toolName: string,
   outcome: "success" | "error",
   errorType: string | undefined,
-  durationMs: number
+  durationMs: number,
+  capturedArgs: string | undefined
 ): void => {
   const sc = span.spanContext();
   const logger = logs.getLogger(INSTRUMENTATION_NAME);
@@ -344,6 +356,8 @@ const emitLog = (
       "tool.outcome": outcome,
       "tool.duration_ms": durationMs,
       ...(errorType ? { "error.type": errorType } : {}),
+      ...hostEnduser(),
+      ...(capturedArgs !== undefined ? { "tool.args": capturedArgs } : {}),
       // Explicit ids for trace-to-log correlation in addition to the record's
       // own trace context.
       trace_id: sc.traceId,
@@ -376,17 +390,23 @@ const getInstruments = (): Instruments => {
 // =============================================================================
 
 /**
- * The host OS account name as an `enduser.id` resource attribute, attributing
- * this per-session process to whoever runs it. Best-effort: returns an empty
- * object if the username can't be read, so telemetry setup never fails on it.
+ * The host OS account name as an `enduser.id` attribute, attributing this
+ * per-session process to whoever runs it. Used on the resource and mirrored
+ * onto each per-call log record, so it is cached after the first read.
+ * Best-effort: yields an empty object if the username can't be read, so
+ * telemetry never fails on it.
  */
+let enduserAttrs: Record<string, string> | undefined;
 const hostEnduser = (): Record<string, string> => {
-  try {
-    const name = userInfo().username;
-    return name ? { "enduser.id": name } : {};
-  } catch {
-    return {};
+  if (!enduserAttrs) {
+    try {
+      const name = userInfo().username;
+      enduserAttrs = name ? { "enduser.id": name } : {};
+    } catch {
+      enduserAttrs = {};
+    }
   }
+  return enduserAttrs;
 };
 
 /** Run a telemetry side effect, swallowing any error so it can't break a tool. */

--- a/test/otel/e2e.test.ts
+++ b/test/otel/e2e.test.ts
@@ -8,6 +8,7 @@
  *   - per-tool-call span (tool/<name>) with outcome attributes
  *   - tool.calls / tool.duration / tool.errors metrics
  *   - structured log correlated by trace/span id
+ *   - log-record attributes mirror enduser.id and, opt-in, tool.args (issue #82)
  *   - failure path: outcome=error, tool result still returned
  *   - exporter unreachable: tool calls still succeed
  *   - flush on shutdown
@@ -132,8 +133,50 @@ describe("OpenTelemetry end-to-end", () => {
       expect(log.attributes.trace_id).toBe(span.traceId);
       expect(log.attributes.span_id).toBe(span.spanId);
 
-      // enduser.id is the host OS account, set at the resource level.
+      // enduser.id is the host OS account, set at the resource level and
+      // mirrored onto the log record itself for log-only backends.
       expect(receiver.resourceAttributes()["enduser.id"]).toBe(userInfo().username);
+      expect(log.attributes["enduser.id"]).toBe(userInfo().username);
+      // Args are opt-in and were not requested here.
+      expect(log.attributes["tool.args"]).toBeUndefined();
+      expect(span.attributes["tool.args"]).toBeUndefined();
+    },
+    TEST_TIMEOUT
+  );
+
+  test(
+    "args capture: OTEL_CAPTURE_TOOL_ARGS puts tool.args on the span and the log record",
+    async () => {
+      const args = { path: tmpdir(), max_depth: 0 };
+      await withServer(otelEnv(receiver, { OTEL_CAPTURE_TOOL_ARGS: "1" }), async (client) => {
+        const res: any = await client.callTool({ name: "list_designs", arguments: args });
+        expect(res.isError).toBeFalsy();
+      });
+
+      // Filter on tool.args presence: earlier tests emitted argless records.
+      const got = await waitFor(
+        () =>
+          receiver
+            .spans()
+            .some((s) => s.name === "tool/list_designs" && "tool.args" in s.attributes) &&
+          receiver
+            .logs()
+            .some((l) => l.body === "tool/list_designs success" && "tool.args" in l.attributes)
+      );
+      expect(got).toBe(true);
+
+      // The handler sees args with schema defaults applied, so match on the
+      // caller-supplied subset; span and log must carry the identical JSON.
+      const span = receiver
+        .spans()
+        .find((s) => s.name === "tool/list_designs" && "tool.args" in s.attributes)!;
+      expect(JSON.parse(String(span.attributes["tool.args"]))).toMatchObject(args);
+
+      const log = receiver
+        .logs()
+        .find((l) => l.body === "tool/list_designs success" && "tool.args" in l.attributes)!;
+      expect(log.attributes["tool.args"]).toBe(span.attributes["tool.args"]);
+      expect(log.attributes["enduser.id"]).toBe(userInfo().username);
     },
     TEST_TIMEOUT
   );


### PR DESCRIPTION
## Summary

- The per-call log record emitted by `instrumentTool` now carries `enduser.id`, mirroring the resource attribute, so log/label-based backends (which index only log-record attributes) can attribute usage per user.
- With the existing `OTEL_CAPTURE_TOOL_ARGS` opt-in, the record also carries `tool.args` — the same JSON already recorded on the span, serialized once and shared by both.
- `docs/observability.md` documents the new log-record attributes; includes v1.4.0 changelog and version bump.

Addresses #82 (left open for the reporter to verify).

## Test plan

- [x] New unit test `src/telemetry/otel.test.ts`: in-memory logger capture asserts `enduser.id`, opt-in `tool.args`, opt-out omission, and error-path records.
- [x] Extended `test/otel/e2e.test.ts`: real server over stdio + OTLP receiver asserts the mirrored attributes on the wire, and that span/log carry identical args JSON.
- [x] `npm run type-check && npm run lint && npm test` (556 tests pass).