### PR TITLE
fix: ignore macOS AppleDouble (._*) files in discovery and test collection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**', '**/*.test.ts'],
+    // '**/._*' — AppleDouble sidecars macOS writes on network volumes; binary, not source.
+    ignores: ['dist/**', 'node_modules/**', '**/*.test.ts', '**/._*'],
   }
 );

--- a/src/parsers/altium/discovery.ts
+++ b/src/parsers/altium/discovery.ts
@@ -114,6 +114,10 @@ const walkForAltiumFiles = async (
     }
 
     for (const entry of entries) {
+      // macOS writes AppleDouble sidecars (`._name`) beside real files on network
+      // volumes (NFS/SMB). They are metadata, never designs — skip files and dirs alike.
+      if (entry.name.startsWith("._")) continue;
+
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         if (maxDepth === undefined || depth < maxDepth) {

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -75,6 +75,10 @@ const walkForCadenceFiles = async (
     }
 
     for (const entry of entries) {
+      // macOS writes AppleDouble sidecars (`._name`) beside real files on network
+      // volumes (NFS/SMB). They are metadata, never designs — skip files and dirs alike.
+      if (entry.name.startsWith("._")) continue;
+
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         if (maxDepth === undefined || depth < maxDepth) {

--- a/src/parsers/discovery.test.ts
+++ b/src/parsers/discovery.test.ts
@@ -224,4 +224,54 @@ describe("discoverDesigns", () => {
       expect(altium).toBeDefined();
     });
   });
+
+  describe("macOS AppleDouble sidecars", () => {
+    it("should ignore ._* sidecar files next to real designs", async () => {
+      await writeFile(join(testDir, "board.DSN"), "");
+      // AppleDouble sidecars carry resource-fork/xattr metadata, not design data.
+      await writeFile(join(testDir, "._board.DSN"), Buffer.from([0x00, 0x05, 0x16, 0x07]));
+
+      // An orphan SchDoc becomes a standalone design, so an OLE-looking sidecar
+      // would show up as a phantom design named "._sheet" if it were not skipped.
+      await writeOleSchDoc(join(testDir, "sheet.SchDoc"));
+      await writeOleSchDoc(join(testDir, "._sheet.SchDoc"));
+
+      const designs = await discoverDesigns(testDir);
+      expect(designs.map((d) => d.name).sort()).toEqual(["board", "sheet"]);
+    });
+
+    it("should not descend into ._* sidecar directories", async () => {
+      const sidecarDir = join(testDir, "._project");
+      await mkdir(sidecarDir, { recursive: true });
+      await writeFile(join(sidecarDir, "phantom.DSN"), "");
+
+      const realDir = join(testDir, "project");
+      await mkdir(realDir, { recursive: true });
+      await writeFile(join(realDir, "real.DSN"), "");
+
+      const designs = await discoverDesigns(testDir);
+      expect(designs.map((d) => d.name)).toEqual(["real"]);
+    });
+
+    it("should ignore ._* sidecars of Cadence .dat files", async () => {
+      const designDir = join(testDir, "dat_only");
+      await mkdir(designDir, { recursive: true });
+      for (const name of ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"]) {
+        await writeFile(join(designDir, name), "test");
+        await writeFile(join(designDir, `._${name}`), Buffer.from([0x00, 0x05, 0x16, 0x07]));
+      }
+
+      const designs = await discoverDesigns(testDir);
+      expect(designs).toHaveLength(1);
+      expect(designs[0].format).toBe("cadence-dat");
+    });
+
+    it("should ignore ._* sidecars of KiCad project files", async () => {
+      await writeFile(join(testDir, "proj.kicad_pro"), "{}");
+      await writeFile(join(testDir, "._proj.kicad_pro"), Buffer.from([0x00, 0x05, 0x16, 0x07]));
+
+      const designs = await discoverDesigns(testDir);
+      expect(designs.map((d) => d.name)).toEqual(["proj"]);
+    });
+  });
 });

--- a/src/parsers/kicad/discovery.ts
+++ b/src/parsers/kicad/discovery.ts
@@ -83,6 +83,10 @@ const walkForProjects = async (rootDir: string, maxDepth?: number): Promise<stri
     }
 
     for (const entry of entries) {
+      // macOS writes AppleDouble sidecars (`._name`) beside real files on network
+      // volumes (NFS/SMB). They are metadata, never designs — skip files and dirs alike.
+      if (entry.name.startsWith("._")) continue;
+
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
         if (maxDepth === undefined || depth < maxDepth) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,11 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    // On network volumes (NFS/SMB) macOS drops `._name` AppleDouble sidecars beside
+    // every file, including `*.test.ts`. They are binary metadata, not test files:
+    // collecting them fails the run with an esbuild "Transform failed" error.
+    exclude: [...configDefaults.exclude, "**/._*"],
   },
 });


### PR DESCRIPTION
On network volumes (NFS/SMB) macOS drops `._*` sidecars beside every file; discovery lists them as phantom designs that fail to parse (e.g. `._board.DSN` shows up in `list_designs`), and vitest/eslint choke on `._*.test.ts` sidecars. Skips `._*` in the three design walkers (cadence/altium/kicad) and excludes them from vitest/eslint. Includes regression tests. Independent of #84/#86 — no traversal changes.