### PR TITLE
fix(dsn): don't merge cross-page nets into designer-named sibling nets

### DIFF
--- a/src/parsers/cadence/dsn/net-builder.test.ts
+++ b/src/parsers/cadence/dsn/net-builder.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Cross-page net disambiguation tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { disambiguateCrossPageNets } from "./net-builder.js";
+
+/**
+ * Build the (netIdToName, netIdGroups) pair the disambiguator consumes.
+ * Each entry is [netId, resolvedName, pageIdx]; pin details are irrelevant to
+ * the heuristic, which only reads pageIdx off the first pin of each group.
+ */
+const buildInputs = (
+  entries: [netId: number, name: string, pageIdx: number][]
+): { netIdToName: Map<number, string>; netIdGroups: Map<number, { pageIdx: number }[]> } => {
+  const netIdToName = new Map<number, string>();
+  const netIdGroups = new Map<number, { pageIdx: number }[]>();
+  for (const [netId, name, pageIdx] of entries) {
+    netIdToName.set(netId, name);
+    netIdGroups.set(netId, [{ pageIdx }]);
+  }
+  return { netIdToName, netIdGroups };
+};
+
+// The disambiguator only touches pageIdx, so a structural stand-in for PinInfo
+// keeps these fixtures readable.
+const run = (
+  entries: [netId: number, name: string, pageIdx: number][],
+  hierNames: string[]
+): Map<number, string> => {
+  const { netIdToName, netIdGroups } = buildInputs(entries);
+  disambiguateCrossPageNets(
+    netIdToName,
+    netIdGroups as unknown as Parameters<typeof disambiguateCrossPageNets>[1],
+    new Set(hierNames)
+  );
+  return netIdToName;
+};
+
+// Cadence allocates net object IDs sequentially from one large space, and the
+// heuristic leans on that: a netlister collision suffix IS a dbObjectId, so it
+// is the same order of magnitude as the page-local netIds. Fixtures use
+// realistic magnitudes — that is exactly what a designer's `_01` is not.
+describe("disambiguateCrossPageNets", () => {
+  it("should not rename cross-page groups into designer-authored numeric siblings", () => {
+    // SIG_N spans three pages (one logical net). The design also has its own
+    // per-port SIG_N_01/_02/_04 nets, each drawn with its own wire label.
+    const result = run(
+      [
+        [21_000_000, "SIG_N", 0],
+        [21_500_000, "SIG_N", 1],
+        [22_000_000, "SIG_N", 2],
+        [21_100_000, "SIG_N_01", 0],
+        [21_600_000, "SIG_N_02", 1],
+        [22_100_000, "SIG_N_04", 2],
+      ],
+      ["SIG_N", "SIG_N_01", "SIG_N_02", "SIG_N_04"]
+    );
+
+    // Every SIG_N page group keeps the bare name -> the pins still merge into
+    // one net downstream, and no sibling gains a foreign pin. Before the fix
+    // the suffixes 1/2/4 cleared `suffix <= minNetId` trivially and all three
+    // groups were renamed away.
+    expect(result.get(21_000_000)).toBe("SIG_N");
+    expect(result.get(21_500_000)).toBe("SIG_N");
+    expect(result.get(22_000_000)).toBe("SIG_N");
+    expect(result.get(21_100_000)).toBe("SIG_N_01");
+    expect(result.get(21_600_000)).toBe("SIG_N_02");
+    expect(result.get(22_100_000)).toBe("SIG_N_04");
+  });
+
+  it("should not rename cross-page groups into rail-suffixed siblings", () => {
+    // `parseInt("1V8")` is 1, not NaN, so a level-shifted sibling used to read
+    // as cross-page duplicate _1. Same for _3V3, _5V, _1V2 ...
+    const result = run(
+      [
+        [21_000_000, "SPI_CS", 0],
+        [22_000_000, "SPI_CS", 1],
+        [21_500_000, "SPI_CS_1V8", 0],
+      ],
+      ["SPI_CS", "SPI_CS_1V8"]
+    );
+
+    expect(result.get(21_000_000)).toBe("SPI_CS");
+    expect(result.get(22_000_000)).toBe("SPI_CS");
+    expect(result.get(21_500_000)).toBe("SPI_CS_1V8");
+  });
+
+  it("should not treat a rail-suffixed hierarchy name as a rename even if unclaimed", () => {
+    // Gate 1 alone: no wire group resolved to SPI_CS_3V3, so only the
+    // entirely-digits test can reject it.
+    const result = run(
+      [
+        [21_000_000, "SPI_CS", 0],
+        [22_000_000, "SPI_CS", 1],
+      ],
+      ["SPI_CS", "SPI_CS_3V3"]
+    );
+
+    expect(result.get(21_000_000)).toBe("SPI_CS");
+    expect(result.get(22_000_000)).toBe("SPI_CS");
+  });
+
+  it("should still apply genuine netlister collision renames", () => {
+    // Two unrelated same-named wire groups; the hierarchy carries the
+    // netlister's _<dbObjectId> rename, which no wire group has claimed.
+    const result = run(
+      [
+        [21_000_000, "BUS_CLK", 0],
+        [22_000_000, "BUS_CLK", 1],
+      ],
+      ["BUS_CLK", "BUS_CLK_21859572"]
+    );
+
+    expect(result.get(21_000_000)).toBe("BUS_CLK");
+    expect(result.get(22_000_000)).toBe("BUS_CLK_21859572");
+  });
+
+  it("should skip claimed siblings but still use unclaimed collision suffixes", () => {
+    // Both situations on the same base name: a designer sibling (_01, claimed
+    // by its own wire group) and a netlister rename (_21859572, unclaimed).
+    const result = run(
+      [
+        [21_000_000, "MUX_SEL", 0],
+        [22_000_000, "MUX_SEL", 1],
+        [21_500_000, "MUX_SEL_01", 0],
+      ],
+      ["MUX_SEL", "MUX_SEL_01", "MUX_SEL_21859572"]
+    );
+
+    expect(result.get(21_500_000)).toBe("MUX_SEL_01");
+    expect(result.get(21_000_000)).toBe("MUX_SEL");
+    expect(result.get(22_000_000)).toBe("MUX_SEL_21859572");
+  });
+
+  it("should leave single-page nets untouched", () => {
+    const result = run(
+      [
+        [21_000_000, "LOCAL_EN", 0],
+        [21_100_000, "LOCAL_EN_01", 0],
+      ],
+      ["LOCAL_EN", "LOCAL_EN_01"]
+    );
+
+    expect(result.get(21_000_000)).toBe("LOCAL_EN");
+    expect(result.get(21_100_000)).toBe("LOCAL_EN_01");
+  });
+
+  it("should leave cross-page nets with no hierarchy suffix untouched", () => {
+    const result = run(
+      [
+        [21_000_000, "RESET_N", 0],
+        [22_000_000, "RESET_N", 1],
+      ],
+      ["RESET_N"]
+    );
+
+    expect(result.get(21_000_000)).toBe("RESET_N");
+    expect(result.get(22_000_000)).toBe("RESET_N");
+  });
+});

--- a/src/parsers/cadence/dsn/net-builder.ts
+++ b/src/parsers/cadence/dsn/net-builder.ts
@@ -398,9 +398,26 @@ function collectPins(
  * and the page-local min pin IDs are allocated sequentially, so sorting by
  * either yields the same order.
  *
+ * A candidate is only a collision rename if it clears two gates, because a
+ * designer's own sibling net must never be mistaken for one:
+ *
+ * 1. The suffix must be entirely digits. A dbObjectId always is; `parseInt()`
+ *    alone is too lenient, since it stops at the first non-digit and reads a
+ *    rail-named sibling like `FOO_N_1V8` as suffix 1.
+ * 2. The name must not already be some wire group's resolved name. A collision
+ *    rename exists only in the hierarchy stream — it is never drawn as a wire
+ *    label — so a name a page actually resolved to cannot be one. This is what
+ *    catches an entirely-numeric family like `FOO_N_01/_02/_04`, which clears
+ *    gate 1 on its own.
+ *
+ * Without both, the two-pointer condition `suffix <= minNetId` is trivially
+ * true for such small suffixes, so every page group of the real `FOO_N` gets
+ * renamed into a sibling: the bare net vanishes and its pins are silently
+ * merged into unrelated real nets.
+ *
  * Mutates netIdToName in place to apply suffixed names.
  */
-function disambiguateCrossPageNets(
+export function disambiguateCrossPageNets(
   netIdToName: Map<number, string>,
   netIdGroups: Map<number, PinInfo[]>,
   canonicalNetNames: Set<string>
@@ -423,8 +440,14 @@ function disambiguateCrossPageNets(
     const suffixedHier: { suffix: number; fullName: string }[] = [];
     for (const hierName of canonicalNetNames) {
       if (hierName.startsWith(prefix)) {
-        const num = parseInt(hierName.substring(prefix.length));
-        if (!isNaN(num)) suffixedHier.push({ suffix: num, fullName: hierName });
+        // Claimed by a wire group => designer-authored sibling, not a rename.
+        if (nameToPageGroups.has(hierName)) continue;
+        const rawSuffix = hierName.substring(prefix.length);
+        // A dbObjectId is entirely digits. parseInt() alone is too lenient: it
+        // stops at the first non-digit, so a rail-named sibling like `_1V8`
+        // reads as suffix 1.
+        if (!/^\d+$/.test(rawSuffix)) continue;
+        suffixedHier.push({ suffix: parseInt(rawSuffix), fullName: hierName });
       }
     }
     if (suffixedHier.length === 0) continue;


### PR DESCRIPTION
Fixes #88. Also fixes #85 — same root cause, as @vzegnameta worked out there.

`disambiguateCrossPageNets` accepts a hierarchy name `<net>_<suffix>` as a Cadence
netlister collision rename whenever `parseInt(suffix)` is not `NaN`. Two kinds of real,
designer-authored sibling net clear that test:

- **Rail-suffixed names** — `parseInt` stops at the first non-digit, so `NET_1V8` reads as
  suffix `1`. This is #88.
- **Entirely-numeric families** — `NET_01` / `NET_02` / `NET_04` are numeric by any test,
  including the `/^\d+$/` tightening suggested in #88.

Either way a page group of `<net>` is relabelled onto the sibling, merging two
electrically distinct nets. It is silent: every relabelled segment lands inside an
already-populated net, so ERC finds no stranded residue to flag.

The numeric families are the worse case, because of the second gate. `suffix <= minNetId`
encodes the monotonicity of sequentially-allocated dbObjectIds, but `1`, `2` and `4` are
below every page-local netId, so it is trivially true. With three page groups and three
numeric siblings all three groups get renamed, none keeps the bare name, and **the net
disappears from the model entirely** while its pins scatter into three unrelated nets.

## Fix

Two conditions distinguish a collision rename from a designer's own net, and both are
needed:

1. **The suffix is entirely digits.** A dbObjectId always is. Rejects `_1V8`.
2. **The name is not already some wire group's resolved name.** A collision rename lives
   only in the hierarchy stream and is never drawn as a wire label, so a name a page
   actually resolved to cannot be one. Rejects `_01` / `_02` / `_04`.

Genuine collision renames satisfy both and still apply.

## Testing

Seven synthetic cases in `net-builder.test.ts`: numeric sibling family, rail-suffixed
sibling (claimed and unclaimed), a genuine collision rename that must still be applied,
mixed claimed-plus-unclaimed, single-page early-out, and no-suffix-present. Fixtures use
realistic netId magnitudes, since the whole heuristic rests on dbObjectIds and page netIds
sharing one sequential ID space.

Removing either gate fails tests.

## How this was found

Diffing the direct `.DSN` read against the Cadence netlister's own `pstxnet.dat` for the
same design. On two revisions of a ~5,780-net production board the pass was reassigning
**23 pins across 20 nets per revision**, in three families — one entirely-numeric, two
rail-suffixed — and none of them was visible to ERC. After the fix every one of those nets
matches the `.dat` ground truth. The design is a customer schematic so I can't share it,
but I'm happy to provide sanitized diagnostics.
