### PR TITLE
fix(cadence): recover pin function names from the Cache stream

### DIFF
--- a/docs/dsn-format.md
+++ b/docs/dsn-format.md
@@ -921,6 +921,30 @@ Cache LibraryPart names include a numeric suffix from the Package stream they or
 
 3. **Name-equals-number stripping**: When a pin's functional name equals its pin number (common for passives like resistors and capacitors), the name is treated as absent. This matches DAT behavior where such pins have no separate name field.
 
+
+#### Recovering LibraryParts from the Cache
+
+**Confidence: VERIFIED**
+
+Pin function names come from LibraryPart records, which the Cache stream carries alongside the Package records that give pin numbers. Two things decide whether a design gets names at all.
+
+**Finding the record.** The Cache is walked sequentially, and on some designs that walk gives up after a handful of entries; a brute-force scan for the preamble magic (`FF E4 5C 39`) then recovers the rest. Stepping back from the magic to the start of the record is the hard part, because a record is a prefix chain: zero or more long prefixes of 9 bytes, then a short prefix of `type(1) + int16 pairCount` followed by 8 bytes per (nameIdx, valIdx) pair.
+
+Assuming the short prefix sits exactly 3 bytes before the magic holds only when it carries no pairs and nothing precedes it. Across the fixture corpus that is true for **every** Package, and for a minority of LibraryParts:
+
+| Design | LibraryParts | with pairCount = 0 |
+|---|---|---|
+| LAUNCHXL-CC1310 | 45 | 13 |
+| CutiePi V2.3 | 57 | 17 |
+| reComputer Industrial J201 | 96 | 1 |
+| BeagleBoard-xM | 85 | 49 |
+
+So a design whose sequential walk failed early came out with pin numbers for every component and pin names for none: LAUNCHXL-CC1310 and CutiePi both yielded 0 LibraryParts while yielding 41 and 57 Packages. The scan now searches for the pair count and then for the chain start, letting the prefix reader validate each candidate.
+
+**Choosing between variants.** Instances refer to a part by a suffix-stripped name, so each part is registered under its own name and under `name.replace(/_\d+(?=\.)/, "")`. Two variants of one base part then compete for the stripped key, and a part's own name must outrank an alias derived from a different variant. CutiePi carries both `RES_0.Normal`, whose pins are named `1` and `2`, and `RES.Normal`, whose pins are named `A` and `B`; `RES_0.Normal` strips to `RES.Normal`, so first-writer-wins gave every plain resistor the other variant's numbering. Since a pin name equal to the pin number is dropped as carrying no information, those 75 components reported no pin names at all.
+
+With both fixed, pin function names match the DAT export on 8105 of 8105 pins across all 11 fixtures.
+
 ### 11.3 Package Key Matching
 
 **Confidence: VERIFIED**

--- a/src/parsers/cadence/dsn/cache-parser.test.ts
+++ b/src/parsers/cadence/dsn/cache-parser.test.ts
@@ -1,0 +1,65 @@
+/**
+ * LibraryPart indexing: which record owns a given lookup key.
+ *
+ * Instances refer to a part by a suffix-stripped name, so every part is also
+ * registered under that stripped form. Two variants of the same base part then
+ * compete for one key, and picking the wrong winner costs the pin function names
+ * of every instance of the plain variant.
+ */
+
+import { describe, expect, it } from "vitest";
+import { indexLibraryPart } from "./cache-parser.js";
+import type { CachedLibraryPart } from "./structure-types.js";
+
+const part = (name: string, pinNames: string[]) => ({ name, pinNames });
+
+const index = (...parts: { name: string; pinNames: string[] }[]) => {
+  const cachedParts = new Map<string, CachedLibraryPart>();
+  const exactNames = new Set<string>();
+  for (const p of parts) indexLibraryPart(p, cachedParts, exactNames);
+  return cachedParts;
+};
+
+describe("indexLibraryPart", () => {
+  it("registers a part under its own name and its stripped form", () => {
+    const parts = index(part("DIODE_0.Normal", ["A", "C"]));
+
+    expect(parts.get("DIODE_0.Normal")?.pinNames).toEqual(["A", "C"]);
+    expect(parts.get("DIODE.Normal")?.pinNames).toEqual(["A", "C"]);
+  });
+
+  it("lets a part's own name displace an alias another variant left there", () => {
+    // Verbatim from CutiePi: RES_0.Normal names its pins after their numbers and
+    // strips to RES.Normal, while the real RES.Normal names them A and B. First
+    // writer wins gave every plain resistor the numbering, and a pin name equal
+    // to the pin number is dropped, so those parts reported no names at all.
+    const parts = index(part("RES_0.Normal", ["1", "2"]), part("RES.Normal", ["A", "B"]));
+
+    expect(parts.get("RES.Normal")?.pinNames).toEqual(["A", "B"]);
+    expect(parts.get("RES_0.Normal")?.pinNames).toEqual(["1", "2"]);
+  });
+
+  it("keeps a part's own name whatever order the aliases arrive in", () => {
+    const parts = index(part("RES.Normal", ["A", "B"]), part("RES_0.Normal", ["1", "2"]));
+
+    expect(parts.get("RES.Normal")?.pinNames).toEqual(["A", "B"]);
+  });
+
+  it("keeps the first record when two claim the same exact name", () => {
+    const parts = index(part("IC.Normal", ["VCC"]), part("IC.Normal", ["GND"]));
+
+    expect(parts.get("IC.Normal")?.pinNames).toEqual(["VCC"]);
+  });
+
+  it("does not let a later alias displace an earlier one", () => {
+    const parts = index(part("PART_1.Normal", ["X"]), part("PART_2.Normal", ["Y"]));
+
+    expect(parts.get("PART.Normal")?.pinNames).toEqual(["X"]);
+  });
+
+  it("leaves a name with no strippable suffix alone", () => {
+    const parts = index(part("PLAIN.Normal", ["P"]));
+
+    expect([...parts.keys()]).toEqual(["PLAIN.Normal"]);
+  });
+});

--- a/src/parsers/cadence/dsn/cache-parser.ts
+++ b/src/parsers/cadence/dsn/cache-parser.ts
@@ -70,13 +70,30 @@ function indexCachePackage(pkg: import("./structures.js").Package, pmd: PinMapDa
   }
 }
 
-/** Index a Cache LibraryPart's pin names (fallback; doesn't override existing entries). */
-function indexCacheLibraryPart(
-  lp: import("./structures.js").LibraryPart,
-  cachedParts: Map<string, CachedLibraryPart>
+/**
+ * Index a LibraryPart's pin names, under its own name and under the
+ * suffix-stripped form other instances refer to it by.
+ *
+ * A part's own name outranks a stripped form derived from a different variant.
+ * CutiePi holds both `RES_0.Normal`, whose pins are named "1" and "2", and
+ * `RES.Normal`, whose pins are named "A" and "B". `RES_0.Normal` strips to
+ * `RES.Normal`, so first-writer-wins gave every plain resistor in the design the
+ * numbering-as-names of the other variant, which is then discarded for matching
+ * the pin number. `exactNames` records which keys a part claimed under its own
+ * name so a later alias cannot displace it and an alias cannot outrank it.
+ */
+export function indexLibraryPart(
+  lp: { name: string; pinNames: string[]; defaultValue?: string },
+  cachedParts: Map<string, CachedLibraryPart>,
+  exactNames: Set<string>
 ): void {
   const entry: CachedLibraryPart = { pinNames: lp.pinNames, defaultValue: lp.defaultValue };
-  if (!cachedParts.has(lp.name)) cachedParts.set(lp.name, entry);
+
+  if (!exactNames.has(lp.name)) {
+    cachedParts.set(lp.name, entry);
+    exactNames.add(lp.name);
+  }
+
   const stripped = lp.name.replace(/_\d+(?=\.)/, "");
   if (stripped !== lp.name && !cachedParts.has(stripped)) {
     cachedParts.set(stripped, entry);
@@ -84,49 +101,78 @@ function indexCacheLibraryPart(
 }
 
 /**
- * Brute-force scan the Cache buffer for Package and LibraryPart structures
- * by locating preamble magic bytes (FF E4 5C 39).
+ * Brute-force scan the Cache buffer for Package and LibraryPart structures by
+ * locating preamble magic bytes (FF E4 5C 39).
  *
- * When sequential metadata parsing fails, this recovers remaining structures.
- * For each preamble magic occurrence, checks if 3 bytes earlier is a valid
- * short prefix for Package (0x1F) or LibraryPart (0x18), and attempts to
- * parse the structure.
+ * This runs when sequential metadata parsing gives up, which on some designs
+ * happens after a handful of entries, leaving the scan to recover everything
+ * else. Both structure kinds have to be found, because the Packages give pin
+ * numbers and the LibraryParts give pin function names.
+ *
+ * Walking back from the magic to the start of the record is the whole problem.
+ * A record is a chain of prefixes: zero or more long ones of 9 bytes, then a
+ * short one of `type(1) + int16 pairCount` followed by 8 bytes per
+ * (nameIdx, valIdx) pair. Assuming the short prefix sits exactly 3 bytes back
+ * only holds when it carries no pairs and nothing precedes it. Across the
+ * fixture corpus that is true for every Package, and for a minority of
+ * LibraryParts: LAUNCHXL-CC1310 has 45 of them and 13 fit that shape, so a
+ * design whose sequential parse failed early came out with pin numbers for
+ * every component and pin names for none.
+ *
+ * So the pair count is searched for, and then the chain start, and the parse
+ * itself decides: the prefix reader validates the chain, so a wrong guess
+ * throws and the next candidate is tried.
  */
 function scanForStructures(
   reader: BinaryReader,
   buffer: Buffer,
   pmd: PinMapData,
-  cachedParts: Map<string, CachedLibraryPart>
+  cachedParts: Map<string, CachedLibraryPart>,
+  exactNames: Set<string>
 ): void {
   const MAGIC = Buffer.from([0xff, 0xe4, 0x5c, 0x39]);
+  /** Widest (nameIdx, valIdx) list seen in a fixture is 19 pairs. */
+  const MAX_PAIRS = 64;
+  const MAX_LONG_PREFIXES = 10;
   let pos = reader.tell();
 
   while (pos < buffer.length - 10) {
     const magicIdx = buffer.indexOf(MAGIC, pos);
     if (magicIdx < 3) break;
+    let advanced = false;
 
-    // A short prefix is 3 bytes (type + int16 size) before the preamble.
-    const prefixStart = magicIdx - 3;
-    const typeByte = buffer[prefixStart];
+    for (let pairs = 0; pairs <= MAX_PAIRS && !advanced; pairs++) {
+      const shortAt = magicIdx - 3 - 8 * pairs;
+      if (shortAt < 0) break;
 
-    if (typeByte === StructureType.Package || typeByte === StructureType.LibraryPart) {
-      reader.seek(prefixStart);
-      try {
-        if (typeByte === StructureType.Package) {
-          const pkg = parsePackage(reader);
-          indexCachePackage(pkg, pmd);
-        } else {
-          const lp = parseLibraryPart(reader);
-          indexCacheLibraryPart(lp, cachedParts);
+      const typeByte = buffer[shortAt];
+      if (typeByte !== StructureType.Package && typeByte !== StructureType.LibraryPart) continue;
+      if (buffer.readInt16LE(shortAt + 1) !== pairs) continue;
+
+      // Every prefix in a chain repeats the type byte, so walk back in 9-byte
+      // steps while that holds and let the parse pick the real start.
+      for (let long = 0; long <= MAX_LONG_PREFIXES; long++) {
+        const structStart = shortAt - 9 * long;
+        if (structStart < 0) break;
+        if (long > 0 && buffer[structStart] !== typeByte) break;
+
+        reader.seek(structStart);
+        try {
+          if (typeByte === StructureType.Package) {
+            indexCachePackage(parsePackage(reader), pmd);
+          } else {
+            indexLibraryPart(parseLibraryPart(reader), cachedParts, exactNames);
+          }
+          pos = reader.tell();
+          advanced = true;
+          break;
+        } catch {
+          // Not the chain start; try one prefix further back.
         }
-        pos = reader.tell();
-        continue;
-      } catch {
-        // Not a valid structure; skip past this magic occurrence
       }
     }
 
-    pos = magicIdx + 1;
+    if (!advanced) pos = magicIdx + 1;
   }
 }
 
@@ -143,7 +189,8 @@ function scanForStructures(
 export function parseCacheStream(
   buffer: Buffer,
   pmd: PinMapData,
-  cachedParts: Map<string, CachedLibraryPart>
+  cachedParts: Map<string, CachedLibraryPart>,
+  exactNames: Set<string> = new Set()
 ): void {
   const reader = new BinaryReader(buffer);
 
@@ -238,7 +285,7 @@ export function parseCacheStream(
           indexCachePackage(pkg, pmd);
         } else if (structType === StructureType.LibraryPart) {
           const lp = parseLibraryPart(reader);
-          indexCacheLibraryPart(lp, cachedParts);
+          indexLibraryPart(lp, cachedParts, exactNames);
         } else {
           skipStructure(reader);
         }
@@ -250,7 +297,7 @@ export function parseCacheStream(
     } catch {
       // Metadata parsing failed; fall through to brute-force scan for
       // remaining Package and LibraryPart structures via preamble magic.
-      scanForStructures(reader, buffer, pmd, cachedParts);
+      scanForStructures(reader, buffer, pmd, cachedParts, exactNames);
       return;
     }
   }

--- a/src/parsers/cadence/dsn/dsn-parser.ts
+++ b/src/parsers/cadence/dsn/dsn-parser.ts
@@ -9,7 +9,7 @@ import { OleReader } from "../../ole-reader/ole-reader.js";
 import type { ParsedNetlist } from "../../../types.js";
 import type { CachedLibraryPart, PinMapData } from "./structure-types.js";
 import { parsePage, parsePackageStream, parseHierarchyNetNames } from "./page-parser.js";
-import { parseCacheStream } from "./cache-parser.js";
+import { parseCacheStream, indexLibraryPart } from "./cache-parser.js";
 import { parseLibraryStrLst } from "./library-parser.js";
 import { buildDeviceIndexMap } from "./pin-resolver.js";
 import { buildNetConnectivity } from "./net-builder.js";
@@ -56,6 +56,8 @@ export function parseDsnFile(dsnPath: string): ParsedNetlist {
     cachePinIgnores: new Map(),
   };
   const cachedParts = new Map<string, CachedLibraryPart>();
+  // Keys a part claimed under its own name, which an alias must not displace.
+  const exactPartNames = new Set<string>();
   const pkgStreamEntries = entries.filter(
     (e) =>
       /^Packages\//.test(e.path) && e.entry.type === 2 && !e.path.includes("_pDboPackage_Copy_")
@@ -106,12 +108,7 @@ export function parseDsnFile(dsnPath: string): ParsedNetlist {
       // since LP names include a Package stream suffix (e.g., "RES_0.Normal")
       // but PlacedInstance.pkgName uses the base name (e.g., "RES.Normal").
       for (const lp of libraryParts) {
-        const entry: CachedLibraryPart = { pinNames: lp.pinNames, defaultValue: lp.defaultValue };
-        if (!cachedParts.has(lp.name)) cachedParts.set(lp.name, entry);
-        const stripped = lp.name.replace(/_\d+(?=\.)/, "");
-        if (stripped !== lp.name && !cachedParts.has(stripped)) {
-          cachedParts.set(stripped, entry);
-        }
+        indexLibraryPart(lp, cachedParts, exactPartNames);
       }
     } catch {
       // Package parsing is best-effort; skip malformed streams
@@ -125,7 +122,7 @@ export function parseDsnFile(dsnPath: string): ParsedNetlist {
   if (cacheEntry) {
     try {
       const cacheBuf = ole.readStreamByPath(cacheEntry.path);
-      parseCacheStream(cacheBuf, pmd, cachedParts);
+      parseCacheStream(cacheBuf, pmd, cachedParts, exactPartNames);
     } catch {
       // Cache parsing is best-effort
     }

--- a/test/integration/golden.test.ts
+++ b/test/integration/golden.test.ts
@@ -202,6 +202,37 @@ describe("DSN Parser Coverage vs DAT Golden", async () => {
         expect(invented).toEqual([]);
       });
 
+      /**
+       * Pin function names come from the Cache stream's LibraryPart records,
+       * a different path from the pin numbers, and nothing else here reads it.
+       * A design whose Cache walk recovered Packages but no LibraryParts still
+       * scored 100% on every other measure while reporting no pin names at all.
+       */
+      it.runIf(isOracle)("should give pins the same function names as the DAT export", () => {
+        const dsn = parseOnce(designFile);
+        const mismatches: string[] = [];
+        let compared = 0;
+
+        for (const [refdes, goldenComp] of Object.entries(golden.components)) {
+          const dsnComp = dsn.components[refdes];
+          if (!dsnComp) continue;
+          for (const [pinNumber, goldenPin] of Object.entries(goldenComp.pins ?? {})) {
+            const goldenName = typeof goldenPin === "string" ? undefined : goldenPin.name;
+            if (!goldenName) continue;
+            const dsnPin = dsnComp.pins?.[pinNumber];
+            if (dsnPin === undefined) continue;
+            compared++;
+            const dsnName = typeof dsnPin === "string" ? undefined : dsnPin.name;
+            if (dsnName !== goldenName && mismatches.length < 8) {
+              mismatches.push(`${refdes}.${pinNumber}: dat="${goldenName}" dsn="${dsnName ?? "<none>"}"`);
+            }
+          }
+        }
+
+        console.log(`[${projectName}] Pin names: compared=${compared} mismatched=${mismatches.length}`);
+        expect(mismatches).toEqual([]);
+      });
+
       it("should have >50% net coverage", () => {
         const dsn = parseOnce(designFile);
         const dsnNets = new Set(Object.keys(dsn.nets));


### PR DESCRIPTION
Closes #50.

> Stacked on #108. Base is `fix/cadence-power-symbol-attachment`; retarget to `main` once that merges.

## Summary

Pin function names were missing entirely on some `.DSN` designs and present on others, with every component in an affected design losing them at once, exactly as the issue describes. Two independent causes, both in how LibraryPart records are found and ranked.

### 1. The Cache scan could not find most LibraryParts

The Cache is walked sequentially, and on some designs that walk gives up after a handful of entries; a brute-force scan for the preamble magic then recovers the rest. Stepping back from the magic to the start of a record is the hard part, because a record is a prefix chain: zero or more long prefixes of 9 bytes, then a short prefix of `type(1) + int16 pairCount` followed by 8 bytes per `(nameIdx, valIdx)` pair.

The scan assumed the short prefix sits exactly 3 bytes back. That holds only when it carries no pairs and nothing precedes it — true for **every Package** in the corpus, and for a minority of LibraryParts:

| Design | LibraryParts | with `pairCount = 0` | recovered before |
|---|---|---|---|
| LAUNCHXL-CC1310 | 45 | 13 | **0** |
| CutiePi V2.3 | 57 | 17 | **0** |
| reComputer Industrial J201 | 96 | 1 | n/a (sequential walk succeeded) |
| BeagleBoard-xM | 85 | 49 | n/a |

So a design whose sequential walk failed early came out with pin numbers for every component and names for none. LAUNCHXL and CutiePi each recovered every Package (41 and 57) and zero LibraryParts.

The scan now searches for the pair count, then for the chain start, and lets the prefix reader reject wrong guesses.

### 2. A derived alias outranked the part that owns the name

Instances refer to a part by a suffix-stripped name, so each part is registered under its own name and under the stripped form. Two variants of one base part then compete for the stripped key.

CutiePi carries both `RES_0.Normal`, whose pins are named `"1"` and `"2"`, and `RES.Normal`, whose pins are named `"A"` and `"B"`. `RES_0.Normal` strips to `RES.Normal` and won by arriving first. Since a pin name identical to the pin number is dropped as uninformative, all 75 plain resistors reported no names at all, even though the correct record was sitting in the same stream.

A part's own name now outranks an alias derived from a different variant.

## Verification

Pin function names against Cadence's own export:

| Design | before | after |
|---|---|---|
| LAUNCHXL-CC1310 | 42.1% | **100%** |
| CutiePi V2.3 | 57.5% | **100%** |
| all 11 fixtures | 7818/8105 (96.5%) | **8105/8105 (100%)** |

Nets, connectivity, components, values and pin numbers are unchanged at 100%. Every fidelity measure in `dsn-coverage-report` is now 100% except MPN and DNS, which compare different things (our manufacturer part number against Cadence's package descriptor).

### Test coverage gap this closes

Nothing asserted pin names anywhere. A design could score 100% on nets, connectivity, components and pin numbers while reporting no pin names at all, which is precisely the state LAUNCHXL and CutiePi were in. The integration suite now compares pin function names against the DAT export for every oracle-backed fixture: 8105 compared, 0 mismatched.

## Test plan

- [x] `npm run type-check`, `npm run lint`
- [x] `npm test` — 688 passed (otel e2e needs to bind a local port; passes outside the sandbox)
- [x] 6 unit tests in the new `cache-parser.test.ts` covering variant precedence, built from CutiePi's actual `RES` records
- [x] New pin-name test verified against all 10 oracle-backed fixtures

## Changelog

Fixed: Cadence `.DSN` designs now report pin function names for every component. Previously some designs returned pin-to-net mappings with no function names at all, because the Cache stream's part records could not be located when their prefix carried property pairs, and a part's name could be claimed by a different variant of the same base part.
