### PR TITLE
fix(altium): expand multi-channel sheets for every designator format

### DIFF
--- a/src/parsers/altium/channel-format.test.ts
+++ b/src/parsers/altium/channel-format.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { applyChannelFormat } from "./index.js";
+
+/**
+ * Every format string below was read verbatim from the `ChannelDesignatorFormatString`
+ * of a real open-source Altium project. The design each came from is named so a
+ * failure points at something reproducible rather than at an invented case.
+ */
+describe("applyChannelFormat", () => {
+  it("substitutes $Component and $RoomName (aberrant-sound-module, PW-Sat2, HELIOS-R)", () => {
+    expect(applyChannelFormat("$Component_$RoomName", "DD12", "AY1", 1)).toBe("DD12_AY1");
+    expect(applyChannelFormat("$Component_$RoomName", "R4", "AY3", 3)).toBe("R4_AY3");
+  });
+
+  it("substitutes $ChannelAlpha (cube-sat-eps, heron-hardware, utca-rtm-8-sfp)", () => {
+    expect(applyChannelFormat("$Component$ChannelAlpha", "R5", "MPPT1", 1)).toBe("R5A");
+    expect(applyChannelFormat("$Component$ChannelAlpha", "R5", "MPPT2", 2)).toBe("R5B");
+    expect(applyChannelFormat("$Component$ChannelAlpha", "C12", "MIC8", 8)).toBe("C12H");
+  });
+
+  it("substitutes $ChannelIndex with a dot separator (easyinverter OnePhase)", () => {
+    expect(applyChannelFormat("$Component.$ChannelIndex", "Q1", "Phase_T1", 1)).toBe("Q1.1");
+    expect(applyChannelFormat("$Component.$ChannelIndex", "Q1", "Phase_T4", 4)).toBe("Q1.4");
+  });
+
+  it("substitutes $RoomName with a dot separator (easyinverter LogicsOnly, RoomNamingStyle=1)", () => {
+    expect(applyChannelFormat("$Component.$RoomName", "K2", "GateCircuit_B2", 2)).toBe(
+      "K2.GateCircuit_B2"
+    );
+  });
+
+  it("substitutes $Component_$ChannelIndex (PW-Sat2, Thermostat_EEM, Booster)", () => {
+    expect(applyChannelFormat("$Component_$ChannelIndex", "U7", "S2", 2)).toBe("U7_2");
+  });
+
+  it("splits a refdes into prefix and index (vme-adc-250k-16b-36cha)", () => {
+    expect(
+      applyChannelFormat("$ComponentPrefix_$ChannelIndex_$ComponentIndex", "R5", "IA3", 3)
+    ).toBe("R_3_5");
+    expect(
+      applyChannelFormat("$ComponentPrefix_$ChannelIndex_$ComponentIndex", "RP12", "IA1", 1)
+    ).toBe("RP_1_12");
+  });
+
+  it("does not let $Component swallow the longer $ComponentPrefix token", () => {
+    // A naive `.replace("$Component", ...)` turns "$ComponentPrefix" into "R5Prefix".
+    expect(applyChannelFormat("$ComponentPrefix", "R5", "X1", 1)).toBe("R");
+    expect(applyChannelFormat("$ComponentIndex", "R5", "X1", 1)).toBe("5");
+  });
+
+  it("substitutes every occurrence, not just the first", () => {
+    expect(applyChannelFormat("$Component_$RoomName_$RoomName", "R1", "CH2", 2)).toBe(
+      "R1_CH2_CH2"
+    );
+  });
+
+  it("rolls the alphabetic label past Z", () => {
+    expect(applyChannelFormat("$ChannelAlpha", "R1", "X", 26)).toBe("Z");
+    expect(applyChannelFormat("$ChannelAlpha", "R1", "X", 27)).toBe("AA");
+    expect(applyChannelFormat("$ChannelAlpha", "R1", "X", 32)).toBe("AF");
+  });
+
+  it("handles a refdes with no numeric part", () => {
+    expect(applyChannelFormat("$ComponentPrefix_$ComponentIndex", "TP", "CH1", 1)).toBe("TP_");
+    expect(applyChannelFormat("$Component$ChannelAlpha", "TP", "CH1", 1)).toBe("TPA");
+  });
+
+  it("leaves an unmodelled token visible rather than dropping it", () => {
+    // A silently dropped token would collapse every channel onto one designator,
+    // which is the failure mode this whole fix exists to remove.
+    expect(applyChannelFormat("$Component_$SomethingElse", "R1", "CH1", 1)).toBe(
+      "R1_$SomethingElse"
+    );
+  });
+});

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -444,7 +444,11 @@ import {
 } from "./discovery.js";
 import { readFile } from "fs/promises";
 import type { EDAProjectFormatHandler } from "../../types.js";
-import { parseProjectStructure, findRepeatedSheets } from "./structure-parser.js";
+import {
+  parseProjectStructure,
+  findRepeatedSheets,
+  expandRepeatDesignator,
+} from "./structure-parser.js";
 import type { SheetInstance } from "./structure-parser.js";
 
 export { discoverAltiumDesigns, findAltiumSchDocs, isAltiumFile } from "./discovery.js";
@@ -497,12 +501,122 @@ const readChannelFormat = async (projectPath: string): Promise<string> => {
   return "$Component_$RoomName";
 };
 
+const recordText = (record: AltiumRecord | undefined): string => {
+  const value = record?.Text ?? record?.TEXT ?? record?.Name ?? record?.NAME;
+  return value === undefined || value === null ? "" : String(value);
+};
+
 /**
- * Apply channel designator format to a component refdes.
- * E.g., format="$Component_$RoomName", component="DD12", room="AY1" → "DD12_AY1"
+ * Derive multi-channel sheets from a parsed schematic, for projects that ship no
+ * `.PrjPcbStructure`.
+ *
+ * A sheet symbol (RECORD=15) owns two children that matter here: its designator
+ * (RECORD=32) and the child document it instantiates (RECORD=33). When the
+ * designator is a `Repeat(...)` expression, that child document is one channel
+ * per repeat index.
+ *
+ * Altium only writes `.PrjPcbStructure` when a project has been compiled and the
+ * file is frequently not committed, so relying on it alone silently collapses
+ * every channel in such a project down to a single instance.
  */
-const applyChannelFormat = (format: string, component: string, roomName: string): string =>
-  format.replace("$Component", component).replace("$RoomName", roomName);
+export const findRepeatedSheetsInSchematic = (
+  schematic: AltiumSchematic,
+  sourceDocument: string
+): Map<string, SheetInstance[]> => {
+  const repeated = new Map<string, SheetInstance[]>();
+
+  for (const record of flattenHierarchy(schematic)) {
+    if (record.RECORD !== RECORD_TYPES.SHEET_SYMBOL) continue;
+
+    const children = record.children ?? [];
+    const schDesignator = recordText(
+      children.find((child) => child.RECORD === RECORD_TYPES.SHEET_NAME)
+    );
+    const fileName = recordText(
+      children.find((child) => child.RECORD === RECORD_TYPES.SHEET_FILE_NAME)
+    );
+    if (!fileName) continue;
+
+    const designators = expandRepeatDesignator(schDesignator);
+    if (designators.length === 0) continue;
+
+    repeated.set(
+      fileName.toLowerCase(),
+      designators.map((designator) => ({
+        sourceDocument,
+        designator,
+        schDesignator,
+        fileName,
+      }))
+    );
+  }
+
+  return repeated;
+};
+
+/**
+ * Render a 1-based channel number as Altium's alphabetic channel label:
+ * 1 → "A", 26 → "Z", 27 → "AA".
+ */
+const channelAlpha = (channelIndex: number): string => {
+  let n = Math.max(1, channelIndex);
+  let out = "";
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    out = String.fromCharCode(65 + rem) + out;
+    n = Math.floor((n - 1) / 26);
+  }
+  return out;
+};
+
+/**
+ * Tokens Altium substitutes into `ChannelDesignatorFormatString`.
+ *
+ * Ordered longest-first: a plain `$Component` alternative listed before
+ * `$ComponentPrefix` would match its prefix and leave a stray "Prefix" behind.
+ */
+const CHANNEL_FORMAT_TOKEN = /\$(ComponentPrefix|ComponentIndex|ChannelIndex|ChannelAlpha|Component|RoomName)/g;
+
+/**
+ * Apply a channel designator format to a component refdes.
+ *
+ * `$Component_$RoomName` with ("DD12", room "AY1") → "DD12_AY1"
+ * `$Component$ChannelAlpha` with ("R5", channel 2) → "R5B"
+ * `$ComponentPrefix_$ChannelIndex_$ComponentIndex` with ("R5", channel 3) → "R_3_5"
+ *
+ * An unrecognized token is left as written rather than dropped, so a format we
+ * do not model yet produces a visibly wrong designator instead of silently
+ * colliding with another channel's.
+ */
+export const applyChannelFormat = (
+  format: string,
+  component: string,
+  roomName: string,
+  channelIndex: number
+): string => {
+  const prefixMatch = component.match(/^([^0-9]*)([0-9].*)?$/);
+  const componentPrefix = prefixMatch?.[1] ?? component;
+  const componentIndex = prefixMatch?.[2] ?? "";
+
+  return format.replace(CHANNEL_FORMAT_TOKEN, (_match, token: string) => {
+    switch (token) {
+      case "Component":
+        return component;
+      case "ComponentPrefix":
+        return componentPrefix;
+      case "ComponentIndex":
+        return componentIndex;
+      case "RoomName":
+        return roomName;
+      case "ChannelIndex":
+        return String(channelIndex);
+      case "ChannelAlpha":
+        return channelAlpha(channelIndex);
+      default:
+        return _match;
+    }
+  });
+};
 
 const unescapeAltiumOverbar = (name: string): string =>
   name.includes("\\") ? name.replace(/\\/g, "") : name;
@@ -594,8 +708,9 @@ const expandChannels = (
   const allNets: NetConnections = {};
   const allComponents: ComponentDetails = {};
 
-  for (const channel of channels) {
+  for (const [channelOffset, channel] of channels.entries()) {
     const roomName = channel.designator;
+    const channelIndex = channelOffset + 1;
 
     // Classify each net for this channel:
     // 1. Power nets → global (keep name)
@@ -625,7 +740,7 @@ const expandChannels = (
       }
 
       for (const [origRefdes, pins] of Object.entries(connections)) {
-        const expandedRefdes = applyChannelFormat(channelFormat, origRefdes, roomName);
+        const expandedRefdes = applyChannelFormat(channelFormat, origRefdes, roomName, channelIndex);
         if (!allNets[expandedNetName][expandedRefdes]) {
           allNets[expandedNetName][expandedRefdes] = pins;
         } else {
@@ -639,7 +754,7 @@ const expandChannels = (
 
     // Expand components with renamed refdes and net references
     for (const [origRefdes, component] of Object.entries(baseResult.components)) {
-      const expandedRefdes = applyChannelFormat(channelFormat, origRefdes, roomName);
+      const expandedRefdes = applyChannelFormat(channelFormat, origRefdes, roomName, channelIndex);
 
       // Deep-clone pins with mapped net names
       const expandedPins: Record<string, PinEntry> = {};
@@ -681,6 +796,11 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
   let channelFormat = "$Component_$RoomName";
   let parentSchematic: AltiumSchematic | undefined;
 
+  // Parent schematic per repeated child document. A project may repeat different
+  // sheets from different parents, and each expansion needs its own parent to
+  // classify that sheet symbol's entries.
+  const repeatParents = new Map<string, AltiumSchematic>();
+
   if (structurePath) {
     const structureContent = await readFile(structurePath, "utf-8");
     const structure = parseProjectStructure(structureContent);
@@ -697,6 +817,27 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       const schematic = parseRecords(buffer);
       parentSchematic = buildHierarchy(schematic);
     }
+  } else {
+    // No compiled structure file: recover the channels from the sheet symbols
+    // themselves. Any document may host a repeated sheet symbol, so scan them
+    // all and remember which parent declared each child.
+    channelFormat = await readChannelFormat(projectPath);
+
+    for (const candidatePath of schdocPaths) {
+      let hierarchical: AltiumSchematic;
+      try {
+        hierarchical = buildHierarchy(parseRecords(readOleStream(candidatePath)));
+      } catch {
+        continue;
+      }
+
+      const found = findRepeatedSheetsInSchematic(hierarchical, path.basename(candidatePath));
+      for (const [childFile, instances] of found) {
+        if (repeatedSheets.has(childFile)) continue;
+        repeatedSheets.set(childFile, instances);
+        repeatParents.set(childFile, hierarchical);
+      }
+    }
   }
 
   const allNets: NetConnections = {};
@@ -708,7 +849,8 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
 
     // Check if this file is a repeated (multi-channel) sheet
     const channels = repeatedSheets.get(schdocBase);
-    if (channels && channels.length > 1 && parentSchematic) {
+    const channelParent = repeatParents.get(schdocBase) ?? parentSchematic;
+    if (channels && channels.length > 1 && channelParent) {
       if (expandedFiles.has(schdocBase)) continue;
       expandedFiles.add(schdocBase);
 
@@ -723,7 +865,7 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       const baseResult: ParsedNetlist = { nets: parsedNets, components };
 
       // Classify SHEET_ENTRY records: Repeat() → per-channel, others → shared
-      const entryClassification = classifySheetEntries(parentSchematic, channels[0].fileName);
+      const entryClassification = classifySheetEntries(channelParent, channels[0].fileName);
 
       // Expand into N channel instances
       const expanded = expandChannels(

--- a/src/parsers/altium/structure-parser.test.ts
+++ b/src/parsers/altium/structure-parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseProjectStructure, findRepeatedSheets } from "./structure-parser.js";
+import {
+  parseProjectStructure,
+  findRepeatedSheets,
+  expandRepeatDesignator,
+} from "./structure-parser.js";
 
 describe("parseProjectStructure", () => {
   it("should parse TopLevelDocument", () => {
@@ -67,5 +71,39 @@ describe("findRepeatedSheets", () => {
     const repeated = findRepeatedSheets(structure);
 
     expect(repeated.size).toBe(0);
+  });
+});
+
+describe("expandRepeatDesignator", () => {
+  it("expands a repeat range into one designator per channel", () => {
+    expect(expandRepeatDesignator("Repeat(AY,1,3)")).toEqual(["AY1", "AY2", "AY3"]);
+  });
+
+  it("tolerates the spacing variants Altium writes in practice", () => {
+    // Observed verbatim in aberrant-sound-module, cube-sat-eps and HELIOS-R.
+    expect(expandRepeatDesignator("Repeat(AY,1,3)")).toEqual(["AY1", "AY2", "AY3"]);
+    expect(expandRepeatDesignator("Repeat(ideal_diode, 1, 2)")).toEqual([
+      "ideal_diode1",
+      "ideal_diode2",
+    ]);
+    expect(expandRepeatDesignator("Repeat(CHAN, 1,9)")).toHaveLength(9);
+    expect(expandRepeatDesignator("  Repeat(CH,1,4)  ")).toEqual(["CH1", "CH2", "CH3", "CH4"]);
+  });
+
+  it("starts from the declared index rather than assuming 1", () => {
+    expect(expandRepeatDesignator("Repeat(M,5,8)")).toEqual(["M5", "M6", "M7", "M8"]);
+  });
+
+  it("ignores a designator that is not a repeat", () => {
+    expect(expandRepeatDesignator("U_Power")).toEqual([]);
+    expect(expandRepeatDesignator("")).toEqual([]);
+    expect(expandRepeatDesignator("Repeat(CS)")).toEqual([]);
+  });
+
+  it("ignores a range that yields fewer than two channels", () => {
+    // A single instance is not multi-channel, and expanding it would rename a
+    // component that Altium leaves alone.
+    expect(expandRepeatDesignator("Repeat(X,1,1)")).toEqual([]);
+    expect(expandRepeatDesignator("Repeat(X,3,2)")).toEqual([]);
   });
 });

--- a/src/parsers/altium/structure-parser.ts
+++ b/src/parsers/altium/structure-parser.ts
@@ -74,6 +74,38 @@ export const parseProjectStructure = (content: string): ProjectStructure => {
 };
 
 /**
+ * A sheet symbol designator that instantiates a sheet once per channel.
+ *
+ * Altium writes the range with inconsistent spacing across real projects —
+ * `Repeat(AY,1,3)`, `Repeat(ideal_diode, 1, 2)`, `Repeat(CHAN, 1,9)` — so every
+ * separator tolerates surrounding whitespace.
+ */
+const REPEAT_SHEET_DESIGNATOR = /^Repeat\(\s*([^,)]+?)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i;
+
+/**
+ * Expand a `Repeat(name,start,end)` sheet symbol designator into one channel
+ * designator per instance: `Repeat(AY,1,3)` → `AY1`, `AY2`, `AY3`.
+ *
+ * Returns an empty array for anything that is not a repeat, or for a range that
+ * yields fewer than two channels — a single instance is not multi-channel.
+ */
+export const expandRepeatDesignator = (schDesignator: string): string[] => {
+  const match = schDesignator.trim().match(REPEAT_SHEET_DESIGNATOR);
+  if (!match) return [];
+
+  const [, base, startText, endText] = match;
+  const start = Number.parseInt(startText, 10);
+  const end = Number.parseInt(endText, 10);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return [];
+
+  const designators: string[] = [];
+  for (let index = start; index <= end; index++) {
+    designators.push(`${base}${index}`);
+  }
+  return designators;
+};
+
+/**
  * Identify repeated (multi-channel) sheets.
  *
  * Returns a map from fileName to the list of channel designators.


### PR DESCRIPTION
Fixes #44.

## Summary

Multi-channel Altium designs collapsed to a single channel unless the project happened to sit in one narrow configuration. Two independent defects.

**1. Only two designator-format tokens were implemented.** `applyChannelFormat` did:

```ts
format.replace("$Component", component).replace("$RoomName", roomName);
```

Altium's `ChannelDesignatorFormatString` has more tokens than that. Formats found across ~30 open-source designs:

| Format | Designs | Before |
|---|---|---|
| `$Component_$RoomName` | aberrant-sound-module, PW-Sat2, HELIOS-R, p4ch-lnls | worked |
| `$Component$ChannelAlpha` | cube-sat-eps, heron-hardware, utca-rtm-8-sfp, amc-carrier-2-sl, fmc-adc-250m-16b-4cha, fmc-dio-32chlvdsa | **collapsed** |
| `$Component.$ChannelIndex` | easyinverter | **collapsed** |
| `$Component_$ChannelIndex` | PW-Sat2, Thermostat_EEM, Booster | **collapsed** |
| `$Component.$RoomName` (`RoomNamingStyle=1`) | easyinverter | **collapsed** |
| `$ComponentPrefix_$ChannelIndex_$ComponentIndex` | vme-adc-250k-16b-36cha | **collapsed** |

Tokens are now matched longest-first, because a plain `.replace("$Component", …)` rewrites `"$ComponentPrefix"` into `"R5Prefix"`. An unmodelled token is left visible rather than dropped — a dropped token collapses two channels onto one designator, which is the exact failure being fixed.

**2. Channel discovery required a committed `.PrjPcbStructure`.** Altium writes that file when a project is compiled, and it is frequently not committed — none of the multi-channel designs surveyed ship one. Those projects lost every channel silently.

Repeats are now recovered from the sheet symbols directly: a `SHEET_SYMBOL` (RECORD=15) owns its designator (RECORD=32) and the document it instantiates (RECORD=33); a `Repeat(name,start,end)` designator names one channel per index. Spacing varies in the wild — `Repeat(AY,1,3)`, `Repeat(ideal_diode, 1, 2)`, `Repeat(CHAN, 1,9)` — so all three parse. The structure-file path is unchanged and still takes precedence.

## Measured on real designs

| Design | Format | Before | After |
|---|---|---|---|
| `PA-OST-2023/heron-hardware` | `$Component$ChannelAlpha` | 40 comps | **320** (4 sheets × 8 ch) → `M2A, M2B … M2H` |
| `Dominik-Workshop/cube-sat-eps` | `$Component$ChannelAlpha` | 86 comps | **112** |
| `pulp-bio/HELIOS-R` | `$Component_$RoomName` | — | 9-way `Repeat(CHAN,1,9)` → `J4_CHAN1…J5_CHAN9` |
| `aberrant-sound-module` (control) | `$Component_$RoomName` + structure file | 105 comps, 24 AY | **unchanged** |

## Changelog

Altium multi-channel designs now expand correctly regardless of the project's channel designator format, and no longer require a compiled `.PrjPcbStructure` to be committed. Previously only `$Component_$RoomName` projects that shipped a structure file expanded; every other configuration silently reported one channel, under-counting components and merging per-channel nets.

## Test plan

- [x] `src/parsers/altium/channel-format.test.ts` — 11 tests, one per format string taken verbatim from a named real project, plus token-shadowing, alphabetic roll past Z (`AA`, `AF`), refdes with no numeric part, and unmodelled-token behaviour
- [x] `structure-parser.test.ts` — repeat expansion incl. all three spacing variants, non-1 start index, non-repeat designators, and single-instance ranges that must not expand
- [x] `npx vitest run` — 622 passed, 7 skipped (`test/otel/e2e.test.ts` fails locally only, sandbox blocks its OTLP socket; passes in CI)
- [x] `npm run type-check`, `npm run lint`
- [x] No regression on the pre-existing fixture, verified component-for-component

Verification used a corpus of ~30 open-source Altium designs gathered for this work; the designs named above are the reproducible cases.