### PR TITLE
feat(coverage): compare per-net connectivity, not just net names + v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-08-05
+
+### Fixed
+
+- Cadence DSN cross-page net disambiguation no longer merges designer-authored sibling nets into one. A hierarchy name `<net>_<suffix>` is treated as a netlister collision rename only when the suffix is entirely digits and the name is not already some wire group's resolved name. Previously `parseInt()` stopped at the first non-digit, so a rail-suffixed sibling like `SIGNAL_1V8` read as suffix `1`, and an entirely-numeric family like `SIGNAL_01`/`_02` cleared the digit test outright; either way the bare net's pins were silently absorbed into unrelated nets (#85, #88)
+- XNET traversal stops at power rails whose names the stop-net regex did not recognize. `PVCC*`, `PVNN*`, and `P<n>V*` join the rail alternatives, `NC` is aligned with the existing query-xnet special case, and a configurable pin-count guard (`TraversalOptions.stopNetPinThreshold`, default 40) stops expansion at structurally rail-shaped nets regardless of name. An explicitly queried rail still expands. Previously every pull-up on such a rail acted as a pass-through and traversal fused much of the board into one false supernet (#84)
+- `circuit_hash` is now backend-invariant. The canonical form hashes connectivity only (`refdes`, pins, net) and no longer folds in `mpn`, which is a best-effort field populated differently by the `.dat` and `.DSN` paths, so an XNET that is pin-for-pin identical across backends hashed differently. Agreement between the two backends across the Cadence fixture corpus rises from 6.8% to 94.6% (#92)
+- Design discovery and test collection skip macOS AppleDouble (`._*`) sidecars. On network volumes these shadow every file, so `._board.DSN` surfaced in `list_designs` as a phantom design that failed to parse
+
+### Added
+
+- The DSN-vs-DAT coverage report gains a `Conn` column comparing the actual `{refdes.pin}` set of every net present in both netlists. Net and component coverage match on names alone, so a net that kept its name but lost pins to another net scored as fully covered; connectivity agreement is what a wrong-connectivity bug actually moves
+
 ## [1.4.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -35,9 +35,11 @@ npx tsx scripts/dsn-coverage-report.ts                    # All fixtures, summar
 npx tsx scripts/dsn-coverage-report.ts BEAGLEBONEBLK_C3   # Single fixture, verbose breakdown
 ```
 
-Summary mode prints a table with net/component coverage and field-level parity (Value, PinNum, PinName, MPN) for each fixture. The MPN column shows `hasDsn/total` since DSN extracts real part numbers while DAT golden uses composite format, so exact match is not meaningful.
+Summary mode prints a table with net/component coverage, per-net connectivity agreement, and field-level parity (Value, PinNum, PinName, MPN) for each fixture. The MPN column shows `hasDsn/total` since DSN extracts real part numbers while DAT golden uses composite format, so exact match is not meaningful.
 
-Single-fixture (verbose) mode adds field mismatch examples, missing nets grouped by category (auto-generated, named, no-connect, bus-range), and extra nets.
+The `Nets` and `Comps` columns match on names, so a net that survives with the wrong pins on it still scores as covered. The `Conn` column is the one that catches that: for every net present in both netlists it compares the actual `{refdes.pin}` set, which is what a wrong-connectivity bug moves. A design reading `Nets 100%` / `Conn 82.7%` has every expected net present and pins on the wrong ones.
+
+Single-fixture (verbose) mode adds the differing nets with their reference-only and dsn-only pins, field mismatch examples, missing nets grouped by category (auto-generated, named, no-connect, bus-range), and extra nets.
 
 Aggregate stats at the bottom show totals across all fixtures.
 

--- a/src/dsn-vs-dat-coverage.test.ts
+++ b/src/dsn-vs-dat-coverage.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { analyzeCoverage, formatCoverageReport } from "./dsn-vs-dat-coverage.js";
+import type { ParsedNetlist } from "./types.js";
+
+const netlist = (nets: Record<string, Record<string, string[]>>): ParsedNetlist => ({
+  nets,
+  components: {},
+});
+
+describe("connectivity comparison", () => {
+  it("counts a net whose pin set is identical as exact", () => {
+    const reference = netlist({ SIGNAL: { R1: ["1"], U1: ["A5"] } });
+    const dsn = netlist({ SIGNAL: { U1: ["A5"], R1: ["1"] } });
+
+    const result = analyzeCoverage("identical", dsn, reference);
+
+    expect(result.connectivity.common).toBe(1);
+    expect(result.connectivity.exact).toBe(1);
+    expect(result.connectivity.differing).toBe(0);
+    expect(result.connectivity.mismatches).toEqual([]);
+  });
+
+  it("flags a net that kept its name but lost a pin to another net", () => {
+    const reference = netlist({
+      SIGNAL: { R1: ["1"], U1: ["A5"] },
+      SIGNAL_1V8: { U2: ["B7"] },
+    });
+    const dsn = netlist({
+      SIGNAL: { R1: ["1"] },
+      SIGNAL_1V8: { U2: ["B7"], U1: ["A5"] },
+    });
+
+    const result = analyzeCoverage("stolen-pin", dsn, reference);
+
+    expect(result.netCoverage).toBe(1);
+    expect(result.connectivity.exact).toBe(0);
+    expect(result.connectivity.differing).toBe(2);
+    expect(result.connectivity.mismatches).toContainEqual({
+      net: "SIGNAL",
+      referenceOnly: ["U1.A5"],
+      dsnOnly: [],
+    });
+    expect(result.connectivity.mismatches).toContainEqual({
+      net: "SIGNAL_1V8",
+      referenceOnly: [],
+      dsnOnly: ["U1.A5"],
+    });
+  });
+
+  it("flags a transposed pin number on an otherwise correct net", () => {
+    const reference = netlist({ DVI_DATA9: { RP3: ["13"] } });
+    const dsn = netlist({ DVI_DATA9: { RP3: ["12"] } });
+
+    const result = analyzeCoverage("transposed", dsn, reference);
+
+    expect(result.connectivity.differing).toBe(1);
+    expect(result.connectivity.mismatches[0]).toEqual({
+      net: "DVI_DATA9",
+      referenceOnly: ["RP3.13"],
+      dsnOnly: ["RP3.12"],
+    });
+  });
+
+  it("reports full agreement when name coverage and connectivity both hold", () => {
+    const reference = netlist({ A: { R1: ["1"] }, B: { R2: ["2"] } });
+    const dsn = netlist({ A: { R1: ["1"] }, B: { R2: ["2"] } });
+
+    const result = analyzeCoverage("clean", dsn, reference);
+
+    expect(result.connectivity.exact).toBe(2);
+    expect(result.connectivity.differing).toBe(0);
+  });
+
+  it("only compares nets present in both netlists", () => {
+    const reference = netlist({ A: { R1: ["1"] }, ONLY_IN_REF: { R9: ["9"] } });
+    const dsn = netlist({ A: { R1: ["1"] }, ONLY_IN_DSN: { R8: ["8"] } });
+
+    const result = analyzeCoverage("disjoint", dsn, reference);
+
+    expect(result.connectivity.common).toBe(1);
+    expect(result.connectivity.exact).toBe(1);
+  });
+
+  it("caps stored mismatch examples but keeps the full differing count", () => {
+    const nets: Record<string, Record<string, string[]>> = {};
+    const wrong: Record<string, Record<string, string[]>> = {};
+    for (let i = 0; i < 30; i++) {
+      nets[`NET${i}`] = { R1: ["1"] };
+      wrong[`NET${i}`] = { R1: ["2"] };
+    }
+
+    const result = analyzeCoverage("many", netlist(wrong), netlist(nets));
+
+    expect(result.connectivity.differing).toBe(30);
+    expect(result.connectivity.mismatches).toHaveLength(20);
+  });
+
+  it("surfaces a Conn column and aggregate line in the report", () => {
+    const reference = netlist({ A: { R1: ["1"] }, B: { R2: ["2"] } });
+    const dsn = netlist({ A: { R1: ["1"] }, B: { R2: ["9"] } });
+
+    const results = [
+      analyzeCoverage("one", dsn, reference),
+      analyzeCoverage("two", dsn, reference),
+    ];
+    const report = formatCoverageReport(results);
+
+    expect(report).toContain("Conn");
+    expect(report).toContain("Conn:    2/4");
+    expect(report).toContain("2 nets with differing pin sets");
+  });
+});

--- a/src/dsn-vs-dat-coverage.test.ts
+++ b/src/dsn-vs-dat-coverage.test.ts
@@ -81,7 +81,7 @@ describe("connectivity comparison", () => {
     expect(result.connectivity.exact).toBe(1);
   });
 
-  it("caps stored mismatch examples but keeps the full differing count", () => {
+  it("stores every mismatch and truncates only at render time", () => {
     const nets: Record<string, Record<string, string[]>> = {};
     const wrong: Record<string, Record<string, string[]>> = {};
     for (let i = 0; i < 30; i++) {
@@ -92,7 +92,29 @@ describe("connectivity comparison", () => {
     const result = analyzeCoverage("many", netlist(wrong), netlist(nets));
 
     expect(result.connectivity.differing).toBe(30);
-    expect(result.connectivity.mismatches).toHaveLength(20);
+    expect(result.connectivity.mismatches).toHaveLength(30);
+
+    const truncated = formatCoverageReport([result], { verbose: true, truncate: true });
+    expect(truncated).toContain("... and 20 more");
+
+    const full = formatCoverageReport([result], { verbose: true, truncate: false });
+    expect(full).not.toContain("more");
+    expect(full).toContain("NET29");
+  });
+
+  it("includes the connectivity detail in the persisted markdown report", () => {
+    const reference = netlist({ DVI_DATA9: { RP3: ["13"] } });
+    const dsn = netlist({ DVI_DATA9: { RP3: ["12"] } });
+
+    const report = formatCoverageReport([analyzeCoverage("md", dsn, reference)], {
+      verbose: true,
+      truncate: false,
+      markdown: true,
+    });
+
+    expect(report).toContain("### Connectivity:");
+    expect(report).toContain("| Net | Reference-only pins | DSN-only pins |");
+    expect(report).toContain("| DVI_DATA9 | RP3.13 | RP3.12 |");
   });
 
   it("surfaces a Conn column and aggregate line in the report", () => {

--- a/src/dsn-vs-dat-coverage.ts
+++ b/src/dsn-vs-dat-coverage.ts
@@ -25,12 +25,28 @@ export interface FieldStats {
   mismatches: string[];
 }
 
+/**
+ * Per-net connectivity agreement on nets present in both netlists.
+ *
+ * Net and component coverage match on names alone, so a net that survives with
+ * the wrong pins on it scores as covered. This metric compares the actual
+ * {refdes.pin} set of every common net, which is what a wrong-connectivity bug
+ * moves.
+ */
+export interface ConnectivityStats {
+  common: number;
+  exact: number;
+  differing: number;
+  mismatches: { net: string; referenceOnly: string[]; dsnOnly: string[] }[];
+}
+
 export interface CoverageResult {
   projectName: string;
   goldenNetCount: number;
   dsnNetCount: number;
   commonNets: number;
   netCoverage: number;
+  connectivity: ConnectivityStats;
   goldenCompCount: number;
   dsnCompCount: number;
   commonComps: number;
@@ -56,6 +72,49 @@ const getPinName = (entry: PinEntry): string | undefined =>
 
 export const pct = (n: number, d: number): string =>
   d > 0 ? ((n / d) * 100).toFixed(1) + "%" : "N/A";
+
+const pinRefs = (connections: Record<string, string[]> | undefined): Set<string> => {
+  const refs = new Set<string>();
+  for (const [refdes, pins] of Object.entries(connections ?? {})) {
+    for (const pin of pins) refs.add(`${refdes}.${pin}`);
+  }
+  return refs;
+};
+
+const pinSetSignature = (connections: Record<string, string[]> | undefined): string =>
+  [...pinRefs(connections)].sort().join(",");
+
+const compareConnectivity = (
+  commonNets: string[],
+  dsn: ParsedNetlist,
+  reference: ParsedNetlist,
+  mismatchLimit = 20
+): ConnectivityStats => {
+  const stats: ConnectivityStats = { common: commonNets.length, exact: 0, differing: 0, mismatches: [] };
+
+  for (const net of commonNets) {
+    const referenceRefs = pinRefs(reference.nets[net]);
+    const dsnRefs = pinRefs(dsn.nets[net]);
+    const same =
+      referenceRefs.size === dsnRefs.size && [...referenceRefs].every((ref) => dsnRefs.has(ref));
+
+    if (same) {
+      stats.exact++;
+      continue;
+    }
+
+    stats.differing++;
+    if (stats.mismatches.length < mismatchLimit) {
+      stats.mismatches.push({
+        net,
+        referenceOnly: [...referenceRefs].filter((ref) => !dsnRefs.has(ref)).sort(),
+        dsnOnly: [...dsnRefs].filter((ref) => !referenceRefs.has(ref)).sort(),
+      });
+    }
+  }
+
+  return stats;
+};
 
 // ---------------------------------------------------------------------------
 // Analysis
@@ -97,14 +156,6 @@ export const analyzeCoverage = (
   // Second pass: match unmatched nets by connectivity (pin-set signature).
   // Handles whitespace-renamed nets: DSN preserves " SIGNAL_A" while DAT
   // strips to "SIGNAL_A" or appends "_1" on collision.
-  const pinSetSignature = (connections: Record<string, string[]>): string => {
-    const pairs: string[] = [];
-    for (const [refdes, pins] of Object.entries(connections)) {
-      for (const pin of pins) pairs.push(`${refdes}.${pin}`);
-    }
-    return pairs.sort().join(",");
-  };
-
   let renamedNets = 0;
   if (missingNets.length > 0 && extraNets.length > 0) {
     const extraBySignature = new Map<string, string>();
@@ -231,6 +282,7 @@ export const analyzeCoverage = (
     dsnNetCount: dsnNets.size,
     commonNets: commonNets.length,
     netCoverage: refNets.size > 0 ? commonNets.length / refNets.size : 1,
+    connectivity: compareConnectivity(commonNets, dsn, reference),
     goldenCompCount: refComps.size,
     dsnCompCount: dsnComps.size,
     commonComps: commonCompKeys.length,
@@ -263,6 +315,23 @@ const formatVerboseDesignTerminal = (
   lines.push("=".repeat(80));
   lines.push(r.projectName);
   lines.push("=".repeat(80));
+
+  lines.push("");
+  lines.push(
+    `Connectivity: ${r.connectivity.exact}/${r.connectivity.common} common nets have identical pin sets (${pct(r.connectivity.exact, r.connectivity.common)})`
+  );
+  for (const mismatch of r.connectivity.mismatches) {
+    lines.push(`  ${mismatch.net}`);
+    if (mismatch.referenceOnly.length > 0) {
+      lines.push(`    reference-only: ${mismatch.referenceOnly.join(" ")}`);
+    }
+    if (mismatch.dsnOnly.length > 0) {
+      lines.push(`    dsn-only:       ${mismatch.dsnOnly.join(" ")}`);
+    }
+  }
+  if (r.connectivity.differing > r.connectivity.mismatches.length) {
+    lines.push(`  ... and ${r.connectivity.differing - r.connectivity.mismatches.length} more`);
+  }
 
   lines.push("");
   lines.push("Field coverage:");
@@ -462,6 +531,12 @@ const formatAggregateTerminal = (results: CoverageResult[], lines: string[]): vo
     )})`
   );
   lines.push(
+    `Conn:    ${sum((r) => r.connectivity.exact)}/${sum((r) => r.connectivity.common)} (${pct(
+      sum((r) => r.connectivity.exact),
+      sum((r) => r.connectivity.common)
+    )}) [${sum((r) => r.connectivity.differing)} nets with differing pin sets]`
+  );
+  lines.push(
     `Comps:   ${sum((r) => r.commonComps)}/${sum((r) => r.goldenCompCount)} (${pct(
       sum((r) => r.commonComps),
       sum((r) => r.goldenCompCount)
@@ -638,7 +713,7 @@ export const formatCoverageReport = (
 
   if (markdown) {
     // Pipe-delimited markdown table
-    const cols = ["Design", "Nets", "Comps", "Value", "MPN"];
+    const cols = ["Design", "Nets", "Conn", "Comps", "Value", "MPN"];
     if (hasDesc) cols.push("Desc");
     if (hasComment) cols.push("Comment");
     if (hasDns) cols.push("DNS");
@@ -651,6 +726,7 @@ export const formatCoverageReport = (
       const cells = [
         r.projectName,
         pct(r.commonNets, r.goldenNetCount),
+        pct(r.connectivity.exact, r.connectivity.common),
         pct(r.commonComps, r.goldenCompCount),
         pct(r.value.match, r.value.total),
         pct(r.mpn.match, r.mpn.total),
@@ -664,7 +740,12 @@ export const formatCoverageReport = (
   } else {
     // Padded plain-text table for terminal
     let header =
-      pad("Design", 50) + pad("Nets", 8) + pad("Comps", 8) + pad("Value", 8) + pad("MPN", 8);
+      pad("Design", 50) +
+      pad("Nets", 8) +
+      pad("Conn", 8) +
+      pad("Comps", 8) +
+      pad("Value", 8) +
+      pad("MPN", 8);
     if (hasDesc) header += pad("Desc", 8);
     if (hasComment) header += pad("Comment", 8);
     if (hasDns) header += pad("DNS", 8);
@@ -676,6 +757,7 @@ export const formatCoverageReport = (
       let row =
         pad(r.projectName, 50) +
         pad(pct(r.commonNets, r.goldenNetCount), 8) +
+        pad(pct(r.connectivity.exact, r.connectivity.common), 8) +
         pad(pct(r.commonComps, r.goldenCompCount), 8) +
         pad(pct(r.value.match, r.value.total), 8) +
         pad(pct(r.mpn.match, r.mpn.total), 8);

--- a/src/dsn-vs-dat-coverage.ts
+++ b/src/dsn-vs-dat-coverage.ts
@@ -87,8 +87,7 @@ const pinSetSignature = (connections: Record<string, string[]> | undefined): str
 const compareConnectivity = (
   commonNets: string[],
   dsn: ParsedNetlist,
-  reference: ParsedNetlist,
-  mismatchLimit = 20
+  reference: ParsedNetlist
 ): ConnectivityStats => {
   const stats: ConnectivityStats = { common: commonNets.length, exact: 0, differing: 0, mismatches: [] };
 
@@ -104,13 +103,11 @@ const compareConnectivity = (
     }
 
     stats.differing++;
-    if (stats.mismatches.length < mismatchLimit) {
-      stats.mismatches.push({
-        net,
-        referenceOnly: [...referenceRefs].filter((ref) => !dsnRefs.has(ref)).sort(),
-        dsnOnly: [...dsnRefs].filter((ref) => !referenceRefs.has(ref)).sort(),
-      });
-    }
+    stats.mismatches.push({
+      net,
+      referenceOnly: [...referenceRefs].filter((ref) => !dsnRefs.has(ref)).sort(),
+      dsnOnly: [...dsnRefs].filter((ref) => !referenceRefs.has(ref)).sort(),
+    });
   }
 
   return stats;
@@ -320,7 +317,8 @@ const formatVerboseDesignTerminal = (
   lines.push(
     `Connectivity: ${r.connectivity.exact}/${r.connectivity.common} common nets have identical pin sets (${pct(r.connectivity.exact, r.connectivity.common)})`
   );
-  for (const mismatch of r.connectivity.mismatches) {
+  const connLimit = truncate ? 10 : r.connectivity.mismatches.length;
+  for (const mismatch of r.connectivity.mismatches.slice(0, connLimit)) {
     lines.push(`  ${mismatch.net}`);
     if (mismatch.referenceOnly.length > 0) {
       lines.push(`    reference-only: ${mismatch.referenceOnly.join(" ")}`);
@@ -329,8 +327,8 @@ const formatVerboseDesignTerminal = (
       lines.push(`    dsn-only:       ${mismatch.dsnOnly.join(" ")}`);
     }
   }
-  if (r.connectivity.differing > r.connectivity.mismatches.length) {
-    lines.push(`  ... and ${r.connectivity.differing - r.connectivity.mismatches.length} more`);
+  if (r.connectivity.mismatches.length > connLimit) {
+    lines.push(`  ... and ${r.connectivity.mismatches.length - connLimit} more`);
   }
 
   lines.push("");
@@ -453,6 +451,25 @@ const formatVerboseDesignMarkdown = (
   lines.push("| --- | ---: | ---: | ---: | --- |");
   for (const [field, match, total, notes] of fieldRows) {
     lines.push(`| ${field} | ${match} | ${total} | ${pct(match, total)} | ${notes} |`);
+  }
+
+  lines.push("");
+  lines.push(
+    `### Connectivity: ${r.connectivity.exact}/${r.connectivity.common} common nets have identical pin sets (${pct(r.connectivity.exact, r.connectivity.common)})`
+  );
+  if (r.connectivity.mismatches.length > 0) {
+    lines.push("");
+    lines.push("| Net | Reference-only pins | DSN-only pins |");
+    lines.push("| --- | --- | --- |");
+    const connLimit = truncate ? 10 : r.connectivity.mismatches.length;
+    for (const mismatch of r.connectivity.mismatches.slice(0, connLimit)) {
+      lines.push(
+        `| ${mismatch.net} | ${mismatch.referenceOnly.join(" ") || "-"} | ${mismatch.dsnOnly.join(" ") || "-"} |`
+      );
+    }
+    if (r.connectivity.mismatches.length > connLimit) {
+      lines.push(`| ... and ${r.connectivity.mismatches.length - connLimit} more | | |`);
+    }
   }
 
   const formatMismatches = (label: string, items: string[]) => {


### PR DESCRIPTION
## Summary

Net and component coverage match on **names alone**, so a net that survives with the wrong pins on it scores as fully covered. Every Cadence fixture reported `Nets 100%` while 171 of 4936 common nets carried a different `{refdes.pin}` set than the DAT reference — the exact signature of the wrong-connectivity bugs this parser keeps hitting (#84, #85, #88, #89).

- Adds a `Conn` column and aggregate line comparing the real pin set of every net present in both netlists, with the differing nets and their reference-only / dsn-only pins listed in verbose mode.
- Adds `src/dsn-vs-dat-coverage.test.ts` (7 tests) pinning the metric: identical sets, a pin stolen by a sibling net, a transposed pin number, disjoint nets, and the mismatch-example cap.
- Carries the v1.5.0 changelog for the four fixes merged today (#85/#88, #84, #92, AppleDouble) and the version bump.

## What it exposes

Measured across all 11 paired Cadence fixtures, before and after today's merges:

| | before | after |
|---|---|---|
| Nets (names) | 100.0% | 100.0% |
| **Conn (pin sets)** | **96.5%** (171 differ) | **98.4%** (79 differ) |

`BeagleBoard-xM` still reads `Nets 100%` / `Conn 83.7%`. The remaining 79 are dominated by resistor-pack pin transpositions (`RP3.13` vs `RP3.12`), which is #89 — real, reproducible on the fixture corpus, and not yet fixed.

## Test plan

- [x] `npx vitest run` — 594 passed, 6 skipped (`test/otel/e2e.test.ts` fails locally only, `listen EPERM` from the sandbox blocking its OTLP socket; passes in CI)
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `bun scripts/dsn-coverage-report.ts` against all 11 paired fixtures