### PR TITLE
docs: maintainer owns the changelog and version bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,14 +50,20 @@ npm run type-check && npm run lint && npm test
 
 ### Releasing
 
-Include version bump and changelog in the feature PR itself (no separate release PR):
+The maintainer owns `CHANGELOG.md` and the version bump. Feature PRs carry code and
+tests only; they must NOT edit `CHANGELOG.md` or `package.json`.
 
-1. Before pushing your feature branch, add the release commits:
-   - Update `CHANGELOG.md` with new version section
-   - `git commit -am "Add vX.Y.Z changelog"`
-   - `npm version patch --no-git-tag-version` (bumps `package.json` only, no tag)
-   - `git commit -am "vX.Y.Z"`
-2. Push branch and open PR as usual
+Both files append at the top, so a bump in every feature PR makes each concurrent PR
+conflict with the last, and a contributor cannot know whether their change is a patch or
+a minor. Instead a PR describes its user-visible effect in a `## Changelog` section of the
+PR body, and the maintainer collects those into one release PR.
+
+1. Cut a release PR from `main` after the fixes for the release have merged:
+   - Update `CHANGELOG.md` with a new version section, written from the merged PRs' own
+     Changelog sections
+   - `npm version minor|patch --no-git-tag-version` (bumps `package.json` only, no tag)
+   - One commit, e.g. `chore: vX.Y.Z changelog`
+2. Open it as a normal PR and let the merge queue land it
 3. After merge, tag the merge commit and push:
 
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,10 +117,17 @@ npm test              # Unit tests
    - Link any related issues
    - Describe what you changed and why
 
-5. **Code Review:**
+5. **Do not edit `CHANGELOG.md` or `package.json`:**
+   Release notes and version bumps are the maintainer's, collected into a separate release
+   PR. Both files append at the top, so editing them in a feature PR conflicts with every
+   other open PR. Instead, add a short `## Changelog` section to your PR description saying
+   what changes for a user — that text is what ends up in the release notes.
+
+6. **Code Review:**
    - Respond to feedback
    - Make requested changes
-   - Keep the PR updated with main
+   - A merge queue lands merged PRs, so you do not need to keep your branch up to date
+     with `main` yourself
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

Records the decision that `CHANGELOG.md` and the version bump belong to the maintainer, not to feature PRs.

The old rule ("include version bump and changelog in the feature PR itself") works for solo development and breaks with concurrent contributions: both files append at the top, so every second PR conflicts by construction, and an outside contributor cannot know whether their change is a patch or a minor. In practice it was already not being followed — none of the four contributor PRs merged for v1.5.0 carried either, while one maintainer PR did, and they would have produced four conflicting bumps.

- `CLAUDE.md`: release section now describes a release PR cut from `main` after the fixes land, landed via the merge queue.
- `CONTRIBUTING.md`: contributors are told not to touch either file, and to put a `## Changelog` section in the PR description instead — that text becomes the release note.
- Also notes that the merge queue keeps branches current, so contributors no longer need to update their branch against `main`.

## Changelog

None — documentation only, no user-visible change.

## Test plan

- [x] Documentation only; no code paths touched
- [ ] Lands through the merge queue (also a check that the queue works with `min_entries_to_merge_wait_minutes: 0`)