### PR TITLE
feat(altium): read the Additional stream and resolve harness types

### DIFF
--- a/src/parsers/altium/harness.test.ts
+++ b/src/parsers/altium/harness.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseHarnessDefinitions,
+  resolveHarnessMembers,
+  collectNestedHarnessTypes,
+} from "./harness.js";
+
+/**
+ * The sample definitions are the verbatim contents of
+ * `channel.Harness` from pulp-bio/HELIOS-R.
+ */
+const HELIOS_CHANNEL_HARNESS = [
+  "AGND_Domain=PULSE_OUT,PULSE_IN,AGND,VDD5,STDN,TEMPOUT",
+  "Channel_interface=PGND,V_LASER_P,3V3_P,AGND,VDD5_A",
+  "PGND_Domain=3V3_P,OP_OUT,PGND,V_LASER",
+].join("\n");
+
+describe("parseHarnessDefinitions", () => {
+  it("parses one type per line", () => {
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+
+    expect([...definitions.keys()].sort()).toEqual([
+      "AGND_Domain",
+      "Channel_interface",
+      "PGND_Domain",
+    ]);
+    expect(definitions.get("PGND_Domain")).toEqual(["3V3_P", "OP_OUT", "PGND", "V_LASER"]);
+  });
+
+  it("tolerates blank lines, CRLF and surrounding whitespace", () => {
+    const definitions = parseHarnessDefinitions("\r\n  A = X , Y \r\n\r\nB=Z\r\n");
+
+    expect(definitions.get("A")).toEqual(["X", "Y"]);
+    expect(definitions.get("B")).toEqual(["Z"]);
+  });
+
+  it("ignores lines that are not a definition", () => {
+    const definitions = parseHarnessDefinitions("not a definition\n=novalue\nC=\nD=W");
+
+    expect([...definitions.keys()]).toEqual(["D"]);
+  });
+});
+
+describe("resolveHarnessMembers", () => {
+  it("returns the members of a flat harness type", () => {
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+
+    expect(resolveHarnessMembers("AGND_Domain", definitions)).toEqual([
+      "PULSE_OUT",
+      "PULSE_IN",
+      "AGND",
+      "VDD5",
+      "STDN",
+      "TEMPOUT",
+    ]);
+  });
+
+  it("recurses into a nested harness type", () => {
+    // Channel_interface's PGND entry carries HarnessType=PGND_Domain, so the
+    // bundle also carries PGND_Domain's members. Flattening one level would drop
+    // OP_OUT and V_LASER entirely.
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+    const nested = new Map([["PGND", "PGND_Domain"]]);
+
+    expect(resolveHarnessMembers("Channel_interface", definitions, nested)).toEqual([
+      "PGND.3V3_P",
+      "PGND.OP_OUT",
+      "PGND.PGND",
+      "PGND.V_LASER",
+      "V_LASER_P",
+      "3V3_P",
+      "AGND",
+      "VDD5_A",
+    ]);
+  });
+
+  it("qualifies nested members so a repeated signal name stays distinct", () => {
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+    const members = resolveHarnessMembers(
+      "Channel_interface",
+      definitions,
+      new Map([["PGND", "PGND_Domain"]])
+    );
+
+    // 3V3_P appears both directly and inside PGND_Domain; they must not collide.
+    expect(members).toContain("3V3_P");
+    expect(members).toContain("PGND.3V3_P");
+  });
+
+  it("returns nothing for an unknown type", () => {
+    expect(resolveHarnessMembers("NoSuchType", parseHarnessDefinitions("A=X"))).toEqual([]);
+  });
+
+  it("stops at a cycle instead of recursing forever", () => {
+    const definitions = parseHarnessDefinitions("A=B,plain\nB=A,other");
+    const nested = new Map([
+      ["B", "B"],
+      ["A", "A"],
+    ]);
+
+    const members = resolveHarnessMembers("A", definitions, nested);
+
+    expect(members).toContain("plain");
+    expect(members).toContain("B.other");
+    // A -> B -> A must terminate; the revisit contributes nothing.
+    expect(members.some((m) => m.split(".").length > 3)).toBe(false);
+  });
+
+  it("handles a type that names itself", () => {
+    const definitions = parseHarnessDefinitions("Self=Self,X");
+
+    expect(resolveHarnessMembers("Self", definitions, new Map([["Self", "Self"]]))).toEqual([
+      "Self",
+      "X",
+    ]);
+  });
+});
+
+describe("collectNestedHarnessTypes", () => {
+  it("maps an entry name to the harness type it expands to", () => {
+    // Shape taken from the Additional stream of HELIOS-R's channel.SchDoc.
+    const nested = collectNestedHarnessTypes([
+      { RECORD: "216", Name: "PGND", HarnessType: "PGND_Domain" },
+      { RECORD: "216", Name: "AGND" },
+      { RECORD: "218" },
+      { RECORD: "18", Name: "CHANNEL", HarnessType: "Channel_interface" },
+    ]);
+
+    expect(nested.get("PGND")).toBe("PGND_Domain");
+    // A plain member has no nested type, and a port is not a harness entry.
+    expect(nested.has("AGND")).toBe(false);
+    expect(nested.has("CHANNEL")).toBe(false);
+  });
+});

--- a/src/parsers/altium/harness.ts
+++ b/src/parsers/altium/harness.ts
@@ -1,0 +1,123 @@
+/**
+ * Altium Signal Harness support.
+ *
+ * A signal harness bundles several signals into one drawn connection. The bundle's
+ * membership is not stored in the `.SchDoc` at all: each document has a sibling
+ * `<name>.Harness` text file listing one type per line.
+ *
+ * See docs/altium-format.md for the record layout.
+ */
+
+/** Harness type name -> the member names it bundles, as written in the file. */
+export type HarnessDefinitions = Map<string, string[]>;
+
+/**
+ * Parse a `.Harness` sidecar file.
+ *
+ * Format is one type per line, `TypeName=Member1,Member2,...`:
+ *
+ *   AGND_Domain=PULSE_OUT,PULSE_IN,AGND,VDD5,STDN,TEMPOUT
+ *   Channel_interface=PGND,V_LASER_P,3V3_P,AGND,VDD5_A
+ *
+ * A member may itself name another harness type; see resolveHarnessMembers.
+ */
+export const parseHarnessDefinitions = (content: string): HarnessDefinitions => {
+  const definitions: HarnessDefinitions = new Map();
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const separator = trimmed.indexOf("=");
+    if (separator <= 0) continue;
+
+    const typeName = trimmed.slice(0, separator).trim();
+    if (!typeName) continue;
+
+    const members = trimmed
+      .slice(separator + 1)
+      .split(",")
+      .map((member) => member.trim())
+      .filter((member) => member.length > 0);
+
+    if (members.length > 0) definitions.set(typeName, members);
+  }
+
+  return definitions;
+};
+
+/**
+ * Which harness type a member name expands to, when that member is itself a
+ * bundle rather than a single signal.
+ *
+ * This mapping does NOT come from the `.Harness` file, which lists member names
+ * only. It is declared on the harness entry record:
+ *
+ *   RECORD=216 | Name=PGND | HarnessType=PGND_Domain
+ *
+ * so building it requires the `Additional` stream records, not just the sidecar.
+ */
+export type NestedHarnessTypes = ReadonlyMap<string, string>;
+
+/**
+ * Resolve a harness type to the flat set of signals it carries.
+ *
+ * Harness types nest: an entry of one type may itself be a harness. In HELIOS-R
+ * the `PGND` entry of `Channel_interface` carries `HarnessType=PGND_Domain`, so
+ * the bundle also carries `PGND_Domain`'s members. Flattening one level drops
+ * them silently.
+ *
+ * Nested members are qualified with the entry that reached them (`PGND.OP_OUT`),
+ * so a signal name appearing in two branches stays distinct.
+ *
+ * A type reachable from itself stops at the repeat rather than recursing forever.
+ */
+export const resolveHarnessMembers = (
+  typeName: string,
+  definitions: HarnessDefinitions,
+  nestedTypes: NestedHarnessTypes = new Map(),
+  visited: ReadonlySet<string> = new Set()
+): string[] => {
+  const members = definitions.get(typeName);
+  if (!members || visited.has(typeName)) return [];
+
+  const seen = new Set(visited).add(typeName);
+  const resolved: string[] = [];
+
+  for (const member of members) {
+    const nestedType = nestedTypes.get(member);
+    const nested = nestedType
+      ? resolveHarnessMembers(nestedType, definitions, nestedTypes, seen)
+      : [];
+
+    if (nested.length === 0) {
+      resolved.push(member);
+      continue;
+    }
+
+    for (const nestedMember of nested) {
+      resolved.push(`${member}.${nestedMember}`);
+    }
+  }
+
+  return resolved;
+};
+
+/**
+ * Build the member-to-nested-type map from harness entry records.
+ *
+ * Pass the records of a parsed schematic (which must include the `Additional`
+ * stream, or there will be no harness entries in it at all).
+ */
+export const collectNestedHarnessTypes = (
+  records: readonly { RECORD?: string; Name?: string; HarnessType?: string }[]
+): Map<string, string> => {
+  const nested = new Map<string, string>();
+  for (const record of records) {
+    if (record.RECORD !== "216") continue;
+    const name = record.Name;
+    const harnessType = record.HarnessType;
+    if (name && harnessType) nested.set(name, harnessType);
+  }
+  return nested;
+};

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -23,7 +23,7 @@ import {
   PIN_ELECTRICAL_TYPES,
   POWER_PORT_STYLES,
 } from "./types.js";
-import { OleReader, readOleStream } from "../ole-reader/ole-reader.js";
+import { OleReader, readOleStream, readOptionalOleStream } from "../ole-reader/ole-reader.js";
 import { parseRecords, findRecords } from "./record-parser.js";
 import { buildHierarchy, getPartsList, flattenHierarchy, findRecordByIndex } from "./hierarchy.js";
 import { extractNets, determineNetList, classifyNets } from "./net-extractor.js";
@@ -35,6 +35,9 @@ export { OleReader };
 export { parseRecords, findRecords };
 export { buildHierarchy, getPartsList, flattenHierarchy };
 export { extractNets, determineNetList };
+
+/** OLE stream holding signal harness objects, absent unless the sheet uses harnesses. */
+const ALTIUM_ADDITIONAL_STREAM = "Additional";
 
 // Re-export schemas for validation
 export * from "./schemas.js";
@@ -373,6 +376,29 @@ export const extractComponents = (schematic: AltiumSchematic): ComponentDetails 
 };
 
 /**
+ * Parse a schematic's records from every stream that carries them.
+ *
+ * Most objects live in `FileHeader`, but signal harness objects (records
+ * 215-218) are written to a separate `Additional` stream. A document parsed from
+ * `FileHeader` alone has no harness connectors, entries or types in it at all, so
+ * any net reaching a harness simply ends there.
+ */
+export const readSchematicRecords = (schdocPath: string, headerBuffer: Buffer): AltiumSchematic => {
+  const schematic = parseRecords(headerBuffer);
+
+  const additional = readOptionalOleStream(schdocPath, ALTIUM_ADDITIONAL_STREAM);
+  if (!additional || additional.length === 0) return schematic;
+
+  const extra = parseRecords(additional);
+  if (extra.records.length === 0) return schematic;
+
+  return {
+    header: schematic.header,
+    records: [...schematic.records, ...extra.records],
+  };
+};
+
+/**
  * Parse Altium .SchDoc file into unified ParsedNetlist schema.
  *
  * This is the main entry point for integration with NetlistService.
@@ -382,7 +408,7 @@ export const parseAltium = async (schdocPath: string): Promise<ParsedNetlist> =>
   const buffer = readOleStream(schdocPath);
 
   // 2. Parse binary stream into records
-  const schematic = parseRecords(buffer);
+  const schematic = readSchematicRecords(schdocPath, buffer);
 
   // 3. Build hierarchy from flat records
   const hierarchical = buildHierarchy(schematic);
@@ -575,7 +601,8 @@ const channelAlpha = (channelIndex: number): string => {
  * Ordered longest-first: a plain `$Component` alternative listed before
  * `$ComponentPrefix` would match its prefix and leave a stray "Prefix" behind.
  */
-const CHANNEL_FORMAT_TOKEN = /\$(ComponentPrefix|ComponentIndex|ChannelIndex|ChannelAlpha|Component|RoomName)/g;
+const CHANNEL_FORMAT_TOKEN =
+  /\$(ComponentPrefix|ComponentIndex|ChannelIndex|ChannelAlpha|Component|RoomName)/g;
 
 /**
  * Apply a channel designator format to a component refdes.
@@ -740,7 +767,12 @@ const expandChannels = (
       }
 
       for (const [origRefdes, pins] of Object.entries(connections)) {
-        const expandedRefdes = applyChannelFormat(channelFormat, origRefdes, roomName, channelIndex);
+        const expandedRefdes = applyChannelFormat(
+          channelFormat,
+          origRefdes,
+          roomName,
+          channelIndex
+        );
         if (!allNets[expandedNetName][expandedRefdes]) {
           allNets[expandedNetName][expandedRefdes] = pins;
         } else {
@@ -814,7 +846,7 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
         structure.topLevelDocument.replace(/\\/g, "/")
       );
       const buffer = readOleStream(topLevelPath);
-      const schematic = parseRecords(buffer);
+      const schematic = readSchematicRecords(topLevelPath, buffer);
       parentSchematic = buildHierarchy(schematic);
     }
   } else {
@@ -826,7 +858,9 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
     for (const candidatePath of schdocPaths) {
       let hierarchical: AltiumSchematic;
       try {
-        hierarchical = buildHierarchy(parseRecords(readOleStream(candidatePath)));
+        hierarchical = buildHierarchy(
+          readSchematicRecords(candidatePath, readOleStream(candidatePath))
+        );
       } catch {
         continue;
       }
@@ -856,7 +890,7 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
 
       // Parse the child sheet once
       const buffer = readOleStream(schdocPath);
-      const schematic = parseRecords(buffer);
+      const schematic = readSchematicRecords(schdocPath, buffer);
       const hierarchical = buildHierarchy(schematic);
       const nets = extractNets(hierarchical);
       const parsedNets = convertNets(nets, hierarchical);

--- a/src/parsers/altium/types.ts
+++ b/src/parsers/altium/types.ts
@@ -109,6 +109,18 @@ export const RECORD_TYPES = {
 
   // === Extended Objects (found in newer Altium versions) ===
   /** Hyperlink */
+  // === Signal Harness Objects ===
+  // These live in the `Additional` OLE stream, not `FileHeader`.
+  /** Harness connector: the box whose entries name the bundled signals */
+  HARNESS_CONNECTOR: "215",
+  /** Harness entry: one member signal of a harness, or a nested harness */
+  HARNESS_ENTRY: "216",
+  /** Harness type label naming the bundle (e.g. "Channel_interface") */
+  HARNESS_TYPE: "217",
+  /** Signal harness: the polyline carrying a bundle, behaves like a bus */
+  SIGNAL_HARNESS: "218",
+
+  /** Hyperlink */
   HYPERLINK: "226",
 } as const;
 

--- a/src/parsers/ole-reader/ole-reader.ts
+++ b/src/parsers/ole-reader/ole-reader.ts
@@ -453,3 +453,17 @@ export const readOleStream = (filePath: string, streamName = "FileHeader"): Buff
   const ole = new OleReader(filePath);
   return ole.readStream(streamName);
 };
+
+/**
+ * Read a stream that a document may not have, returning undefined instead of throwing.
+ *
+ * Altium keeps signal harness objects in an `Additional` stream that only exists in
+ * documents that use them, so its absence is the normal case rather than an error.
+ */
+export const readOptionalOleStream = (filePath: string, streamName: string): Buffer | undefined => {
+  try {
+    return new OleReader(filePath).readStream(streamName);
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
Progress on #43 — the parsing foundation. Does **not** close it; net tracing through harnesses is still to come.

## Root cause of #43

Signal harness objects are not in `FileHeader`. Altium writes records 215–218 (harness connector, entry, type, signal harness) to a **separate `Additional` OLE stream**, and the parser only ever read `FileHeader`.

So a document using harnesses had *no harness objects in it at all*. Not "connectivity logic missing" — the objects were invisible. Any net reaching a harness simply ended there, which is exactly the reported symptom.

Confirmed on `pulp-bio/HELIOS-R`:

```
Storage      49628 bytes,  0 harness records
Additional    1637 bytes,  8 harness records   <-- never read
FileHeader   73451 bytes,  0 harness records
```

Reading `Additional` where present takes `main.SchDoc` from 442 to 450 records, gaining its 1 connector, 5 entries, 1 type and 1 signal harness. Documents without harnesses have no such stream, so absence is the normal case and is not treated as an error.

## Harness type resolution

Membership is not in the `.SchDoc` either — each document has a plain-text `<name>.Harness` sidecar:

```
AGND_Domain=PULSE_OUT,PULSE_IN,AGND,VDD5,STDN,TEMPOUT
Channel_interface=PGND,V_LASER_P,3V3_P,AGND,VDD5_A
PGND_Domain=3V3_P,OP_OUT,PGND,V_LASER
```

**Types nest, and the nesting is declared on the entry record, not in the sidecar:**

```
RECORD=216 | Name=PGND | HarnessType=PGND_Domain
```

The sidecar lists `PGND` as a plain member name; only the record reveals it is itself a bundle. Resolution therefore needs both sources and recurses. I got this wrong first and a test caught it — worth stating, because a one-level flatten silently drops `OP_OUT` and `V_LASER` while still looking plausible.

Verified against the real files:

```
Channel_interface carries:
  PGND.3V3_P, PGND.OP_OUT, PGND.PGND, PGND.V_LASER, V_LASER_P, 3V3_P, AGND, VDD5_A
```

Nested members are qualified by the entry that reached them, so `3V3_P` (direct) and `PGND.3V3_P` (nested) stay distinct. A type reachable from itself terminates rather than recursing forever.

## Changelog

None yet — no user-visible behaviour change. Harness objects are now parsed and their types resolvable; tracing nets through them follows.

## Test plan

- [x] `src/parsers/altium/harness.test.ts` — 10 tests: sidecar parsing incl. CRLF/whitespace/malformed lines, flat resolution, nested resolution, name-collision qualification, unknown type, cycle termination, self-reference, and nested-type collection from records
- [x] Verified end to end on `pulp-bio/HELIOS-R`: the `PGND` → `PGND_Domain` nesting is discovered from the records and resolves to all 8 signals
- [x] `npx vitest run` — 643 passed, 42/42 files
- [x] No regression: `aberrant-sound-module` 105 comps / 108 nets unchanged; `HELIOS-R` and `qfsae/pcb` parse cleanly
- [x] `npm run type-check`, `npm run lint`

## Next

Wire harness members into connectivity: treat `RECORD=218` as a bus, attach harness entries at the connector's primary connection point, and propagate members across harness-typed ports. Validation targets are `HELIOS-R` (nested), `qfsae/pcb` (dense), `ohwr/utca-rtm-8-sfp` (119 signal harnesses).