### PR TITLE
fix(traversal): make circuit_hash backend-invariant by dropping mpn

### DIFF
--- a/src/circuit-traversal.test.ts
+++ b/src/circuit-traversal.test.ts
@@ -759,9 +759,66 @@ describe("computeCircuitHash", () => {
 
   it("should return different hash for different circuits", () => {
     const circuit1 = [{ refdes: "R1", mpn: "10k", connections: [{ net: "A", pins: ["1"] }] }];
-    const circuit2 = [{ refdes: "R1", mpn: "20k", connections: [{ net: "A", pins: ["1"] }] }];
+    const circuit2 = [{ refdes: "R1", mpn: "10k", connections: [{ net: "B", pins: ["1"] }] }];
 
     expect(computeCircuitHash(circuit1)).not.toBe(computeCircuitHash(circuit2));
+  });
+
+  it("should return different hash when a pin moves to another net", () => {
+    const circuit1 = [{ refdes: "R1", mpn: "10k", connections: [{ net: "A", pins: ["1", "2"] }] }];
+    const circuit2 = [
+      {
+        refdes: "R1",
+        mpn: "10k",
+        connections: [
+          { net: "A", pins: ["1"] },
+          { net: "B", pins: ["2"] },
+        ],
+      },
+    ];
+
+    expect(computeCircuitHash(circuit1)).not.toBe(computeCircuitHash(circuit2));
+  });
+
+  // mpn is backend-dependent -- the .dat path reports a netlister part-name
+  // string, the .DSN path the bare symbol name -- so hashing it made the same
+  // physical circuit mismatch across backends.
+  it("should ignore mpn so the same topology hashes equal across backends", () => {
+    const fromDat = [
+      {
+        refdes: "R1",
+        mpn: "RES_H_R0402_0R/0.05/0402_72E00*",
+        connections: [
+          { net: "A", pins: ["1"] },
+          { net: "B", pins: ["2"] },
+        ],
+      },
+      {
+        refdes: "U1",
+        mpn: "SOME_PART_NUMBER_TRUNCATED_AT_31",
+        connections: [{ net: "B", pins: ["W3"] }],
+      },
+    ];
+    const fromDsn = [
+      {
+        refdes: "R1",
+        mpn: "RES_H",
+        connections: [
+          { net: "A", pins: ["1"] },
+          { net: "B", pins: ["2"] },
+        ],
+      },
+      { refdes: "U1", mpn: "SYMBOL_NAME", connections: [{ net: "B", pins: ["W3"] }] },
+    ];
+
+    expect(computeCircuitHash(fromDat)).toBe(computeCircuitHash(fromDsn));
+  });
+
+  it("should ignore a missing mpn as well", () => {
+    const withMpn = [{ refdes: "R1", mpn: "10k", connections: [{ net: "A", pins: ["1"] }] }];
+    const withoutMpn = [{ refdes: "R1", connections: [{ net: "A", pins: ["1"] }] }];
+
+    expect(computeCircuitHash(withMpn)).toBe(computeCircuitHash(withoutMpn));
   });
 
   it("should return zero hash for empty components", () => {

--- a/src/circuit-traversal.ts
+++ b/src/circuit-traversal.ts
@@ -162,6 +162,15 @@ export const naturalSort = (a: string, b: string): number => {
 /**
  * Compute a stable hash for a circuit.
  * Components with the same XNET produce identical hashes regardless of query starting point.
+ *
+ * The canonical form covers connectivity only (refdes + per-net pin assignments).
+ * Display metadata is deliberately excluded so that the same physical circuit
+ * hashes identically no matter which backend parsed it: `mpn` is a best-effort,
+ * backend-dependent field (the .dat path reports the pstxprt `MFGR_PN` or a
+ * netlister part-name string truncated to 31 chars, while the .DSN path reports
+ * an MPN-ish property or the bare `sourcePackage` symbol name), so hashing it
+ * made every cross-backend comparison of an identical circuit mismatch. `value`
+ * was already excluded for the same reason.
  */
 export const computeCircuitHash = (components: CircuitComponent[]): string => {
   if (!components || components.length === 0) {
@@ -172,7 +181,6 @@ export const computeCircuitHash = (components: CircuitComponent[]): string => {
 
   const canonicalForm = sortedComponents.map((comp) => ({
     refdes: comp.refdes,
-    mpn: comp.mpn,
     connections: comp.connections
       .map((conn) => ({
         pins: [...conn.pins].sort(naturalSort),

--- a/src/parsers/cadence/dsn/dsn-parser.test.ts
+++ b/src/parsers/cadence/dsn/dsn-parser.test.ts
@@ -8,6 +8,7 @@ import { join } from "path";
 import { OleReader } from "../../ole-reader/ole-reader.js";
 import { parseDsnFile } from "./dsn-parser.js";
 import { parseCadence, buildCadencePinMap } from "../index.js";
+import { traverseCircuitFromNet, computeCircuitHash } from "../../../circuit-traversal.js";
 
 const FIXTURE_DIR = join(__dirname, "../../../../test/fixtures/cadence/BeagleBone-Black/ALLEGRO");
 const DSN_FIXTURE = join(FIXTURE_DIR, "BEAGLEBONEBLK_C3.DSN");
@@ -160,5 +161,59 @@ describe.skipIf(!hasDsnFixture || !hasDatFixtures)("DSN vs DAT comparison", () =
 
     // Expect at least 50% component coverage
     expect(coverage).toBeGreaterThan(0.5);
+  });
+
+  // circuit_hash used to fold in the backend-dependent `mpn`, so an XNET that is
+  // pin-for-pin identical on both paths still produced two different hashes.
+  // Any net whose traversal agrees across the two backends must agree on the
+  // hash too.
+  it("should produce backend-invariant circuit hashes for identical XNETs", async () => {
+    const dsnResult = parseDsnFile(DSN_FIXTURE);
+
+    const datRaw = await parseCadence({
+      pstxnetPath: PSTXNET_FIXTURE,
+      pstxprtPath: PSTXPRT_FIXTURE,
+      pstchipPath: PSTCHIP_FIXTURE,
+    });
+    const datComponents = buildCadencePinMap(
+      datRaw.nets,
+      datRaw.components,
+      datRaw.chips,
+      datRaw.partNames
+    );
+
+    const commonNets = Object.keys(datRaw.nets).filter((n) => dsnResult.nets[n]);
+    expect(commonNets.length).toBeGreaterThan(0);
+
+    const describeCircuit = (r: ReturnType<typeof traverseCircuitFromNet>): string =>
+      JSON.stringify(
+        [...r.components]
+          .map((c) => ({
+            refdes: c.refdes,
+            connections: [...c.connections]
+              .map((conn) => ({ net: conn.net, pins: [...conn.pins].sort() }))
+              .sort((a, b) => a.net.localeCompare(b.net)),
+          }))
+          .sort((a, b) => a.refdes.localeCompare(b.refdes))
+      );
+
+    let compared = 0;
+    for (const net of commonNets) {
+      const datCircuit = traverseCircuitFromNet(net, datRaw.nets, datComponents);
+      const dsnCircuit = traverseCircuitFromNet(net, dsnResult.nets, dsnResult.components);
+
+      // Only nets the two backends genuinely agree on are in scope here; net
+      // membership differences are what the coverage tests above measure.
+      if (describeCircuit(datCircuit) !== describeCircuit(dsnCircuit)) continue;
+
+      compared++;
+      expect(
+        computeCircuitHash(dsnCircuit.components),
+        `circuit_hash differs across backends for net ${net}`
+      ).toBe(computeCircuitHash(datCircuit.components));
+    }
+
+    console.log(`\nBackend-invariant hash check: ${compared} identical XNETs compared`);
+    expect(compared).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Fixes #92.

`computeCircuitHash` folds each component's `mpn` into the canonical form, but `mpn` is a
best-effort, backend-dependent display field — `MFGR_PN` or a netlister-truncated part-name
string on the `.dat` path, an MPN-ish property or the bare `sourcePackage` symbol name on
the `.DSN` path. The same physical part is `RES_H_R0402_0R/0.05/0402_72E00*` on one and
`RES_H` on the other, so an XNET that is pin-for-pin identical across both backends hashes
differently.

Hashing connectivity only (`{refdes, connections: [{pins, net}]}`) fixes it. `refdes`, pin
and net all come from the design itself and are stable across backends, which is what the
function's doc comment already promises.

## Testing

A cross-backend regression in `dsn-parser.test.ts`, using the existing `BeagleBone-Black`
fixture (it ships both a `.DSN` and its exported DAT trio): every net whose traversal is
pin-for-pin identical on the two paths must hash identically. **327 XNETs qualify and all
327 now agree.** With `mpn` restored to the canonical form, they all disagree — so the test
is not vacuous.

Plus two unit cases: equal connectivity with differing `mpn` hashes equal, and a missing
`mpn` is equivalent to a present one.

The existing "different hash for different circuits" test varied only `mpn`, encoding the
behaviour being fixed. It now varies connectivity, and a second case covers a pin moving
between nets — so the "different circuits hash differently" property is still covered.

## Compatibility

This changes `circuit_hash` values for existing callers. Nothing in the repo asserts a
specific value, but anyone caching hashes across versions sees a one-time invalidation.
If you would rather keep existing values stable, the alternative in #92 — keep
`circuit_hash` and add a connectivity-only `topology_hash` — is a small change to make
instead; say the word and I'll switch the PR over.
