### PR TITLE
fix: stop gitignoring .claude/skills, track the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: release
+description: "ALWAYS use this skill when the user mentions: commit, push, PR, pull request, release, ship, tag, or any git workflow. This skill defines how to stage, commit, push, create PRs, and tag releases. It MUST be loaded before performing any git commit or push operation."
+---
+
+## Committing
+
+### Include ALL changes
+
+The user works in parallel with you. When asked to commit, include ALL changes in the working tree, not just the ones you made. The user's manual edits are equally important. Always run `git status` first and review everything.
+
+### Workflow
+
+1. Run `git status` (never use `-uall`) and `git diff --stat` to see the full picture
+2. Run `git log --oneline -5` to match the repository's commit message style
+3. Review ALL changes, both yours and the user's, to understand the full scope
+4. Stage ALL relevant files. Do not cherry-pick only your changes
+   - Do NOT stage files that contain secrets (`.env`, credentials, keys)
+   - Warn the user if they ask to commit such files
+5. Draft a commit message:
+   - Format: `type: description` (e.g., `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`)
+   - Focus on the "why", not the "what"
+   - Keep it concise (1-2 sentences)
+6. Commit using a HEREDOC for clean formatting:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   type: description
+   EOF
+   )"
+   ```
+7. NEVER add Claude Code or any other AI assistant as co-author or author
+8. NEVER use `--no-verify` to skip hooks unless the user explicitly asks
+9. If pre-commit hooks fail, fix the issue and create a NEW commit (do not amend)
+
+### Grouping commits
+
+For large changesets, plan multiple logical commits. After the first commit passes hooks cleanly, subsequent commits can use `--no-verify` to speed things up.
+
+## Pushing
+
+- Push without asking. The PR and its checks are the review gate, not a confirmation prompt
+- Use `git push` for tracked branches
+- Use `git push -u origin <branch>` for new branches
+- NEVER force push to `main`/`master`
+
+## Merging
+
+**If a PR's work is fully done and verified, merge it.** Do not leave finished work
+sitting open waiting for permission, and do not ask whether to merge something that is
+complete and green.
+
+Done and verified means: the change does what the PR says, `build` is green, and any
+claim the PR makes about behavior has been checked against real data rather than asserted.
+A PR that is still exploratory, or whose effect has not been measured, is not done — say
+what is missing instead of merging it.
+
+`main` uses a merge queue, which changes the mechanics:
+
+- `gh pr merge <n> --squash` **enqueues**; the queue builds the PR stacked on the entries
+  ahead of it and merges it when green. `! The merge strategy for main is set by the merge
+  queue` is the normal success message, not an error
+- `--delete-branch` is rejected while a queue is enabled; the repo's
+  `delete_branch_on_merge` setting handles cleanup
+- Inspect the queue with:
+  ```bash
+  gh api graphql -f query='{ repository(owner:"IntelligentElectron", name:"universal-netlist") {
+    mergeQueue(branch:"main") { entries(first:10) { nodes { position state pullRequest { number } } } } } }'
+  ```
+- `merge_group` events build on `gh-readonly-queue/...` refs. `ci.yml` must keep its
+  `merge_group` trigger or queued PRs wait for a check that never reports and are ejected
+
+## Pull Requests
+
+1. Check the full branch diff: `git log --oneline main..HEAD` and `git diff main...HEAD --stat`
+2. Push the branch if needed
+3. Create PR with:
+   ```bash
+   gh pr create --title "short title" --body "$(cat <<'EOF'
+   ## Summary
+   <1-3 bullet points>
+
+   ## Test plan
+   - [ ] verification steps
+   EOF
+   )"
+   ```
+4. Return the PR URL to the user
+5. Merge it once the work is done and the checks are green (see Merging above)
+
+## Releases
+
+Tagging is the one step that is NOT automatic: the tag push publishes to npm and cuts a
+public GitHub Release, so it is the maintainer's call. Ask before tagging; merge freely.
+
+1. Ensure `main` is clean and all checks pass
+2. Ensure `CHANGELOG.md` covers every change in the release. Feature PRs do not edit it
+   (see CLAUDE.md), so collect their `## Changelog` sections into the version section first
+3. Create and push the tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. Monitor CI: `gh run list` and `gh run view`
+
+## Pre-commit Hooks
+
+This repo uses husky + lint-staged. Pre-commit runs:
+- ESLint (with auto-fix) and type-check on staged TS/TSX files
+- All TypeScript tests (`npm test`) across all workspaces
+- Python validation for `services/server`: Black, Pyright, pytest
+
+If hooks fail:
+- Git pull issues: work with the user to resolve
+- Type/lint errors: fix the code
+- Test failures: identify root cause and fix (code or tests)

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ package-lock.json
 dist/
 build/
 bin/
-release/
+/release/
 *.tsbuildinfo
 
 # Logs


### PR DESCRIPTION
## Summary

`.claude/skills/` was being ignored by accident, so the repo's only skill — the one defining the commit / push / PR / release workflow — lived on one machine and was invisible to everyone else.

The cause is in `.gitignore` under **"# Build output"**:

```diff
-release/
+/release/
```

Without a leading slash, a gitignore pattern matches at *any* depth, so a rule meant for a root build directory silently swallowed `.claude/skills/release/`. That it was unintentional is clear from the neighbours: `.claude/hooks/*.sh` and `.claude/settings.json` are tracked, and the only ignore rules deliberately aimed at `.claude/` are `settings.local.json` (explicit) and `scheduled_tasks.lock` (in `.git/info/exclude`).

Anchoring the pattern to `/release/` preserves the build-output intent — there is no `release/` directory anywhere in the tree today, so nothing changes for builds — and lets the skill be versioned alongside the code it governs.

Also adds the skill itself, including today's revision: finished, green PRs get merged rather than parked, while tagging stays the maintainer's call since it publishes to npm. It also records the merge-queue mechanics (enqueue semantics, `--delete-branch` being rejected, the `merge_group` trigger `ci.yml` must keep) so they aren't rediscovered each session.

## Changelog

None — repository tooling and agent workflow docs, no user-facing change.

## Test plan

- [x] `git check-ignore` no longer matches `.claude/skills/release/SKILL.md`
- [x] No `release/` directory exists anywhere in the tree, so the build-output rule still covers its intended target
- [x] `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` remain ignored via their own rules