### PR TITLE
ci: report claude-review on merge_group so it can be a required check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,18 +3,29 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  # `claude-review` is a required check, and a required check must report on the
+  # merge queue's `merge_group` event or every queued PR waits for a result that
+  # never arrives and is ejected on timeout. The review itself already ran on the
+  # pull_request event, so the job below skips here — a skipped job still reports
+  # its check, which is what satisfies the requirement.
+  merge_group:
+    branches: [main]
 
 jobs:
   claude-review:
-    # Same-repo branches only. For a `pull_request` from a fork, GitHub withholds
-    # repository secrets (`CLAUDE_CODE_OAUTH_TOKEN` arrives empty) and downgrades the
-    # job to a read-only token, dropping the `id-token: write` requested below — the
-    # action then fails its OIDC exchange. Skipping keeps fork PRs green instead of
-    # red-for-infrastructure-reasons.
+    # Same-repo pull requests only.
+    #
+    # For a `pull_request` from a fork, GitHub withholds repository secrets
+    # (`CLAUDE_CODE_OAUTH_TOKEN` arrives empty) and downgrades the job to a read-only
+    # token, dropping the `id-token: write` requested below — the action then fails its
+    # OIDC exchange. For a `merge_group` event there is no pull_request payload at all.
+    # Both cases skip rather than fail, so the required check still reports.
     #
     # To review a fork PR, comment `@claude` on it: claude.yml runs on `issue_comment`
     # in base-repo context, where both the secret and OIDC are available.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Prerequisite for making `claude-review` a **required** status check. Must land before the ruleset changes.

A required check has to report on the merge queue's `merge_group` event. `claude-review` only listened for `pull_request`, so as a required check it would never report on a queue entry — every queued PR would sit until `check_response_timeout_minutes` elapsed and then be ejected. That is exactly the trap `ci.yml` had before #96, and it fails silently: the repo looks healthy while nothing merges.

- Adds a `merge_group` trigger.
- The job now skips on `merge_group` (the review already ran on the `pull_request` event). **A skipped job still reports its check**, which is what satisfies the requirement — no duplicate review, no wasted minutes.
- The fork guard is now an explicit `github.event_name == 'pull_request'` test rather than relying on the `pull_request` payload being absent, so both the fork case and the merge-group case skip deliberately instead of incidentally.

Fork PRs continue to skip (they get no secrets and no OIDC), and a skipped check satisfies a required check, so requiring this does not block outside contributions. Those are still reviewed by commenting `@claude`, which runs in base-repo context.

## Changelog

None — CI configuration, no user-facing change.

## Test plan

- [x] `js-yaml` parses the workflow
- [ ] `claude-review` reports on this PR via `pull_request` (it is a same-repo branch, so it should actually run)
- [ ] `claude-review` reports as skipped on the `merge_group` event when this PR is queued
- [ ] After it is made required, a subsequent PR merges through the queue without stalling