### PR TITLE
ci: run build on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for the merge queue: a queued PR is built on a temporary
+  # `gh-readonly-queue/...` ref that fires `merge_group`, not `pull_request`.
+  # Without this the required `build` check never reports and every entry is
+  # ejected on timeout.
+  merge_group:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Prerequisite for turning on the merge queue. Must land **before** the queue is enabled.

A queued PR is not built on its own branch — GitHub creates a temporary `gh-readonly-queue/main/pr-N-<sha>` ref containing the PR merged onto the current queue head, and that fires a **`merge_group`** event, not `pull_request`. `ci.yml` only listened for `push` and `pull_request`, so with a queue enabled the required `build` check would never report on any queue entry. Every PR would sit in the queue until `check_response_timeout_minutes` elapsed and then be ejected — the repo would look like it had silently stopped merging.

## Test plan

- [x] `js-yaml` parses the workflow
- [ ] `build` reports on this PR via `pull_request` (unchanged behaviour)
- [ ] After the queue is enabled, `build` reports on the `merge_group` event for the first queued PR

## Rollout order

1. **This PR** — merge normally, queue still off
2. Add the `merge_queue` rule to the `main-protection` ruleset and turn off `strict_required_status_checks_policy` (redundant with a queue, and the two fight each other)
3. Merge an ordinary PR through the queue to confirm end to end