### PR TITLE
fix(dsn): reject partially numeric hierarchy suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-08-04
+
+### Fixed
+
+- Cadence DSN cross-page net disambiguation now accepts only fully numeric hierarchy suffixes, preventing distinct nets whose suffix begins with a digit from being silently merged (#85, #88)
+
 ## [1.4.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/parsers/cadence/dsn/net-builder.test.ts
+++ b/src/parsers/cadence/dsn/net-builder.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { buildNetConnectivity } from "./net-builder.js";
+import type { PageData } from "./page-parser.js";
+import type { PinMapData } from "./structure-types.js";
+import type { PlacedInstance, Wire } from "./structures.js";
+
+interface Connection {
+  netName: string;
+  netId: number;
+  refdes: string;
+  x: number;
+}
+
+const emptyPinMapData: PinMapData = {
+  pinMaps: new Map(),
+  cachePinMaps: new Map(),
+  deviceUnitRefs: new Map(),
+};
+
+function makePage(name: string, connections: Connection[]): PageData {
+  const netTable = new Map<number, string[]>();
+  const wires: Wire[] = [];
+  const placedInstances: PlacedInstance[] = [];
+
+  connections.forEach((connection, index) => {
+    const wireId = index + 1;
+    netTable.set(wireId, [connection.netName]);
+    wires.push({
+      segmentId: wireId,
+      id: wireId,
+      startX: connection.x,
+      startY: 0,
+      endX: connection.x + 10,
+      endY: 0,
+      aliases: [],
+    });
+    placedInstances.push({
+      pkgName: "GENERIC.Normal",
+      dbId: connection.netId,
+      reference: connection.refdes,
+      sourcePackage: "GENERIC",
+      partValueIdx: 0,
+      prefixProperties: [],
+      locX: connection.x,
+      locY: 0,
+      symbolDisplayProps: [],
+      t0x10s: [
+        {
+          pinIndex: 1,
+          pointX: connection.x,
+          pointY: 0,
+          netId: connection.netId,
+          symbolDisplayProps: [],
+        },
+      ],
+    });
+  });
+
+  return {
+    name,
+    netTable,
+    wires,
+    placedInstances,
+    ports: [],
+    globals: [],
+    offPageConnectors: [],
+  };
+}
+
+function build(pages: PageData[], canonicalNetNames: string[]) {
+  return buildNetConnectivity(pages, new Set(canonicalNetNames), emptyPinMapData, new Map(), [])
+    .nets;
+}
+
+describe("cross-page net disambiguation", () => {
+  it("keeps a partially numeric sibling net separate", () => {
+    const nets = build(
+      [
+        makePage("PAGE_A", [
+          { netName: "SIGNAL", netId: 100, refdes: "R1", x: 0 },
+          { netName: "SIGNAL_1V8", netId: 300, refdes: "U1", x: 100 },
+        ]),
+        makePage("PAGE_B", [{ netName: "SIGNAL", netId: 200, refdes: "R2", x: 0 }]),
+      ],
+      ["SIGNAL", "SIGNAL_1V8"]
+    );
+
+    expect(nets.SIGNAL).toEqual({ R1: ["1"], R2: ["1"] });
+    expect(nets.SIGNAL_1V8).toEqual({ U1: ["1"] });
+  });
+
+  it("continues to recognize an entirely numeric hierarchy suffix", () => {
+    const nets = build(
+      [
+        makePage("PAGE_A", [{ netName: "SIGNAL", netId: 100, refdes: "R1", x: 0 }]),
+        makePage("PAGE_B", [{ netName: "SIGNAL", netId: 200, refdes: "R2", x: 0 }]),
+      ],
+      ["SIGNAL", "SIGNAL_150"]
+    );
+
+    expect(nets.SIGNAL).toEqual({ R1: ["1"] });
+    expect(nets.SIGNAL_150).toEqual({ R2: ["1"] });
+  });
+});

--- a/src/parsers/cadence/dsn/net-builder.ts
+++ b/src/parsers/cadence/dsn/net-builder.ts
@@ -423,8 +423,9 @@ function disambiguateCrossPageNets(
     const suffixedHier: { suffix: number; fullName: string }[] = [];
     for (const hierName of canonicalNetNames) {
       if (hierName.startsWith(prefix)) {
-        const num = parseInt(hierName.substring(prefix.length));
-        if (!isNaN(num)) suffixedHier.push({ suffix: num, fullName: hierName });
+        const suffix = hierName.substring(prefix.length);
+        if (!/^\d+$/.test(suffix)) continue;
+        suffixedHier.push({ suffix: Number(suffix), fullName: hierName });
       }
     }
     if (suffixedHier.length === 0) continue;


### PR DESCRIPTION
## Summary

- Require cross-page hierarchy suffixes to contain only decimal digits.
- Keep distinct sibling nets from being silently merged.
- Add generic synthetic regressions for partially numeric and numeric suffixes.
- Bump the package version to 1.4.1.

## Verification

- `npm run type-check`
- `npm run lint`
- `npm test` (490 passed, 17 skipped)

Fixes #85
Fixes #88