### PR TITLE
feat(altium): trace nets through signal harness entries

### DIFF
--- a/src/parsers/altium/harness.test.ts
+++ b/src/parsers/altium/harness.test.ts
@@ -3,6 +3,7 @@ import {
   parseHarnessDefinitions,
   resolveHarnessMembers,
   collectNestedHarnessTypes,
+  positionHarnessEntries,
 } from "./harness.js";
 
 /**
@@ -130,5 +131,72 @@ describe("collectNestedHarnessTypes", () => {
     // A plain member has no nested type, and a port is not a harness entry.
     expect(nested.has("AGND")).toBe(false);
     expect(nested.has("CHANNEL")).toBe(false);
+  });
+});
+
+describe("positionHarnessEntries", () => {
+  it("places entries on the connector's left edge at the verified pitch", () => {
+    // Geometry taken from pulp-bio/HELIOS-R main.SchDoc, where the five wires
+    // landing on this connector end at y = 660, 650, 580, 570 and 540.
+    const records = [
+      {
+        RECORD: "215",
+        "Location.X": "410",
+        "Location.Y": "670",
+        XSize: "80",
+        HarnessConnectorSide: "1",
+      },
+      { RECORD: "216", Name: "V_LASER_P", DistanceFromTop: "1" },
+      { RECORD: "216", Name: "PGND", DistanceFromTop: "2" },
+      { RECORD: "216", Name: "3V3_P", DistanceFromTop: "9" },
+      { RECORD: "216", Name: "AGND", DistanceFromTop: "10" },
+      { RECORD: "216", Name: "VDD5_A", DistanceFromTop: "13" },
+    ];
+
+    expect(positionHarnessEntries(records)).toBe(5);
+    expect(records.map((r) => r["Location.Y"]).slice(1)).toEqual([
+      "660",
+      "650",
+      "580",
+      "570",
+      "540",
+    ]);
+    expect(records[1]["Location.X"]).toBe("410");
+  });
+
+  it("assigns entries to the most recent connector, not by OwnerIndex", () => {
+    // OwnerIndex is present on some entries and absent on others in real files,
+    // so stream order is what links an entry to its connector.
+    const records = [
+      { RECORD: "215", "Location.X": "100", "Location.Y": "500", HarnessConnectorSide: "1" },
+      { RECORD: "216", Name: "A", DistanceFromTop: "1" },
+      { RECORD: "215", "Location.X": "300", "Location.Y": "800", HarnessConnectorSide: "1" },
+      { RECORD: "216", Name: "B", DistanceFromTop: "2" },
+    ];
+
+    positionHarnessEntries(records);
+
+    expect(records[1]["Location.X"]).toBe("100");
+    expect(records[1]["Location.Y"]).toBe("490");
+    expect(records[3]["Location.X"]).toBe("300");
+    expect(records[3]["Location.Y"]).toBe("780");
+  });
+
+  it("leaves entries on an unverified connector side unpositioned", () => {
+    // Better to contribute no connectivity than to invent a connection whose
+    // geometry has not been confirmed against a real design.
+    const records = [
+      { RECORD: "215", "Location.X": "10", "Location.Y": "20", HarnessConnectorSide: "2" },
+      { RECORD: "216", Name: "X", DistanceFromTop: "1" },
+    ];
+
+    expect(positionHarnessEntries(records)).toBe(0);
+    expect(records[1]["Location.Y"]).toBeUndefined();
+  });
+
+  it("ignores an entry with no preceding connector", () => {
+    const records = [{ RECORD: "216", Name: "orphan", DistanceFromTop: "1" }];
+
+    expect(positionHarnessEntries(records)).toBe(0);
   });
 });

--- a/src/parsers/altium/harness.ts
+++ b/src/parsers/altium/harness.ts
@@ -121,3 +121,65 @@ export const collectNestedHarnessTypes = (
   }
   return nested;
 };
+
+/**
+ * Grid units per `DistanceFromTop` step on a harness connector.
+ *
+ * Derived from pulp-bio/HELIOS-R: its connector sits at Location.Y=670 with
+ * entries at DistanceFromTop 1, 2, 9, 10 and 13, and the five wires that land on
+ * it end at y = 660, 650, 580, 570 and 540 — exactly Location.Y - n * 10.
+ */
+const HARNESS_ENTRY_PITCH = 10;
+
+/** Connector side whose geometry is verified against a real design. */
+const HARNESS_SIDE_ENTRIES_LEFT = "1";
+
+interface PositionedRecord {
+  RECORD?: string;
+  Name?: string;
+  DistanceFromTop?: string;
+  "Location.X"?: string;
+  "Location.Y"?: string;
+  XSize?: string;
+  HarnessConnectorSide?: string;
+}
+
+/**
+ * Give every harness entry the coordinate at which wires meet it.
+ *
+ * Entries carry only a `DistanceFromTop` and inherit their position from the
+ * harness connector that owns them. `OwnerIndex` is present on some entries and
+ * absent on others, so ownership is taken from stream order: entries follow
+ * their connector.
+ *
+ * Only `HarnessConnectorSide=1` is positioned, because that is the arrangement
+ * confirmed against a real design. Entries on an unverified side are left
+ * without coordinates, so they simply do not participate in connectivity rather
+ * than inventing a connection that may not exist.
+ */
+export const positionHarnessEntries = (records: PositionedRecord[]): number => {
+  let connector: PositionedRecord | undefined;
+  let positioned = 0;
+
+  for (const record of records) {
+    if (record.RECORD === "215") {
+      connector = record;
+      continue;
+    }
+    if (record.RECORD !== "216" || !connector) continue;
+    if (connector.HarnessConnectorSide !== HARNESS_SIDE_ENTRIES_LEFT) continue;
+
+    const originX = Number(connector["Location.X"]);
+    const originY = Number(connector["Location.Y"]);
+    const distance = Number(record.DistanceFromTop);
+    if (!Number.isFinite(originX) || !Number.isFinite(originY) || !Number.isFinite(distance)) {
+      continue;
+    }
+
+    record["Location.X"] = String(originX);
+    record["Location.Y"] = String(originY - distance * HARNESS_ENTRY_PITCH);
+    positioned++;
+  }
+
+  return positioned;
+};

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -27,6 +27,7 @@ import { OleReader, readOleStream, readOptionalOleStream } from "../ole-reader/o
 import { parseRecords, findRecords } from "./record-parser.js";
 import { buildHierarchy, getPartsList, flattenHierarchy, findRecordByIndex } from "./hierarchy.js";
 import { extractNets, determineNetList, classifyNets } from "./net-extractor.js";
+import { positionHarnessEntries } from "./harness.js";
 
 // Re-export types and utilities for external use
 export type { AltiumSchematic, AltiumNet, AltiumRecord, OutputFormat };
@@ -391,6 +392,8 @@ export const readSchematicRecords = (schdocPath: string, headerBuffer: Buffer): 
 
   const extra = parseRecords(additional);
   if (extra.records.length === 0) return schematic;
+
+  positionHarnessEntries(extra.records as never);
 
   return {
     header: schematic.header,

--- a/src/parsers/altium/net-extractor.ts
+++ b/src/parsers/altium/net-extractor.ts
@@ -82,6 +82,9 @@ const findConnectableDevices = (schematic: AltiumSchematic): AltiumRecord[] => {
     RECORD_TYPES.NET_LABEL,
     RECORD_TYPES.POWER_PORT,
     RECORD_TYPES.PORT,
+    // Harness entries are given a Location by positionHarnessEntries(); a wire
+    // landing on one joins the signal that entry names.
+    RECORD_TYPES.HARNESS_ENTRY,
     // Note: SHEET_ENTRY (16) is NOT included here. It uses DISTANCEFROMTOP relative to its
     // parent SHEET_SYMBOL, not absolute Location.X/Y. Cross-sheet connectivity is handled
     // by multi-channel expansion in parseAltiumProject() instead.
@@ -305,6 +308,7 @@ const assignNetName = (net: AltiumNet, schematic: AltiumSchematic): void => {
     RECORD_TYPES.POWER_PORT,
     RECORD_TYPES.NET_LABEL,
     RECORD_TYPES.PORT,
+    RECORD_TYPES.HARNESS_ENTRY,
   ]);
   for (const device of net.devices) {
     if (device.RECORD && namingTypes.has(device.RECORD)) {


### PR DESCRIPTION
Fixes #43.

## Summary

Completes harness support. #104 made the harness objects visible by reading the `Additional` OLE stream; this makes nets actually route through them.

Harness entries carry only a `DistanceFromTop` and inherit their position from the connector that owns them, so even once parsed they had no coordinates — nothing in the parse gave a wire anywhere to land. Entries are now positioned and registered as connectable, naming devices, so a wire ending on one joins the signal that entry names.

## The pitch was derived, not assumed

From `pulp-bio/HELIOS-R`. Its connector sits at `Location.Y=670` with entries at `DistanceFromTop` 1, 2, 9, 10 and 13. The five wires that land on that connector end at:

```
entry      DistanceFromTop   predicted y   actual wire endpoint
V_LASER_P        1               660              660
PGND             2               650              650
3V3_P            9               580              580
AGND            10               570              570
VDD5_A          13               540              540
```

`y = Location.Y − DistanceFromTop × 10`, five out of five.

Two deliberate conservatisms:

- **Ownership comes from stream order**, because `OwnerIndex` is present on some entries and absent on others in real files.
- **Only `HarnessConnectorSide=1` is positioned** — the arrangement confirmed against a real design. Entries on any other side are left without coordinates, so they contribute no connectivity rather than inventing a connection whose geometry hasn't been verified.

## Result

`HELIOS-R` resolves **96 harness-member nets across its nine channels** — `V_LASER_CHAN1`, `AGND_CHAN1`, `PGND_CHAN1`, `OP_OUT_CHAN1` … — where those signals previously terminated at the harness and the components on them read as unconnected, which is the symptom reported in #43.

| Design | Harness records | Result |
|---|---|---|
| `pulp-bio/HELIOS-R` | nested types, 9 channels | 21 comps, 96 harness-member nets |
| `qfsae/pcb` q23-harness | 115/359/115/66 | 63 comps, 154 nets |
| `ohwr/utca-rtm-8-sfp` | 51/168/45/119 | 188 comps, 297 nets |
| `memristor/electronics` | 2/6/2/2 | 86 comps, 77 nets |
| `aberrant-sound-module` (no harness, control) | none | **105/108 unchanged** |

## Changelog

Nets are now traced through Altium signal harnesses. Harness objects live in a separate `Additional` OLE stream that was never read, so harness connectors, entries and types were absent from the parse entirely and any net reaching a harness ended there, leaving connected components reported as unconnected. Harness entries are now parsed, positioned and connected, and harness types — including nested ones — resolve to their member signals.

## Test plan

- [x] `src/parsers/altium/harness.test.ts` — 14 tests: sidecar parsing, flat and nested type resolution, name-collision qualification, cycle termination, nested-type collection from records, entry positioning against the verified HELIOS-R geometry, stream-order ownership, unverified-side skip, orphan entry
- [x] `npx vitest run` — 643 passed, 42/42 files
- [x] Four harness designs parse; the no-harness control is unchanged component-for-component
- [x] `npm run type-check`, `npm run lint`

## Not covered

Cross-sheet propagation of a harness through a harness-typed `PORT`/`SHEET_ENTRY` — the members resolve and connect within a sheet, and `resolveHarnessMembers` supplies the bundle contents, but the port-to-port hand-off is not wired. Worth a follow-up issue if a design needs it.