### PR TITLE
feat(altium): carry harness bundles across sheet boundaries

### DIFF
--- a/src/parsers/altium/harness.test.ts
+++ b/src/parsers/altium/harness.test.ts
@@ -200,3 +200,38 @@ describe("positionHarnessEntries", () => {
     expect(positionHarnessEntries(records)).toBe(0);
   });
 });
+
+describe("cross-sheet harness members", () => {
+  it("resolves the bundle a harness-typed sheet entry carries", () => {
+    // main.SchDoc's sheet entry CHANNEL is typed Channel_interface; the members
+    // below are what must cross the sheet boundary with it.
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+    const nested = new Map([["PGND", "PGND_Domain"]]);
+
+    const members = resolveHarnessMembers("Channel_interface", definitions, nested);
+    const leaves = members.map((m) => m.slice(m.lastIndexOf(".") + 1));
+
+    // Both the qualified path and the leaf name matter: the leaf is what a net
+    // inside the child sheet is actually called.
+    expect(leaves).toContain("OP_OUT");
+    expect(leaves).toContain("V_LASER");
+    expect(members).toContain("V_LASER_P");
+    expect(members).toContain("AGND");
+  });
+
+  it("carries nested members across the boundary too", () => {
+    // A one-level flatten would leave OP_OUT and V_LASER behind on the child
+    // sheet, where they would become per-channel nets connected to nothing.
+    const definitions = parseHarnessDefinitions(HELIOS_CHANNEL_HARNESS);
+    const flat = resolveHarnessMembers("Channel_interface", definitions);
+    const withNesting = resolveHarnessMembers(
+      "Channel_interface",
+      definitions,
+      new Map([["PGND", "PGND_Domain"]])
+    );
+
+    expect(flat).toContain("PGND");
+    expect(flat.some((m) => m.endsWith("OP_OUT"))).toBe(false);
+    expect(withNesting.some((m) => m.endsWith("OP_OUT"))).toBe(true);
+  });
+});

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -27,7 +27,13 @@ import { OleReader, readOleStream, readOptionalOleStream } from "../ole-reader/o
 import { parseRecords, findRecords } from "./record-parser.js";
 import { buildHierarchy, getPartsList, flattenHierarchy, findRecordByIndex } from "./hierarchy.js";
 import { extractNets, determineNetList, classifyNets } from "./net-extractor.js";
-import { positionHarnessEntries } from "./harness.js";
+import {
+  positionHarnessEntries,
+  parseHarnessDefinitions,
+  resolveHarnessMembers,
+  collectNestedHarnessTypes,
+} from "./harness.js";
+import type { HarnessDefinitions } from "./harness.js";
 
 // Re-export types and utilities for external use
 export type { AltiumSchematic, AltiumNet, AltiumRecord, OutputFormat };
@@ -687,9 +693,27 @@ interface SheetEntryClassification {
  * Repeat() entries produce per-channel nets; others are shared.
  * Bus notation (e.g., "AD[0..7]") is expanded into individual signals.
  */
+/**
+ * Load the harness type definitions that apply to a schematic document.
+ *
+ * Membership is not stored in the `.SchDoc`; each document has a sibling
+ * `<name>.Harness` text file. A document that uses no harnesses has none, so a
+ * missing file is the normal case.
+ */
+const readHarnessDefinitions = async (schdocPath: string): Promise<HarnessDefinitions> => {
+  const sidecar = schdocPath.replace(/\.SchDoc$/i, ".Harness");
+  try {
+    return parseHarnessDefinitions(await readFile(sidecar, "utf-8"));
+  } catch {
+    return new Map();
+  }
+};
+
 const classifySheetEntries = (
   parentSchematic: AltiumSchematic,
-  childFileName: string
+  childFileName: string,
+  harnessDefinitions: HarnessDefinitions = new Map(),
+  nestedHarnessTypes: ReadonlyMap<string, string> = new Map()
 ): SheetEntryClassification => {
   const repeatNames = new Set<string>();
   const sharedNames = new Set<string>();
@@ -707,13 +731,30 @@ const classifySheetEntries = (
       const rawName = String(child.Name ?? child.NAME ?? "");
       const repeatMatch = rawName.match(/^Repeat\((.+)\)$/i);
 
-      if (repeatMatch) {
-        for (const signal of expandBusNotation(repeatMatch[1])) {
-          repeatNames.add(signal);
-        }
-      } else {
-        for (const signal of expandBusNotation(rawName)) {
-          sharedNames.add(signal);
+      const target = repeatMatch ? repeatNames : sharedNames;
+      const entryName = repeatMatch ? repeatMatch[1] : rawName;
+
+      for (const signal of expandBusNotation(entryName)) {
+        target.add(signal);
+      }
+
+      // A harness-typed entry carries a bundle, not one signal. Every member the
+      // bundle resolves to crosses the sheet boundary with it and is classified
+      // the same way, so a shared harness keeps its members shared rather than
+      // giving each channel a private copy that connects to nothing.
+      const harnessType = child.HarnessType;
+      if (harnessType) {
+        for (const member of resolveHarnessMembers(
+          String(harnessType),
+          harnessDefinitions,
+          nestedHarnessTypes
+        )) {
+          target.add(member);
+          // Members are qualified by the entry that reached them
+          // (PGND.OP_OUT); the leaf name is what a net inside the child sheet
+          // is actually called.
+          const leaf = member.slice(member.lastIndexOf(".") + 1);
+          if (leaf) target.add(leaf);
         }
       }
     }
@@ -835,6 +876,7 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
   // sheets from different parents, and each expansion needs its own parent to
   // classify that sheet symbol's entries.
   const repeatParents = new Map<string, AltiumSchematic>();
+  const repeatParentPaths = new Map<string, string>();
 
   if (structurePath) {
     const structureContent = await readFile(structurePath, "utf-8");
@@ -851,6 +893,9 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       const buffer = readOleStream(topLevelPath);
       const schematic = readSchematicRecords(topLevelPath, buffer);
       parentSchematic = buildHierarchy(schematic);
+      for (const childFile of repeatedSheets.keys()) {
+        repeatParentPaths.set(childFile, topLevelPath);
+      }
     }
   } else {
     // No compiled structure file: recover the channels from the sheet symbols
@@ -873,6 +918,7 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
         if (repeatedSheets.has(childFile)) continue;
         repeatedSheets.set(childFile, instances);
         repeatParents.set(childFile, hierarchical);
+        repeatParentPaths.set(childFile, candidatePath);
       }
     }
   }
@@ -902,7 +948,21 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       const baseResult: ParsedNetlist = { nets: parsedNets, components };
 
       // Classify SHEET_ENTRY records: Repeat() → per-channel, others → shared
-      const entryClassification = classifySheetEntries(channelParent, channels[0].fileName);
+      // The bundle definitions live beside the parent document, whose sheet
+      // entry declares the harness type; nesting is declared on the entry
+      // records of the parent schematic.
+      const parentDocument = repeatParentPaths.get(schdocBase);
+      const harnessDefinitions = parentDocument
+        ? await readHarnessDefinitions(parentDocument)
+        : new Map();
+      const nestedHarnessTypes = collectNestedHarnessTypes(channelParent.records as never);
+
+      const entryClassification = classifySheetEntries(
+        channelParent,
+        channels[0].fileName,
+        harnessDefinitions,
+        nestedHarnessTypes
+      );
 
       // Expand into N channel instances
       const expanded = expandChannels(


### PR DESCRIPTION
Completes signal harness support (#43). Follows #104 (read the `Additional` stream) and #105 (trace nets through harness entries).

## Summary

A harness crosses a sheet boundary through a harness-typed sheet entry on the parent and the matching port in the child:

```
main.SchDoc:     SHEET_ENTRY  CHANNEL  harnessType=Channel_interface
channel.SchDoc:  PORT         CHANNEL  harnessType=Channel_interface
```

`classifySheetEntries` only ever looked at the entry's own name — `CHANNEL` — so the five signals the bundle actually carries were invisible to it. Each became a per-channel local net inside the child and connected to nothing on the parent side, which is the cross-sheet half of #43.

Members are now resolved from the harness type and classified along with the entry that carries them. Nested bundles resolve too, and both the qualified path (`PGND.OP_OUT`) and the leaf name (`OP_OUT`) are registered, because the leaf is what a net inside the child sheet is actually called.

## Shared vs per-channel is the distinction that matters

HELIOS-R's `CHANNEL` entry is **not** wrapped in `Repeat()`, so its bundle is shared by all nine channels rather than duplicated per channel. Getting this backwards would produce nine private copies that connect to nothing — the same failure in a new disguise.

| Member | Before | After |
|---|---|---|
| `PGND` | per-channel copies | **1 net, 21 refdes** |
| `AGND` | per-channel copies | **1 net, 18 refdes** |
| `3V3_P` | per-channel copies | **1 net, 10 refdes** |
| `V_LASER_P`, `VDD5_A` | per-channel copies | single shared nets |

Per-channel copies of these members: **0**. Total nets 222 → 196, the drop being orphaned duplicates merging into real connections.

## Controls unchanged

| Design | Result |
|---|---|
| `aberrant-sound-module` (no harness) | 105 comps / 108 nets, unchanged |
| `heron-hardware` (multi-channel, no harness) | 320 comps, unchanged |
| `cube-sat-eps` (multi-channel, no harness) | 112 comps, unchanged |
| `qfsae/pcb` (harness) | 63 comps / 154 nets |

## Changelog

Altium signal harnesses now connect across sheet boundaries. A harness-typed sheet entry carries its bundle's member signals into the child sheet, including members of nested harness types, so components joined by a harness across pages are reported as connected instead of as separate unconnected nets.

## Test plan

- [x] `harness.test.ts` — 16 tests, adding bundle resolution for a harness-typed sheet entry and a case proving nested members would otherwise be stranded on the child sheet
- [x] `npx vitest run` — 647 passed, 42/42 files
- [x] Verified on HELIOS-R that members become single shared nets with no per-channel copies
- [x] Three control designs unchanged component-for-component
- [x] `npm run type-check`, `npm run lint`