### PR TITLE
fix(dsn): decode the PlacedInstance section index (fixes #89)

### DIFF
--- a/docs/dsn-format.md
+++ b/docs/dsn-format.md
@@ -444,13 +444,26 @@ BODY:
               T0x10[] sub-records (pin instances)
     -- checkpoint --
     string    source_package   # package name for pin map lookup
-    2 bytes   unknown
+    uint16    section_index    # 0-based section within a multi-section package
     -- checkpoint --
 ```
 
-**VERIFIED** fields: `pkg_name`, `db_id`, `loc_x`, `loc_y`, `reference`, `part_value_idx`, `source_package`, `t0x10s`, prefix properties.
+**VERIFIED** fields: `pkg_name`, `db_id`, `loc_x`, `loc_y`, `reference`, `part_value_idx`, `source_package`, `section_index`, `t0x10s`, prefix properties.
 
-**UNKNOWN**: The 8 bytes at offset +0x00, the 8 bytes after `db_id`, the 4 bytes before `len_symbol_display_props` (includes rotation/mirror per the reference photos, but we don't extract them), the 1 byte after SDPs, and the 10 bytes after `part_value_idx`.
+**UNKNOWN**: The 8 bytes at offset +0x00, the 8 bytes after `db_id` (a symbol bounding box: four int16 as x1, y1, x2, y2), the 4 bytes before `len_symbol_display_props` (includes rotation/mirror per the reference photos, but we don't extract them), the 1 byte after SDPs, and the 10 bytes after `part_value_idx`.
+
+##### section_index
+
+The `uint16` following `source_package` is the instance's 0-based section within a
+multi-section package. A single-section part carries `0`; the eight sections of a
+`RPAK_10_8RES` resistor pack carry `0`–`7`; a dual transistor carries `0` and `1`.
+
+The OpenOrCadParser reference treats these two bytes as unknown padding
+(`printUnknownData(2, ...)` at the end of `StructPlacedInstance::read`). The field was
+identified here by dumping every discarded byte block for the eight `RP3` instances of
+`BeagleBoard-xM_ORCAD` and correlating against the section order derived independently
+from that design's `pstxnet.dat` export: the field reads `0,1,2,...,7` in exactly that
+order. Verified across the Cadence fixture corpus — see section 11.2.
 
 #### User property resolution (MPN, Value)
 
@@ -902,18 +915,15 @@ Cache LibraryPart names include a numeric suffix from the Package stream they or
 
 For multi-unit matching, `pkgName` format is `{sourcePackage}{unitLetter}.Normal` (e.g., `OMAP_CBP_1AA.Normal`). Cadence sometimes doubles the unit letter ("AA"), but the Device `unitRef` uses a single letter ("A").
 
-#### Positional device assignment (strategy 3)
+#### Section-based device assignment (strategy 3)
 
-Multi-section components like resistor packs (e.g., RP1 with package `RPAK_10_8RES`, 8 sections, 16 physical pins) have multiple PlacedInstances sharing the same `(refdes, pkgName)` with no unit suffix in `pkgName`. When `extractUnitRef()` returns `undefined` for a group of >1 instances, Cadence assigns Devices **positionally by `dbId` order**.
+Multi-section components like resistor packs (e.g., RP1 with package `RPAK_10_8RES`, 8 sections, 16 physical pins) have multiple PlacedInstances sharing the same `(refdes, pkgName)` with no unit suffix in `pkgName`. Each such instance names its own Device through `PlacedInstance.section_index` (section 7.7).
 
-The parser builds a `deviceIndexMap` (`Map<dbId, index>`) by:
-1. Grouping PlacedInstances by `(reference, pkgName)` across all pages
-2. Skipping instances where `extractUnitRef()` returns a value (already distinguished)
-3. For groups with >1 instance: sorting by `dbId` ascending, assigning 0-based positional index
+The parser builds a `deviceIndexMap` (`Map<dbId, sectionIndex>`) over every instance whose `extractUnitRef()` returns `undefined`; instances with a unit suffix resolve by that suffix instead. A parallel `deviceUnitRefs` map (`Map<pkgBaseName, unitRef[]>`) stores the ordered Device unit reference letters from Package structures, and `findPinMap` selects the Device with `pinMaps.get(base + unitRefs[sectionIndex])`.
 
-A parallel `deviceUnitRefs` map (`Map<pkgBaseName, unitRef[]>`) stores the ordered Device unit reference letters from Package structures. During `findPinMap`, the positional index selects the correct Device: `pinMaps.get(base + unitRefs[deviceIndex])`.
+This replaced an earlier heuristic that sorted each `(refdes, pkgName)` group by `dbId` and assigned positional indices. `dbId` order is *not* section order: on `BeagleBoard-xM_ORCAD` the eight `RP3` sections are allocated with adjacent pairs transposed, so six of its sixteen pins attached to the wrong nets. Because the nets and the pin numbers were each individually valid, net and component coverage stayed at 100% and `verify-pin-numbers.ts` reported 100% — only a per-net `{refdes.pin}` comparison against the DAT export exposed it.
 
-This resolved the primary PinNum gap for BeagleBoard-xM (RP1-RP7 resistor packs, Q1-Q2 transistor arrays).
+Measured over the Cadence fixture corpus, nets whose pin set disagrees with the DAT reference fell from **79 to 24** (98.4% → 99.5%), with no design regressing. Geometric orderings were tested as alternatives to `dbId` and every one was worse (`locY` 81, `locX` 103, descending variants 131 and 139).
 
 ### 11.4 Net Name Resolution
 

--- a/src/parsers/cadence/dsn/pin-resolver.test.ts
+++ b/src/parsers/cadence/dsn/pin-resolver.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { resolvePinNumber, findPinMap, extractUnitRef } from "./pin-resolver.js";
+import {
+  resolvePinNumber,
+  findPinMap,
+  extractUnitRef,
+  buildDeviceIndexMap,
+} from "./pin-resolver.js";
 import type { PinMapData } from "./structure-types.js";
 import type { PlacedInstance, T0x10 } from "./structures.js";
+import type { PageData } from "./page-parser.js";
 
 const pin = (pinIndex: number): T0x10 => ({
   pinIndex,
@@ -22,6 +28,7 @@ const instance = (sourcePackage: string, pinCount: number, pkgName?: string): Pl
   locY: 0,
   symbolDisplayProps: [],
   t0x10s: Array.from({ length: pinCount }, (_, i) => pin(i + 1)),
+  sectionIndex: 0,
 });
 
 const pinMapData = (
@@ -106,6 +113,74 @@ describe("findPinMap", () => {
     const unitRefs = new Map<string, string[]>([["RPAK", ["A", "B"]]]);
 
     expect(findPinMap(inst, maps, unitRefs, 1)).toEqual(["2", "15"]);
+  });
+});
+
+describe("buildDeviceIndexMap", () => {
+  const placed = (
+    reference: string,
+    dbId: number,
+    sectionIndex: number,
+    pkgName?: string
+  ): PlacedInstance => ({
+    ...instance("RPAK_8RES", 2, pkgName),
+    reference,
+    dbId,
+    sectionIndex,
+  });
+
+  const page = (placedInstances: PlacedInstance[]): PageData =>
+    ({
+      name: "P1",
+      netTable: new Map(),
+      wires: [],
+      placedInstances,
+      ports: [],
+      globals: [],
+      offPageConnectors: [],
+    }) as PageData;
+
+  it("indexes each instance by its own section, not by dbId order", () => {
+    // dbId order and section order disagree: the sections were placed on the
+    // sheet in an order Cadence did not allocate dbIds in.
+    const map = buildDeviceIndexMap([
+      page([placed("RP3", 100, 0), placed("RP3", 108, 2), placed("RP3", 116, 1)]),
+    ]);
+
+    expect(map.get(100)).toBe(0);
+    expect(map.get(108)).toBe(2);
+    expect(map.get(116)).toBe(1);
+  });
+
+  it("indexes a lone placed section by its real section, not zero", () => {
+    const map = buildDeviceIndexMap([page([placed("RP9", 200, 5)])]);
+
+    expect(map.get(200)).toBe(5);
+  });
+
+  it("spans pages for one multi-section part", () => {
+    const map = buildDeviceIndexMap([
+      page([placed("RP1", 300, 0)]),
+      page([placed("RP1", 301, 3)]),
+    ]);
+
+    expect(map.get(300)).toBe(0);
+    expect(map.get(301)).toBe(3);
+  });
+
+  it("skips instances whose pkgName already carries a unit suffix", () => {
+    const map = buildDeviceIndexMap([
+      page([placed("U4", 400, 1, "RPAK_8RESB.Normal"), placed("U5", 401, 0)]),
+    ]);
+
+    expect(map.has(400)).toBe(false);
+    expect(map.get(401)).toBe(0);
+  });
+
+  it("skips instances without a usable refdes", () => {
+    const map = buildDeviceIndexMap([page([placed("", 500, 1), placed("?", 501, 1)])]);
+
+    expect(map.size).toBe(0);
   });
 });
 

--- a/src/parsers/cadence/dsn/pin-resolver.test.ts
+++ b/src/parsers/cadence/dsn/pin-resolver.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { resolvePinNumber, findPinMap, extractUnitRef } from "./pin-resolver.js";
+import type { PinMapData } from "./structure-types.js";
+import type { PlacedInstance, T0x10 } from "./structures.js";
+
+const pin = (pinIndex: number): T0x10 => ({
+  pinIndex,
+  pointX: 0,
+  pointY: 0,
+  netId: 0,
+  symbolDisplayProps: [],
+});
+
+const instance = (sourcePackage: string, pinCount: number, pkgName?: string): PlacedInstance => ({
+  pkgName: pkgName ?? `${sourcePackage}.Normal`,
+  dbId: 1,
+  reference: "X1",
+  sourcePackage,
+  partValueIdx: 0,
+  prefixProperties: [],
+  locX: 0,
+  locY: 0,
+  symbolDisplayProps: [],
+  t0x10s: Array.from({ length: pinCount }, (_, i) => pin(i + 1)),
+});
+
+const pinMapData = (
+  pinMaps: Record<string, (string | null)[]>,
+  cachePinMaps: Record<string, (string | null)[]> = {}
+): PinMapData => ({
+  pinMaps: new Map(Object.entries(pinMaps)),
+  cachePinMaps: new Map(Object.entries(cachePinMaps)),
+  deviceUnitRefs: new Map(),
+});
+
+describe("resolvePinNumber", () => {
+  it("maps the pin index through the Packages/ pin map", () => {
+    const inst = instance("RES", 2);
+    const pmd = pinMapData({ RES: ["1", "2"] });
+
+    expect(resolvePinNumber(pin(1), inst, pmd)).toBe("1");
+    expect(resolvePinNumber(pin(2), inst, pmd)).toBe("2");
+  });
+
+  it("prefers the Cache map when the package has pads the symbol does not expose", () => {
+    const inst = instance("XTAL", 2);
+    const pmd = pinMapData({ XTAL: ["1", "2", "3", "4"] }, { XTAL: ["1", "3"] });
+
+    expect(resolvePinNumber(pin(2), inst, pmd)).toBe("3");
+  });
+
+  it("falls back to the Cache map when the Packages/ lookup misses entirely", () => {
+    const inst = instance("XTAL_4PAD", 4);
+    const pmd = pinMapData({ SOMETHING_ELSE: ["9", "9"] }, { XTAL_4PAD: ["1", "3", "2", "4"] });
+
+    expect(resolvePinNumber(pin(1), inst, pmd)).toBe("1");
+    expect(resolvePinNumber(pin(2), inst, pmd)).toBe("3");
+    expect(resolvePinNumber(pin(3), inst, pmd)).toBe("2");
+    expect(resolvePinNumber(pin(4), inst, pmd)).toBe("4");
+  });
+
+  it("falls back to the Cache map when the Packages/ map has a null at the index", () => {
+    const inst = instance("CONN", 3);
+    const pmd = pinMapData({ CONN: ["1", null, "3"] }, { CONN: ["1", "7", "3"] });
+
+    expect(resolvePinNumber(pin(2), inst, pmd)).toBe("7");
+  });
+
+  it("uses the symbol record order only when neither map resolves the pin", () => {
+    const inst = instance("UNKNOWN_PART", 2);
+    const pmd = pinMapData({});
+
+    expect(resolvePinNumber(pin(1), inst, pmd)).toBe("1");
+    expect(resolvePinNumber(pin(2), inst, pmd)).toBe("2");
+  });
+
+  it("does not consult the Cache map past its end", () => {
+    const inst = instance("SHORT", 4);
+    const pmd = pinMapData({}, { SHORT: ["1", "2"] });
+
+    expect(resolvePinNumber(pin(3), inst, pmd)).toBe("3");
+  });
+
+  it("treats a non-positive pin index as pin 1", () => {
+    const inst = instance("RES", 2);
+    const pmd = pinMapData({ RES: ["5", "6"] });
+
+    expect(resolvePinNumber(pin(0), inst, pmd)).toBe("1");
+  });
+});
+
+describe("findPinMap", () => {
+  it("matches a multi-unit package through the doubled unit letter in pkgName", () => {
+    const inst = instance("OMAP_CBP", 2, "OMAP_CBPAA.Normal");
+    const maps = new Map<string, (string | null)[]>([["OMAP_CBPA", ["A1", "A2"]]]);
+
+    expect(findPinMap(inst, maps, new Map())).toEqual(["A1", "A2"]);
+  });
+
+  it("selects the device positionally when pkgName carries no unit suffix", () => {
+    const inst = instance("RPAK", 2);
+    const maps = new Map<string, (string | null)[]>([
+      ["RPAKA", ["1", "16"]],
+      ["RPAKB", ["2", "15"]],
+    ]);
+    const unitRefs = new Map<string, string[]>([["RPAK", ["A", "B"]]]);
+
+    expect(findPinMap(inst, maps, unitRefs, 1)).toEqual(["2", "15"]);
+  });
+});
+
+describe("extractUnitRef", () => {
+  it("returns the unit letters between the package name and the view suffix", () => {
+    expect(extractUnitRef(instance("DP_HDMI_CONN", 2, "DP_HDMI_CONNA.Normal"))).toBe("A");
+    expect(extractUnitRef(instance("OMAP_CBP", 2, "OMAP_CBPAA.Normal"))).toBe("AA");
+  });
+
+  it("returns undefined when the instance has no unit suffix", () => {
+    expect(extractUnitRef(instance("RES", 2))).toBeUndefined();
+  });
+});

--- a/src/parsers/cadence/dsn/pin-resolver.ts
+++ b/src/parsers/cadence/dsn/pin-resolver.ts
@@ -84,12 +84,25 @@ export function findPinMap(
   return undefined;
 }
 
+const lookupPin = (
+  map: (string | null)[] | undefined,
+  pinIndex: number
+): string | undefined => {
+  if (!map || pinIndex - 1 >= map.length) return undefined;
+  return map[pinIndex - 1] ?? undefined;
+};
+
 /**
  * Resolve a T0x10 pin to a physical pin number using package pin map data.
  *
  * Uses T0x10.pinIndex (1-based logical pin index from the binary) to look up
- * the physical pin number in the Device.pinMap array.
- * Falls back to the pinIndex value itself if no pin map is available.
+ * the physical pin number in the Device.pinMap array, preferring the
+ * `Packages/` stream and falling back to the Cache stream.
+ *
+ * The pinIndex value itself is only used when neither stream maps it. That
+ * value is the symbol's pin record order, which equals the physical pin number
+ * only for parts whose symbol order matches their package numbering, so it is a
+ * last resort rather than a peer of the two maps.
  */
 export function resolvePinNumber(
   pin: T0x10,
@@ -99,7 +112,9 @@ export function resolvePinNumber(
 ): string {
   if (pin.pinIndex <= 0) return String(pin.pinIndex || 1);
   const pinMap = findPinMap(inst, pmd.pinMaps, pmd.deviceUnitRefs, deviceIndex);
-  if (pinMap && pin.pinIndex - 1 < pinMap.length && pinMap[pin.pinIndex - 1] !== null) {
+  const packagePin = lookupPin(pinMap, pin.pinIndex);
+
+  if (pinMap && packagePin !== undefined) {
     // When the Packages/ pinMap has more entries than the instance has T0x10
     // records, the physical package has pads not exposed on the schematic
     // symbol (e.g., a 2-pin crystal in a 4-pad package). In that case, the
@@ -107,17 +122,23 @@ export function resolvePinNumber(
     // be preferred.
     if (pinMap.length > inst.t0x10s.length) {
       const cacheMap = findPinMap(inst, pmd.cachePinMaps, pmd.deviceUnitRefs, deviceIndex);
-      if (
-        cacheMap &&
-        cacheMap.length <= inst.t0x10s.length &&
-        pin.pinIndex - 1 < cacheMap.length &&
-        cacheMap[pin.pinIndex - 1] !== null
-      ) {
-        return cacheMap[pin.pinIndex - 1]!;
+      const cachePin = lookupPin(cacheMap, pin.pinIndex);
+      if (cacheMap && cacheMap.length <= inst.t0x10s.length && cachePin !== undefined) {
+        return cachePin;
       }
     }
-    return pinMap[pin.pinIndex - 1]!;
+    return packagePin;
   }
+
+  // The Packages/ lookup missed entirely, or has no entry at this index. The
+  // Cache stream carries a schematic-level map for the same part, so consult it
+  // before falling back to the symbol record order.
+  const cachePin = lookupPin(
+    findPinMap(inst, pmd.cachePinMaps, pmd.deviceUnitRefs, deviceIndex),
+    pin.pinIndex
+  );
+  if (cachePin !== undefined) return cachePin;
+
   return String(pin.pinIndex);
 }
 

--- a/src/parsers/cadence/dsn/pin-resolver.ts
+++ b/src/parsers/cadence/dsn/pin-resolver.ts
@@ -74,8 +74,9 @@ export function findPinMap(
       }
     }
 
-    // Single-instance fallback (no positional info): try unit "A"
-    if (!unitRef && deviceIndex === undefined) {
+    // Fallback: a package whose devices are not enumerated in deviceUnitRefs
+    // still has a single unit "A" entry to try.
+    if (!unitRef) {
       const unitAMatch = pinMaps.get(base + "A");
       if (unitAMatch) return unitAMatch;
     }
@@ -143,32 +144,20 @@ export function resolvePinNumber(
 }
 
 /**
- * Build a map from PlacedInstance dbId to positional device index for
- * multi-section components (e.g., resistor packs, transistor arrays).
+ * Map each PlacedInstance dbId to its 0-based section index within a
+ * multi-section package (resistor packs, transistor arrays, multi-gate logic).
  *
- * When multiple PlacedInstances share the same (refdes, pkgName) and have no
- * unit suffix in pkgName, Cadence assigns Devices positionally by dbId order.
- * This function detects those groups and assigns 0-based indices.
+ * The index is `PlacedInstance.sectionIndex`, read from the binary. Instances
+ * whose pkgName already carries a unit suffix are skipped: those resolve their
+ * Device by that suffix and never consult a positional index.
  */
 export function buildDeviceIndexMap(pages: PageData[]): Map<number, number> {
-  const groups = new Map<string, PlacedInstance[]>();
+  const result = new Map<number, number>();
   for (const page of pages) {
     for (const inst of page.placedInstances) {
       if (!inst.reference || !isValidRefdes(inst.reference)) continue;
-      if (extractUnitRef(inst)) continue; // already has unit suffix
-      const key = `${inst.reference}\0${inst.pkgName}`;
-      const group = groups.get(key);
-      if (group) group.push(inst);
-      else groups.set(key, [inst]);
-    }
-  }
-
-  const result = new Map<number, number>();
-  for (const [, group] of groups) {
-    if (group.length <= 1) continue;
-    group.sort((a, b) => a.dbId - b.dbId);
-    for (let i = 0; i < group.length; i++) {
-      result.set(group[i].dbId, i);
+      if (extractUnitRef(inst)) continue;
+      result.set(inst.dbId, inst.sectionIndex);
     }
   }
   return result;

--- a/src/parsers/cadence/dsn/structures.ts
+++ b/src/parsers/cadence/dsn/structures.ts
@@ -61,6 +61,11 @@ export interface PlacedInstance {
   locY: number;
   symbolDisplayProps: SymbolDisplayProp[];
   t0x10s: T0x10[];
+  /**
+   * 0-based section (device) index within a multi-section package, read from
+   * the uint16 following sourcePackage. Single-section parts carry 0.
+   */
+  sectionIndex: number;
 }
 
 export interface GraphicInst {
@@ -232,7 +237,7 @@ export function parsePlacedInstance(reader: BinaryReader): PlacedInstance {
   futureData.checkpoint();
 
   const sourcePackage = reader.readStringLenZeroTerm();
-  reader.skip(2); // unknown
+  const sectionIndex = reader.readUint16();
 
   futureData.checkpoint();
 
@@ -247,6 +252,7 @@ export function parsePlacedInstance(reader: BinaryReader): PlacedInstance {
     locY,
     symbolDisplayProps,
     t0x10s,
+    sectionIndex,
   };
 }
 


### PR DESCRIPTION
Fixes #89.

## Summary

Two changes to Cadence DSN pin resolution. The second is the one that matters.

**1. `resolvePinNumber` now consults the Cache pin map before the record-order fallback.** This is what #89 reported: `cachePinMaps` was only reachable from inside the branch where the `Packages/` lookup had already succeeded *and* returned more entries than the instance has pins. On an outright miss, or a `null` at the index, resolution went straight to the raw `pinIndex` — the symbol's record order, which equals the physical pin number only when symbol order matches package numbering.

**2. `PlacedInstance` now decodes a `section_index` field, replacing the `dbId`-order heuristic.**

Investigating #89 on real designs showed its stated mechanism was *not* what produced the transpositions in our corpus — the `Packages/` lookup hits for those parts and returns correct maps. The real cause was which instance got assigned which Device. We inferred that by sorting each `(refdes, pkgName)` group by `dbId`, and **`dbId` order is not section order**: on `BeagleBoard-xM_ORCAD` the eight `RP3` sections are allocated with adjacent pairs transposed.

The `uint16` following `source_package` turns out to be the 0-based section index. The OpenOrCadParser reference discards it (`printUnknownData(2, ": 5")`), so it had never been used. It was found by dumping every byte block we discard for RP3's eight instances and correlating against the section order derived independently from that design's `pstxnet.dat`: the field reads `0,1,…,7` in exactly that order. Across the corpus its distribution is what a section index should be — 438 single-section parts at `0`, `RP1`–`RP7` spanning `0`–`7`, dual transistors `0`–`1`.

## Why nothing caught this before

The nets were real and the pin numbers were real; only their pairing was wrong. So `Nets` and `Comps` coverage stayed at **100%**, and `verify-pin-numbers.ts` reported **100%** on every fixture, because it compares the *set* of pin numbers per component and never checks which net each pin lands on. Only the per-net `{refdes.pin}` comparison added in #95 exposed it.

## Measured on real designs

Nets whose pin set disagrees with the DAT export, across all 11 paired Cadence fixtures:

| | before | after |
|---|---|---|
| **Total** | 79 (98.4%) | **24 (99.5%)** |
| BeagleBoard-xM_ORCAD | 65 | **10** |

No design regressed. Geometric orderings were tested as alternatives to `dbId` and every one was worse: `locY` 81, `locX` 103, descending variants 131 and 139.

## Changelog

Cadence DSN multi-section parts (resistor packs, transistor arrays, multi-gate logic) now resolve each section's pins from the section index stored in the file rather than from `dbId` ordering, correcting pin-to-net assignment on parts whose sections are not allocated in placement order.

## Test plan

- [x] `src/parsers/cadence/dsn/pin-resolver.test.ts` — 16 tests covering both maps, both fallback paths, the record-order last resort, and section indexing (including a group whose `dbId` and section order disagree, a lone placed section, and cross-page sections)
- [x] `npx vitest run` — 611 passed, 6 skipped (`test/otel/e2e.test.ts` fails locally only, `listen EPERM` from the sandbox; passes in CI)
- [x] `npm run type-check`, `npm run lint`
- [x] `bun scripts/dsn-coverage-report.ts` and `bun scripts/verify-pin-numbers.ts` across all fixtures
- [x] `docs/dsn-format.md` updated: `section_index` documented in 7.7 with how it was identified, and 11.3 rewritten from positional to section-based assignment