### PR TITLE
fix(cadence): give each design its own netlist export directory

### DIFF
--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -28,7 +28,7 @@ Generates Allegro-compatible netlist files from Cadence schematics using the `ps
     },
     "outputDir": {
       "type": "string",
-      "description": "Directory where output files were written (relative to CWD; absolute if on a different Windows drive)"
+      "description": "Absolute path of the directory the netlist was written to"
     },
     "log": {
       "type": "string",
@@ -82,7 +82,7 @@ Response (success):
 ```json
 {
   "success": true,
-  "outputDir": "Schematics/Board_netlist",
+  "outputDir": "C:/repo/Schematics/MyBoard_netlist",
   "cadenceVersion": "17.4",
   "generatedFiles": [
     "pstchip.dat",
@@ -99,10 +99,10 @@ Response (success):
 }
 ```
 
-**Error (export produced no netlist):**
+**Error (export produced an incomplete netlist):**
 ```json
 {
-  "error": "Cadence pstswp reported success but wrote no netlist to C:/repo/Schematics/Board_netlist. Check the log for the directory it actually used."
+  "error": "Cadence pstswp reported success but did not write pstxprt.dat to C:/repo/Schematics/MyBoard_netlist. Check the log for the directory it actually used."
 }
 ```
 

--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -82,7 +82,7 @@ Response (success):
 ```json
 {
   "success": true,
-  "outputDir": "Schematics/Allegro",
+  "outputDir": "Schematics/Board_netlist",
   "cadenceVersion": "17.4",
   "generatedFiles": [
     "pstchip.dat",
@@ -99,6 +99,13 @@ Response (success):
 }
 ```
 
+**Error (export produced no netlist):**
+```json
+{
+  "error": "Cadence pstswp reported success but wrote no netlist to C:/repo/Schematics/Board_netlist. Check the log for the directory it actually used."
+}
+```
+
 **Error (missing Cadence installation):**
 ```json
 {
@@ -110,7 +117,10 @@ Response (success):
 
 - Cadence SPB is auto-detected from `C:/Cadence` (e.g., `C:/Cadence/SPB_17.4`)
 - When multiple versions are installed, the latest version is used
-- Output files are written to an `Allegro/` or `allegro/` subdirectory next to the schematic (reuses whichever exists; creates `allegro/` if neither is present)
+- Output files are written to a `<design>_netlist/` subdirectory next to the schematic, one per design, so several designs in the same folder each keep their own netlist
+- A folder holding a single design that already has an `allegro` directory (any case) keeps using it, since that layout is often what a PCB editor or build script reads
+- Both `.DSN` and `.cpm` designs count towards "a single design", because Design Entry HDL writes the same three filenames
+- The export reports an error rather than success when pstswp leaves no `pstxnet.dat` behind
 - The export uses pstswp flags: `-pst -v 3 -l 255 -j "PCB Footprint"`
 - Timeout is set to 2 minutes for large designs
 - Concurrent calls are queued and run one at a time to avoid Cadence license conflicts

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,11 @@ export default tseslint.config(
   },
   {
     // '**/._*' — AppleDouble sidecars macOS writes on network volumes; binary, not source.
-    ignores: ['dist/**', 'node_modules/**', '**/*.test.ts', '**/._*'],
+    //
+    // Colocated tests are linted. They used to be ignored here while
+    // tsconfig.check.json excluded them too, so no test file in the repo was
+    // type-checked or linted, and `npm run type-check && npm run lint && npm test`
+    // passed on a test file tsc rejects outright for a duplicate import.
+    ignores: ['dist/**', 'node_modules/**', '**/._*'],
   }
 );

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -4,13 +4,12 @@
  */
 
 import { existsSync, rmSync, writeFileSync } from "node:fs";
-import { basename, dirname, extname, resolve } from "node:path";
+import { basename, dirname, extname, join, resolve } from "node:path";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "../version.js";
 import { exportTelemetry } from "../telemetry/index.js";
 import { parseDesign } from "../parsers/index.js";
 import {
   discoverCadenceDesigns,
-  findCadenceDatFiles,
   parseDsnFile,
   parseCadence,
   buildCadencePinMap,
@@ -231,7 +230,14 @@ export const handleCoverageCommand = async (
       if (isErrorResult(exportResult)) {
         console.error(`  Export failed: ${exportResult.error}`);
       } else {
-        datFiles = await findCadenceDatFiles(design.sourcePath);
+        // The export already reports the directory it wrote, and it has verified
+        // all three files came from this run. Re-deriving the location instead
+        // could land on a different directory than the one just written.
+        datFiles = {
+          pstxnet: join(exportResult.outputDir, "pstxnet.dat"),
+          pstxprt: join(exportResult.outputDir, "pstxprt.dat"),
+          pstchip: join(exportResult.outputDir, "pstchip.dat"),
+        };
       }
     }
 

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -134,6 +134,9 @@ Windows only. Requires Cadence SPB installation. \
 Calls are queued internally so it is safe to call in parallel \
 for multiple designs, but serialize calls if you encounter \
 license or timeout errors. DSN lock files are handled automatically. \
+Output goes to \`<design>_netlist/\` beside the .DSN, so several designs \
+in one folder no longer overwrite each other's netlist; a folder holding a \
+single design that already has an \`allegro/\` directory keeps using it. \
 After a successful export, re-run \`list_designs\` \
 to get the updated pstxnet.dat path.`;
 

--- a/src/parsers/cadence/discovery.test.ts
+++ b/src/parsers/cadence/discovery.test.ts
@@ -349,27 +349,49 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       expect(designs).toHaveLength(2);
     });
 
-    it("should not hand a design a netlist Cadence generated from another design", async () => {
-      // Mid-migration: BOARD_A has been re-exported and the shared allegro/ it
-      // used to share with BOARD_B is orphaned. BOARD_B has never been exported,
-      // so it must fall back to its own .DSN rather than silently answer every
-      // query with BOARD_A's circuit.
+    it("should leave a contested shared directory unassigned rather than guess", async () => {
+      // Mid-migration: BOARD_A has been re-exported and the shared allegro/ they
+      // used to overwrite each other in is orphaned. Nothing in the tree says
+      // whose it is, and BOARD_B has never been exported, so handing it over
+      // would make BOARD_B answer every query with BOARD_A's circuit.
       const projectDir = join(testDir, "project");
       await createDesign(join(projectDir, "BOARD_A.DSN"));
       await createDesign(join(projectDir, "BOARD_B.DSN"));
-      await createDatFiles(join(projectDir, "allegro"), "BOARD_A");
-      await createDatFiles(join(projectDir, "BOARD_A_netlist"), "BOARD_A");
+      await createDatFiles(join(projectDir, "allegro"));
+      await createDatFiles(join(projectDir, "BOARD_A_netlist"));
 
       const designs = await discoverCadenceDesigns(testDir);
-
       const a = designs.find((d) => d.name === "BOARD_A" && d.format === "cadence-cis");
       const b = designs.find((d) => d.name === "BOARD_B");
 
       expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
       expect(b?.datFiles?.pstxnet).toBeNull();
-      // The orphan is still listed, under a name that cannot be mistaken for
-      // the live design.
-      expect(designs.some((d) => d.name === "BOARD_A" && d.format === "cadence-dat")).toBe(false);
+      // findCadenceDatFiles must reach the same conclusion, or the query path
+      // serves a circuit list_designs says the design does not have.
+      const direct = await findCadenceDatFiles(join(projectDir, "BOARD_B.DSN"));
+      expect(direct.pstxnet).toBeNull();
+    });
+
+    it("should still match a shared directory when only one design can claim it", async () => {
+      // One design, one unnamed directory: nothing is contested, so the ordinary
+      // proximity match still applies.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD.DSN"));
+      await createDatFiles(join(projectDir, "allegro"));
+
+      const designs = await discoverCadenceDesigns(testDir);
+      expect(designs.find((d) => d.name === "BOARD")?.datFiles?.pstxnet).toContain("allegro");
+    });
+
+    it("should give a nested design its own directory over a distant sibling", async () => {
+      // Not a tie: the nested design is strictly closer, so it still wins.
+      await createDesign(join(testDir, "TOP.DSN"));
+      await createDesign(join(testDir, "sub", "NESTED.DSN"));
+      await createDatFiles(join(testDir, "sub", "allegro"));
+
+      const designs = await discoverCadenceDesigns(testDir);
+      expect(designs.find((d) => d.name === "NESTED")?.datFiles?.pstxnet).toContain("allegro");
+      expect(designs.find((d) => d.name === "TOP")?.datFiles?.pstxnet).toBeNull();
     });
 
     it("should prefer a fresh <design>_netlist over a stale directory with the same name", async () => {
@@ -402,7 +424,11 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       const designs = await discoverCadenceDesigns(testDir);
 
       const a = designs.find((d) => d.name === "BOARD_A");
+      const b = designs.find((d) => d.name === "BOARD_B");
       expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
+      // The other half of the same scenario: the stale shared directory is
+      // contested, so BOARD_B gets nothing rather than BOARD_A's circuit.
+      expect(b?.datFiles?.pstxnet).toBeNull();
     });
 
     it("should prefer name-matching over proximity when resolving conflicts", async () => {
@@ -463,13 +489,19 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       expect(design1V2!.error).toBeUndefined();
     });
 
-    it("should use proximity when names dont match any candidate", async () => {
+    it("should not guess which of two equal designs owns a generically named directory", async () => {
       // Structure:
       // project/
       // ├── DesignA.cpm
       // ├── DesignB.cpm
-      // └── output/              <- generic name, no name match
+      // └── output/              <- generic name, names neither design
       //     └── *.dat
+      //
+      // This used to hand the set to whichever design sorted first, which is
+      // right half the time and silent when it is wrong: the loser's queries
+      // would answer with the winner's circuit. Nothing here says whose netlist
+      // it is, so neither design claims it and it is listed in its own right,
+      // where it stays queryable and visibly separate.
       const projectDir = join(testDir, "project");
       await createDesign(join(projectDir, "DesignA.cpm"));
       await createDesign(join(projectDir, "DesignB.cpm"));
@@ -477,14 +509,12 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
 
       const designs = await discoverCadenceDesigns(testDir);
 
-      expect(designs).toHaveLength(2);
-
-      // One should get the .dat files (first processed or by proximity)
-      const withDat = designs.filter((d) => d.datFiles?.pstxnet !== null);
-      const withoutDat = designs.filter((d) => d.datFiles?.pstxnet === null);
-
-      expect(withDat).toHaveLength(1);
-      expect(withoutDat).toHaveLength(1);
+      expect(designs.filter((d) => d.format !== "cadence-dat")).toHaveLength(2);
+      for (const d of designs.filter((d) => d.format !== "cadence-dat")) {
+        expect(d.datFiles?.pstxnet).toBeNull();
+      }
+      // The netlist itself is not lost.
+      expect(designs.filter((d) => d.format === "cadence-dat")).toHaveLength(1);
     });
 
     it("should NOT match based on project folder name in absolute path", async () => {

--- a/src/parsers/cadence/discovery.test.ts
+++ b/src/parsers/cadence/discovery.test.ts
@@ -349,6 +349,47 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       expect(designs).toHaveLength(2);
     });
 
+    it("should not hand a design a netlist Cadence generated from another design", async () => {
+      // Mid-migration: BOARD_A has been re-exported and the shared allegro/ it
+      // used to share with BOARD_B is orphaned. BOARD_B has never been exported,
+      // so it must fall back to its own .DSN rather than silently answer every
+      // query with BOARD_A's circuit.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD_A.DSN"));
+      await createDesign(join(projectDir, "BOARD_B.DSN"));
+      await createDatFiles(join(projectDir, "allegro"), "BOARD_A");
+      await createDatFiles(join(projectDir, "BOARD_A_netlist"), "BOARD_A");
+
+      const designs = await discoverCadenceDesigns(testDir);
+
+      const a = designs.find((d) => d.name === "BOARD_A" && d.format === "cadence-cis");
+      const b = designs.find((d) => d.name === "BOARD_B");
+
+      expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
+      expect(b?.datFiles?.pstxnet).toBeNull();
+      // The orphan is still listed, under a name that cannot be mistaken for
+      // the live design.
+      expect(designs.some((d) => d.name === "BOARD_A" && d.format === "cadence-dat")).toBe(false);
+    });
+
+    it("should prefer a fresh <design>_netlist over a stale directory with the same name", async () => {
+      // Both directories name the design, so nothing but the export convention
+      // distinguishes them; returning the stale one makes a successful export
+      // look like it did nothing.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD.DSN"));
+      await createDatFiles(join(projectDir, "BOARD"), "BOARD");
+      await createDatFiles(join(projectDir, "BOARD_netlist"), "BOARD");
+
+      const designs = await discoverCadenceDesigns(testDir);
+      const live = designs.find((d) => d.format === "cadence-cis");
+
+      expect(live?.datFiles?.pstxnet).toContain("BOARD_netlist");
+      // list_designs and findCadenceDatFiles must not disagree for one design.
+      const direct = await findCadenceDatFiles(join(projectDir, "BOARD.DSN"));
+      expect(direct.pstxnet).toBe(live?.datFiles?.pstxnet);
+    });
+
     it("should prefer a design's own _netlist directory over a shared allegro/", async () => {
       // A folder mid-migration: the legacy shared directory still holds one
       // design's stale export while the other has been re-exported.

--- a/src/parsers/cadence/discovery.test.ts
+++ b/src/parsers/cadence/discovery.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { writeFile, mkdir, rm } from "fs/promises";
+import { writeFile, mkdir, rm, chmod } from "fs/promises";
 import { join } from "path";
 import { discoverCadenceDesigns, findCadenceDatFiles, isCadenceFile } from "./discovery.js";
 
@@ -366,10 +366,126 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
 
       expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
       expect(b?.datFiles?.pstxnet).toBeNull();
+      // A withheld netlist says so. Silent, it looked exactly like a design that
+      // had never been exported, whose remedy (run export_cadence_netlist) is
+      // not the remedy for this one.
+      expect(b?.error).toContain("allegro");
+      expect(a?.error).toBeUndefined();
+
       // findCadenceDatFiles must reach the same conclusion, or the query path
       // serves a circuit list_designs says the design does not have.
       const direct = await findCadenceDatFiles(join(projectDir, "BOARD_B.DSN"));
       expect(direct.pstxnet).toBeNull();
+    });
+
+    it("should answer for a design whichever case the extension is written in", async () => {
+      // Cadence writes .DSN; callers, agents and this project's own docs write
+      // .dsn, and on Windows and macOS both name one file. Comparing the two
+      // exactly sent every case-mismatched path down a fallback that scored the
+      // directories itself, which answered with a neighbour's netlist where one
+      // was reachable and with nothing where one was not.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD.DSN"));
+      await createDatFiles(join(projectDir, "allegro"));
+
+      const upper = await findCadenceDatFiles(join(projectDir, "BOARD.DSN"));
+      const lower = await findCadenceDatFiles(join(projectDir, "BOARD.dsn"));
+
+      expect(upper.pstxnet).toContain("allegro");
+      expect(lower.pstxnet).toBe(upper.pstxnet);
+    });
+
+    it("should not let one unreadable pstxprt.dat hide the whole tree", async () => {
+      // The name in ROOT_DRAWING is a nicety, and reading it was unguarded inside
+      // a Promise.all: one ACL-locked or Cadence-held file rejected discovery,
+      // which rejected the Promise.all over every format handler, and a single
+      // "Failed to search" replaced every design of every format in the tree.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "A.DSN"));
+      await createDesign(join(projectDir, "B.DSN"));
+      await createDatFiles(join(projectDir, "allegro"));
+      const locked = join(projectDir, "allegro", "pstxprt.dat");
+      await chmod(locked, 0o000);
+
+      try {
+        const designs = await discoverCadenceDesigns(testDir);
+        expect(designs.map((d) => d.name)).toEqual(expect.arrayContaining(["A", "B"]));
+      } finally {
+        await chmod(locked, 0o644);
+      }
+    });
+
+    it("should give a _netlist directory to the design that exports it", async () => {
+      // A .DSN and a .cpm sharing a stem resolve to one <stem>_netlist, and both
+      // score it identically. export_cadence_netlist only accepts a .DSN, so the
+      // directory is the CIS design's output; awarding it to the HDL namesake
+      // left the design that had just exported with nothing, and a caller
+      // following the documented loop re-exported forever.
+      //
+      // Both spellings, because path order alone decides this the moment the
+      // preference is absent, and which way it falls is an accident of where the
+      // extension's first letter sits relative to "c": upper-case .DSN happens
+      // to sort first and lower-case .dsn happens to sort second.
+      for (const [i, dsnName] of ["BOARD.DSN", "BOARD.dsn"].entries()) {
+        const projectDir = join(testDir, `project${i}`);
+        await createDesign(join(projectDir, dsnName));
+        await createDesign(join(projectDir, "BOARD.cpm"));
+        await createDatFiles(join(projectDir, "BOARD_netlist"), "BOARD");
+
+        const designs = (await discoverCadenceDesigns(projectDir)).filter((d) =>
+          d.sourcePath.includes(`project${i}`)
+        );
+
+        expect(designs.find((d) => d.format === "cadence-cis")?.datFiles?.pstxnet).toContain(
+          "BOARD_netlist"
+        );
+        expect(designs.find((d) => d.format === "cadence-hdl")?.datFiles?.pstxnet).toBeNull();
+      }
+    });
+
+    it("should not hand a design a netlist a design above it claims", async () => {
+      // findCadenceDatFiles walks from the design's own directory, so a rival in
+      // an ancestor directory is invisible to it while list_designs, walking from
+      // the root it was given, can see it. Answering anyway served INNER's every
+      // query from shared.DSN's circuit, with no error.
+      await createDesign(join(testDir, "shared.DSN"));
+      await createDesign(join(testDir, "inner", "INNER.DSN"));
+      await createDatFiles(join(testDir, "inner", "shared"), "SHARED");
+
+      const designs = await discoverCadenceDesigns(testDir);
+      expect(designs.find((d) => d.name === "shared")?.datFiles?.pstxnet).toContain("shared");
+      expect(designs.find((d) => d.name === "INNER")?.datFiles?.pstxnet).toBeNull();
+
+      const direct = await findCadenceDatFiles(join(testDir, "inner", "INNER.DSN"));
+      expect(direct.pstxnet).toBeNull();
+    });
+
+    it("should refuse a directory two designs name by different conventions", async () => {
+      // `X_netlist/` is where export_cadence_netlist puts design X, and it is
+      // also the directory named for a design called X_netlist. The export bonus
+      // outranks a bare name match unconditionally, so X took X_netlist's own
+      // directory and X_netlist was reported as having no netlist at all.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "X.DSN"));
+      await createDesign(join(projectDir, "X_netlist.DSN"));
+      await createDatFiles(join(projectDir, "X_netlist"), "X");
+
+      const designs = await discoverCadenceDesigns(testDir);
+
+      expect(designs.find((d) => d.name === "X")?.datFiles?.pstxnet).toBeNull();
+      expect(designs.find((d) => d.name === "X_netlist")?.datFiles?.pstxnet).toBeNull();
+      expect(designs.find((d) => d.name === "X")?.error).toContain("X_netlist");
+    });
+
+    it("should resolve a pstxnet.dat path to its own directory", async () => {
+      // list_designs hands out the pstxnet.dat for any design that has one, so
+      // this is the path queries actually arrive with.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD.DSN"));
+      await createDatFiles(join(projectDir, "allegro"));
+
+      const direct = await findCadenceDatFiles(join(projectDir, "allegro", "pstxnet.dat"));
+      expect(direct.pstxnet).toContain(join("allegro", "pstxnet.dat"));
     });
 
     it("should still match a shared directory when only one design can claim it", async () => {
@@ -410,25 +526,6 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       // list_designs and findCadenceDatFiles must not disagree for one design.
       const direct = await findCadenceDatFiles(join(projectDir, "BOARD.DSN"));
       expect(direct.pstxnet).toBe(live?.datFiles?.pstxnet);
-    });
-
-    it("should prefer a design's own _netlist directory over a shared allegro/", async () => {
-      // A folder mid-migration: the legacy shared directory still holds one
-      // design's stale export while the other has been re-exported.
-      const projectDir = join(testDir, "project");
-      await createDesign(join(projectDir, "BOARD_A.DSN"));
-      await createDesign(join(projectDir, "BOARD_B.DSN"));
-      await createDatFiles(join(projectDir, "allegro"));
-      await createDatFiles(join(projectDir, "BOARD_A_netlist"));
-
-      const designs = await discoverCadenceDesigns(testDir);
-
-      const a = designs.find((d) => d.name === "BOARD_A");
-      const b = designs.find((d) => d.name === "BOARD_B");
-      expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
-      // The other half of the same scenario: the stale shared directory is
-      // contested, so BOARD_B gets nothing rather than BOARD_A's circuit.
-      expect(b?.datFiles?.pstxnet).toBeNull();
     });
 
     it("should prefer name-matching over proximity when resolving conflicts", async () => {

--- a/src/parsers/cadence/discovery.test.ts
+++ b/src/parsers/cadence/discovery.test.ts
@@ -323,6 +323,47 @@ describe("Cadence Discovery - Subtree Scoped Matching", () => {
       expect(design1V2!.error).toBeUndefined();
     });
 
+    it("should attribute <design>_netlist directories to their own design", async () => {
+      // The layout export_cadence_netlist produces. BOARD_B's export sits one
+      // level closer than BOARD_A's, so proximity alone pairs both designs
+      // wrongly; only recognising the directory's name gets it right.
+      // project/
+      // ├── BOARD_A.DSN
+      // ├── BOARD_B.DSN
+      // ├── archive/BOARD_A_netlist/  *.dat
+      // └── BOARD_B_netlist/          *.dat
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD_A.DSN"));
+      await createDesign(join(projectDir, "BOARD_B.DSN"));
+      await createDatFiles(join(projectDir, "archive", "BOARD_A_netlist"));
+      await createDatFiles(join(projectDir, "BOARD_B_netlist"));
+
+      const designs = await discoverCadenceDesigns(testDir);
+
+      const a = designs.find((d) => d.name === "BOARD_A");
+      const b = designs.find((d) => d.name === "BOARD_B");
+
+      expect(a?.datFiles?.pstxnet).toContain(join("archive", "BOARD_A_netlist"));
+      expect(b?.datFiles?.pstxnet).toContain("BOARD_B_netlist");
+      // Neither export is left over as a standalone dat-only design.
+      expect(designs).toHaveLength(2);
+    });
+
+    it("should prefer a design's own _netlist directory over a shared allegro/", async () => {
+      // A folder mid-migration: the legacy shared directory still holds one
+      // design's stale export while the other has been re-exported.
+      const projectDir = join(testDir, "project");
+      await createDesign(join(projectDir, "BOARD_A.DSN"));
+      await createDesign(join(projectDir, "BOARD_B.DSN"));
+      await createDatFiles(join(projectDir, "allegro"));
+      await createDatFiles(join(projectDir, "BOARD_A_netlist"));
+
+      const designs = await discoverCadenceDesigns(testDir);
+
+      const a = designs.find((d) => d.name === "BOARD_A");
+      expect(a?.datFiles?.pstxnet).toContain("BOARD_A_netlist");
+    });
+
     it("should prefer name-matching over proximity when resolving conflicts", async () => {
       // Structure:
       // project/

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -13,7 +13,7 @@
 import { readdir, readFile } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
-import { isNetlistDirFor } from "../../paths.js";
+import { isNetlistDirFor, REQUIRED_DAT_FILES } from "../../paths.js";
 
 const CADENCE_EXTENSIONS = [".dsn", ".cpm"] as const;
 
@@ -31,9 +31,6 @@ export interface CadenceDiscoveredDesign {
   };
   error?: string;
 }
-
-/** Required .dat files for a complete netlist export */
-const REQUIRED_DAT_FILES = ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"] as const;
 
 interface CadenceDatFiles {
   pstxnet: string | null;
@@ -160,10 +157,6 @@ const isDescendantOrEqual = (childDir: string, parentDir: string): boolean => {
   return normalizedChild.startsWith(parentWithSep);
 };
 
-/**
- * Check if design name appears as an exact directory component in a relative path.
- * Case-insensitive matching.
- */
 /** A path component naming the design outweighs any amount of distance. */
 const NAME_MATCH_BONUS = 1000;
 /**
@@ -217,12 +210,26 @@ const scoreDatSetMatch = (designDir: string, designName: string, datSet: DatFile
 };
 
 /**
+ * Order two paths by code unit.
+ *
+ * Not `localeCompare`: its collation follows the host locale, so which dat set a
+ * design gets changed with LANG (Czech sorts the digraph "ch" after "h", Danish
+ * orders "Allegro" against "allegro" the other way round from English), and Bun
+ * pins en-US while Node honours the environment, so CI cannot observe what the
+ * shipped binaries do. It is also not a total order: two distinct strings that
+ * differ only by a soft hyphen compare equal, and the sort then falls back to
+ * readdir order. Code-unit order is the same everywhere.
+ */
+const comparePaths = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
  * A candidate pairing of a design with a dat set.
  */
 interface MatchCandidate {
   designPath: string;
   datSet: DatFileSet;
   score: number;
+  match: NameMatch;
 }
 
 /**
@@ -237,7 +244,7 @@ interface MatchCandidate {
 const matchDatSetsToDesigns = (
   designFiles: string[],
   datSets: DatFileSet[]
-): Map<string, DatFileSet | null> => {
+): { assignments: Map<string, DatFileSet | null>; withheld: Map<string, string[]> } => {
   const assignments = new Map<string, DatFileSet | null>();
 
   // Initialize all designs with null
@@ -257,6 +264,7 @@ const matchDatSetsToDesigns = (
         designPath,
         datSet,
         score: scoreDatSetMatch(designDir, designName, datSet),
+        match: designNameInRelativePath(path.relative(designDir, datSet.directory), designName),
       });
     }
   }
@@ -286,32 +294,84 @@ const matchDatSetsToDesigns = (
       .map(([directory]) => directory)
   );
 
+  // Two designs can name one directory by different conventions and both be
+  // right: `X_netlist/` is where export_cadence_netlist puts design `X`, and it
+  // is also the directory named for a design called `X_netlist`. The export
+  // bonus outranks the bare name match unconditionally, so `X` took it and
+  // `X_netlist` was told it had no netlist. Nothing on disk settles which
+  // reading is correct, so neither design gets it.
+  for (const [directory, best] of bestByDatSet) {
+    if (best.designs.size !== 1) continue;
+    const claimant = [...best.designs][0];
+    const claim = candidates.find(
+      (c) => c.datSet.directory === directory && c.designPath === claimant
+    );
+    if (claim?.match !== "exported") continue;
+
+    const basename = path.basename(directory).toLowerCase();
+    const namesake = candidates.some(
+      (c) =>
+        c.datSet.directory === directory &&
+        c.designPath !== claimant &&
+        path.basename(c.designPath, path.extname(c.designPath)).toLowerCase() === basename
+    );
+    if (namesake) contested.add(directory);
+  }
+
   // Sort by score (descending), then by paths for determinism
   candidates.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;
+
+    // `<design>_netlist/` is export_cadence_netlist's own convention and that
+    // tool only accepts a .DSN, so when a .DSN and a .cpm share a stem and
+    // therefore tie for it, it belongs to the design that produced it. Without
+    // this the CIS design that had just exported got nothing while its HDL
+    // namesake took the directory, and a caller following the documented loop
+    // (export, re-list, still no netlist) re-exported forever.
+    if (a.match === "exported" && b.match === "exported") {
+      const aIsDsn = path.extname(a.designPath).toLowerCase() === ".dsn";
+      const bIsDsn = path.extname(b.designPath).toLowerCase() === ".dsn";
+      if (aIsDsn !== bIsDsn) return aIsDsn ? -1 : 1;
+    }
+
     // Tiebreaker: sort by design path, then dat directory
     if (a.designPath !== b.designPath) {
-      return a.designPath.localeCompare(b.designPath);
+      return comparePaths(a.designPath, b.designPath);
     }
-    return a.datSet.directory.localeCompare(b.datSet.directory);
+    return comparePaths(a.datSet.directory, b.datSet.directory);
   });
 
   // Assign greedily from highest score
   const usedDatSets = new Set<string>();
   const assignedDesigns = new Set<string>();
 
+  // Which designs were refused which directories, so a withheld netlist can say
+  // so. Left silent, a design whose netlist was withheld looked byte for byte
+  // like one that had never been exported, and the advice for that (run
+  // export_cadence_netlist) does not help: exporting to its own directory does,
+  // and nothing said so.
+  const withheld = new Map<string, string[]>();
+
   for (const candidate of candidates) {
     if (assignedDesigns.has(candidate.designPath) || usedDatSets.has(candidate.datSet.directory)) {
       continue;
     }
-    if (contested.has(candidate.datSet.directory)) continue;
+    if (contested.has(candidate.datSet.directory)) {
+      const dirs = withheld.get(candidate.designPath) ?? [];
+      dirs.push(candidate.datSet.directory);
+      withheld.set(candidate.designPath, dirs);
+      continue;
+    }
 
     assignments.set(candidate.designPath, candidate.datSet);
     assignedDesigns.add(candidate.designPath);
     usedDatSets.add(candidate.datSet.directory);
   }
 
-  return assignments;
+  // A design that ended up with a directory of its own was never short of one.
+  for (const designPath of assignedDesigns) withheld.delete(designPath);
+
+  return { assignments, withheld };
 };
 
 /**
@@ -330,7 +390,18 @@ const normalizeSeparators = (p: string): string => {
  * Returns null if ROOT_DRAWING is not found.
  */
 const extractRootDrawing = async (pstxprtPath: string): Promise<string | null> => {
-  const content = await readFile(pstxprtPath, "utf-8");
+  // A name is a nicety; the walk already deliberately swallows EACCES to keep one
+  // unreadable directory from hiding a tree. An unguarded read here rejected the
+  // Promise.all above it, which rejected discoverCadenceDesigns, which rejected
+  // the Promise.all over the format handlers in parsers/index.ts: one ACL-locked
+  // or Cadence-held pstxprt.dat made every design of every format in the tree
+  // invisible, reported as a single "Failed to search" error.
+  let content: string;
+  try {
+    content = await readFile(pstxprtPath, "utf-8");
+  } catch {
+    return null;
+  }
   const match = content.match(/ROOT_DRAWING='([^']+)'/);
   return match ? match[1] : null;
 };
@@ -422,7 +493,7 @@ export const discoverCadenceDesigns = async (
   const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir, options?.maxDepth);
 
   // Match dat sets to designs
-  const assignments = matchDatSetsToDesigns(designFiles, datSets);
+  const { assignments, withheld } = matchDatSetsToDesigns(designFiles, datSets);
 
   const designs: CadenceDiscoveredDesign[] = [];
 
@@ -449,6 +520,13 @@ export const discoverCadenceDesigns = async (
       datFiles,
     };
 
+    const refused = withheld.get(designPath);
+    if (refused && refused.length > 0) {
+      design.error =
+        `A netlist in ${refused.join(", ")} could belong to this design or to another one nearby, ` +
+        `so it is not attributed to either. Export ${name} to a directory of its own to resolve it.`;
+    }
+
     designs.push(design);
   }
 
@@ -471,7 +549,6 @@ export const findCadenceDatFiles = async (designFilePath: string): Promise<Caden
   // Normalize separators before processing to handle cross-platform paths
   const normalizedPath = normalizeSeparators(designFilePath);
   const designDir = path.dirname(normalizedPath);
-  const designName = path.basename(normalizedPath, path.extname(normalizedPath));
 
   const { designFiles, datSets } = await walkForCadenceFiles(designDir);
 
@@ -481,33 +558,113 @@ export const findCadenceDatFiles = async (designFilePath: string): Promise<Caden
     return { pstxnet: null, pstxprt: null, pstchip: null };
   }
 
+  const nothing: CadenceDatFiles = { pstxnet: null, pstxprt: null, pstchip: null };
+  const filesOf = (ds: DatFileSet): CadenceDatFiles => ({
+    pstxnet: ds.pstxnet,
+    pstxprt: ds.pstxprt,
+    pstchip: ds.pstchip,
+  });
+
   // Run the same assignment discoverCadenceDesigns runs, and read this design's
   // answer out of it. Re-deriving the choice here let the two disagree: this
   // function once returned a netlist for a design that list_designs had
   // correctly left unmatched, and every query then answered about that design
   // with a neighbour's circuit.
-  const self = designFiles.find((d) => normalizeSeparators(d) === normalizedPath);
+  //
+  // Same scope, same answer. The scopes are not always the same: this walk
+  // starts at the design's directory and is unbounded, while list_designs walks
+  // from the root it was given and honours max_depth. Queries arrive with the
+  // path list_designs handed out, which for a design that has a netlist is the
+  // pstxnet.dat itself and is resolved exactly below, so the two only diverge
+  // when a caller names a .cpm directly under a narrowed max_depth.
+  const self = findDesignFile(designFiles, normalizedPath);
   if (self) {
-    const assigned = matchDatSetsToDesigns(designFiles, datSets).get(self);
-    return assigned
-      ? { pstxnet: assigned.pstxnet, pstxprt: assigned.pstxprt, pstchip: assigned.pstchip }
-      : { pstxnet: null, pstxprt: null, pstchip: null };
+    const assigned = matchDatSetsToDesigns(designFiles, datSets).assignments.get(self);
+    if (!assigned) return nothing;
+    // The walk starts at this design's own directory, so a design sitting above
+    // it is invisible here while discoverCadenceDesigns, walking from the root
+    // the caller asked about, can see it and award the set to that one instead.
+    // Declining rather than guessing keeps the answer either right or absent.
+    const selfDir = path.dirname(self);
+    const selfName = path.basename(self, path.extname(self));
+    const outranked = await outrankedFromAbove(
+      assigned,
+      selfDir,
+      scoreDatSetMatch(selfDir, selfName, assigned)
+    );
+    return outranked ? nothing : filesOf(assigned);
   }
 
-  // The caller passed something the walk does not treat as a design file, such
-  // as a pstxnet.dat path. Fall back to scoring, with the assignment's ordering.
-  const scored = candidates.map((ds) => ({
-    datSet: ds,
-    score: scoreDatSetMatch(designDir, designName, ds),
-  }));
-  scored.sort((a, b) => b.score - a.score || a.datSet.directory.localeCompare(b.datSet.directory));
-  const best = scored[0].datSet;
+  // The caller named a dat file rather than a design: list_designs hands out
+  // pstxnet.dat for any design that has one, and that is the path queries then
+  // arrive with. Its own directory is the answer, and saying so directly avoids
+  // the scoring fallback that used to sit here, which could reach past it to a
+  // neighbouring directory and did not honour the contested rule.
+  const own = candidates.find(
+    (ds) => normalizeForComparison(ds.directory) === normalizeForComparison(designDir)
+  );
+  if (own) return filesOf(own);
 
-  return {
-    pstxnet: best.pstxnet,
-    pstxprt: best.pstxprt,
-    pstchip: best.pstchip,
-  };
+  // Not a design the walk recognises and not a dat directory. Naming a netlist
+  // here would be a guess, and a guess reads as an answer.
+  return nothing;
+};
+
+/**
+ * The walked design file the caller meant.
+ *
+ * Cadence writes `.DSN`; callers, agents and documentation all write `.dsn`, and
+ * on Windows and macOS both spellings name one file. Comparing exactly sent
+ * every case-mismatched path down the fallback branch, which answered with a
+ * neighbouring design's netlist and reported no error. The insensitive match is
+ * only accepted when it is unambiguous, so a case-sensitive volume holding two
+ * files that differ only in case declines instead of guessing.
+ */
+const findDesignFile = (designFiles: string[], normalizedPath: string): string | undefined => {
+  const wanted = normalizeForComparison(normalizedPath);
+  const exact = designFiles.find((d) => normalizeForComparison(d) === wanted);
+  if (exact) return exact;
+
+  const wantedLower = wanted.toLowerCase();
+  const insensitive = designFiles.filter(
+    (d) => normalizeForComparison(d).toLowerCase() === wantedLower
+  );
+  return insensitive.length === 1 ? insensitive[0] : undefined;
+};
+
+/**
+ * Does a design above this one claim this dat set more strongly?
+ *
+ * Only the directories on the way up are read, and only their own entries, so
+ * this costs one readdir per level rather than another tree walk.
+ */
+const outrankedFromAbove = async (
+  datSet: DatFileSet,
+  designDir: string,
+  ownScore: number
+): Promise<boolean> => {
+  let dir = path.dirname(designDir);
+  for (let level = 0; level < 32; level++) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      break;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.name.startsWith("._")) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!CADENCE_EXTENSIONS.includes(ext as (typeof CADENCE_EXTENSIONS)[number])) continue;
+      const rivalName = path.basename(entry.name, path.extname(entry.name));
+      if (scoreDatSetMatch(dir, rivalName, datSet) > ownScore) return true;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
 };
 
 /**

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -164,6 +164,15 @@ const isDescendantOrEqual = (childDir: string, parentDir: string): boolean => {
  * Check if design name appears as an exact directory component in a relative path.
  * Case-insensitive matching.
  */
+/** A path component naming the design outweighs any amount of distance. */
+const NAME_MATCH_BONUS = 1000;
+/**
+ * The export directory outranks a bare name match by more than the depth
+ * penalty can erode, so a fresh export still wins from a directory or two
+ * deeper than a stale one carrying the same name.
+ */
+const EXPORT_DIR_BONUS = NAME_MATCH_BONUS + 100;
+
 type NameMatch = "none" | "named" | "exported";
 
 /**
@@ -198,25 +207,14 @@ const scoreDatSetMatch = (designDir: string, designName: string, datSet: DatFile
   // Bonus for design name appearing as a path component in the RELATIVE path
   // (not the absolute path, which might contain project folder names)
   const match = designNameInRelativePath(relPath, designName);
-  if (match === "exported") score += 1001;
-  else if (match === "named") score += 1000;
+  if (match === "exported") score += EXPORT_DIR_BONUS;
+  else if (match === "named") score += NAME_MATCH_BONUS;
 
   // Prefer closer paths (fewer directory levels between design and dat)
   score -= depth;
 
   return score;
 };
-
-/**
- * Does a dat set's `ROOT_DRAWING` identify this design?
- *
- * Cadence writes the design's own name, uppercased and cut at the first `.`,
- * so `CutiePi_V2.3-20210409` is recorded as `CUTIEPI_V2` and
- * `reComputer J401_V1.0` as `RECOMPUTER J401_V1`. Comparing the design name cut
- * the same way is what makes the two comparable.
- */
-const rootDrawingNames = (rootDrawing: string, designName: string): boolean =>
-  rootDrawing.toUpperCase() === designName.split(".")[0].toUpperCase();
 
 /**
  * A candidate pairing of a design with a dat set.
@@ -238,8 +236,7 @@ interface MatchCandidate {
  */
 const matchDatSetsToDesigns = (
   designFiles: string[],
-  datSets: DatFileSet[],
-  rootDrawings: Map<string, string> = new Map()
+  datSets: DatFileSet[]
 ): Map<string, DatFileSet | null> => {
   const assignments = new Map<string, DatFileSet | null>();
 
@@ -249,7 +246,6 @@ const matchDatSetsToDesigns = (
   }
 
   // Build all valid candidate pairings
-  const designNames = designFiles.map((d) => path.basename(d, path.extname(d)));
   const candidates: MatchCandidate[] = [];
   for (const designPath of designFiles) {
     const designDir = path.dirname(designPath);
@@ -257,20 +253,6 @@ const matchDatSetsToDesigns = (
 
     for (const datSet of datSets) {
       if (!isDescendantOrEqual(datSet.directory, designDir)) continue;
-      // Cadence records which design it generated a netlist from. When that
-      // says another design in scope, this set is not a candidate at all: a
-      // shared directory left over from before per-design exports would
-      // otherwise be handed to whichever sibling happened to be left over,
-      // and that sibling would answer every query with another design's
-      // circuit and no error to show for it.
-      const rootDrawing = rootDrawings.get(datSet.directory);
-      if (
-        rootDrawing !== undefined &&
-        !rootDrawingNames(rootDrawing, designName) &&
-        designNames.some((n) => rootDrawingNames(rootDrawing, n))
-      ) {
-        continue;
-      }
       candidates.push({
         designPath,
         datSet,
@@ -278,6 +260,31 @@ const matchDatSetsToDesigns = (
       });
     }
   }
+
+  // A dat set no design can claim by name, that two designs reach equally well,
+  // belongs to neither of them. Greedy assignment would hand it to whichever
+  // design sorted first, and the other would answer every query with that
+  // design's circuit and show no error for it. This is the shape a folder is
+  // left in mid-migration: one design re-exported to its own directory, the
+  // shared one they used to overwrite each other in now orphaned.
+  //
+  // Leaving it unassigned costs a fallback to parsing the schematic directly,
+  // which now reproduces the DAT export exactly, so the cost is time rather
+  // than fidelity.
+  const bestByDatSet = new Map<string, { score: number; designs: Set<string> }>();
+  for (const c of candidates) {
+    const seen = bestByDatSet.get(c.datSet.directory);
+    if (!seen || c.score > seen.score) {
+      bestByDatSet.set(c.datSet.directory, { score: c.score, designs: new Set([c.designPath]) });
+    } else if (c.score === seen.score) {
+      seen.designs.add(c.designPath);
+    }
+  }
+  const contested = new Set(
+    [...bestByDatSet.entries()]
+      .filter(([, best]) => best.score < NAME_MATCH_BONUS && best.designs.size > 1)
+      .map(([directory]) => directory)
+  );
 
   // Sort by score (descending), then by paths for determinism
   candidates.sort((a, b) => {
@@ -297,6 +304,7 @@ const matchDatSetsToDesigns = (
     if (assignedDesigns.has(candidate.designPath) || usedDatSets.has(candidate.datSet.directory)) {
       continue;
     }
+    if (contested.has(candidate.datSet.directory)) continue;
 
     assignments.set(candidate.designPath, candidate.datSet);
     assignedDesigns.add(candidate.designPath);
@@ -369,21 +377,23 @@ const buildStandaloneDesigns = async (
   );
 
   // Detect duplicate names and disambiguate
-  // A name is ambiguous if another leftover set answers to it, and equally if a
-  // real design already does: a shared directory orphaned by per-design exports
-  // records the design it came from, so it arrives here carrying that design's
-  // name and would otherwise appear twice in the listing with no way to tell
-  // the stale entry from the live one.
+  // A leftover set answers to the name Cadence recorded for it, which is often
+  // a live design's name. Compared case-insensitively because that name comes
+  // from ROOT_DRAWING, which Cadence always writes uppercase, while a design
+  // takes its name from the filename.
   const nameCounts = new Map<string, number>();
   for (const entry of nameEntries) {
-    nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
+    const key = entry.name.toLowerCase();
+    nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
   }
+  const taken = new Set([...takenNames].map((n) => n.toLowerCase()));
 
   return nameEntries.map((entry) => {
-    const ambiguous = nameCounts.get(entry.name)! > 1 || takenNames.has(entry.name);
-    const finalName = ambiguous
-      ? `${entry.name}_${shortPathHash(entry.datSet.directory)}`
-      : entry.name;
+    const key = entry.name.toLowerCase();
+    const finalName =
+      nameCounts.get(key)! > 1 || taken.has(key)
+        ? `${entry.name}_${shortPathHash(entry.datSet.directory)}`
+        : entry.name;
 
     return {
       name: finalName,
@@ -411,21 +421,8 @@ export const discoverCadenceDesigns = async (
   const absoluteRootDir = path.resolve(normalizeSeparators(rootDir));
   const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir, options?.maxDepth);
 
-  // Which design each netlist was generated from, straight from Cadence.
-  const rootDrawings = new Map<string, string>();
-  await Promise.all(
-    datSets.map(async (ds) => {
-      try {
-        const name = await extractRootDrawing(ds.pstxprt);
-        if (name) rootDrawings.set(ds.directory, name);
-      } catch {
-        // Unreadable pstxprt just means no signal; matching falls back to paths.
-      }
-    })
-  );
-
   // Match dat sets to designs
-  const assignments = matchDatSetsToDesigns(designFiles, datSets, rootDrawings);
+  const assignments = matchDatSetsToDesigns(designFiles, datSets);
 
   const designs: CadenceDiscoveredDesign[] = [];
 
@@ -476,31 +473,34 @@ export const findCadenceDatFiles = async (designFilePath: string): Promise<Caden
   const designDir = path.dirname(normalizedPath);
   const designName = path.basename(normalizedPath, path.extname(normalizedPath));
 
-  const { datSets } = await walkForCadenceFiles(designDir);
+  const { designFiles, datSets } = await walkForCadenceFiles(designDir);
 
   // Find dat sets in this design's subtree
   const candidates = datSets.filter((ds) => isDescendantOrEqual(ds.directory, designDir));
-
   if (candidates.length === 0) {
     return { pstxnet: null, pstxprt: null, pstchip: null };
   }
 
-  // If multiple candidates, pick best by score
-  if (candidates.length === 1) {
-    const ds = candidates[0];
-    return { pstxnet: ds.pstxnet, pstxprt: ds.pstxprt, pstchip: ds.pstchip };
+  // Run the same assignment discoverCadenceDesigns runs, and read this design's
+  // answer out of it. Re-deriving the choice here let the two disagree: this
+  // function once returned a netlist for a design that list_designs had
+  // correctly left unmatched, and every query then answered about that design
+  // with a neighbour's circuit.
+  const self = designFiles.find((d) => normalizeSeparators(d) === normalizedPath);
+  if (self) {
+    const assigned = matchDatSetsToDesigns(designFiles, datSets).get(self);
+    return assigned
+      ? { pstxnet: assigned.pstxnet, pstxprt: assigned.pstxprt, pstchip: assigned.pstchip }
+      : { pstxnet: null, pstxprt: null, pstchip: null };
   }
 
+  // The caller passed something the walk does not treat as a design file, such
+  // as a pstxnet.dat path. Fall back to scoring, with the assignment's ordering.
   const scored = candidates.map((ds) => ({
     datSet: ds,
     score: scoreDatSetMatch(designDir, designName, ds),
   }));
-  // Same ordering as matchDatSetsToDesigns, so the two agree for one design.
-  // Without the tiebreak the winner of a tie came down to readdir order, and
-  // list_designs could report a different netlist than this function returned.
-  scored.sort(
-    (a, b) => b.score - a.score || a.datSet.directory.localeCompare(b.datSet.directory)
-  );
+  scored.sort((a, b) => b.score - a.score || a.datSet.directory.localeCompare(b.datSet.directory));
   const best = scored[0].datSet;
 
   return {

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -13,6 +13,7 @@
 import { readdir, readFile } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
+import { isNetlistDirFor } from "../../paths.js";
 
 const CADENCE_EXTENSIONS = [".dsn", ".cpm"] as const;
 
@@ -163,17 +164,25 @@ const isDescendantOrEqual = (childDir: string, parentDir: string): boolean => {
  * Check if design name appears as an exact directory component in a relative path.
  * Case-insensitive matching.
  */
-const designNameInRelativePath = (relPath: string, designName: string): boolean => {
-  if (relPath === "" || relPath === ".") return false;
+type NameMatch = "none" | "named" | "exported";
+
+/**
+ * How a path names a design: as a bare `<design>` component, or as the
+ * `<design>_netlist` directory `export_cadence_netlist` writes to.
+ *
+ * The two are distinguished because they can both be present, and then one is
+ * a fresh export and the other is whatever was there before. Scoring the export
+ * higher means a successful export is not silently ignored in favour of a stale
+ * directory that happens to carry the design's name.
+ */
+const designNameInRelativePath = (relPath: string, designName: string): NameMatch => {
+  if (relPath === "" || relPath === ".") return "none";
   const components = relPath.split(path.sep);
   const lowerName = designName.toLowerCase();
-  // `<design>_netlist` is the directory `export_cadence_netlist` writes to, and
-  // it names the design as surely as a bare `<design>` component does.
-  const exported = `${lowerName}_netlist`;
-  return components.some((c) => {
-    const lower = c.toLowerCase();
-    return lower === lowerName || lower === exported;
-  });
+
+  if (components.some((c) => isNetlistDirFor(c, designName))) return "exported";
+  if (components.some((c) => c.toLowerCase() === lowerName)) return "named";
+  return "none";
 };
 
 /**
@@ -188,15 +197,26 @@ const scoreDatSetMatch = (designDir: string, designName: string, datSet: DatFile
 
   // Bonus for design name appearing as a path component in the RELATIVE path
   // (not the absolute path, which might contain project folder names)
-  if (designNameInRelativePath(relPath, designName)) {
-    score += 1000;
-  }
+  const match = designNameInRelativePath(relPath, designName);
+  if (match === "exported") score += 1001;
+  else if (match === "named") score += 1000;
 
   // Prefer closer paths (fewer directory levels between design and dat)
   score -= depth;
 
   return score;
 };
+
+/**
+ * Does a dat set's `ROOT_DRAWING` identify this design?
+ *
+ * Cadence writes the design's own name, uppercased and cut at the first `.`,
+ * so `CutiePi_V2.3-20210409` is recorded as `CUTIEPI_V2` and
+ * `reComputer J401_V1.0` as `RECOMPUTER J401_V1`. Comparing the design name cut
+ * the same way is what makes the two comparable.
+ */
+const rootDrawingNames = (rootDrawing: string, designName: string): boolean =>
+  rootDrawing.toUpperCase() === designName.split(".")[0].toUpperCase();
 
 /**
  * A candidate pairing of a design with a dat set.
@@ -218,7 +238,8 @@ interface MatchCandidate {
  */
 const matchDatSetsToDesigns = (
   designFiles: string[],
-  datSets: DatFileSet[]
+  datSets: DatFileSet[],
+  rootDrawings: Map<string, string> = new Map()
 ): Map<string, DatFileSet | null> => {
   const assignments = new Map<string, DatFileSet | null>();
 
@@ -228,19 +249,33 @@ const matchDatSetsToDesigns = (
   }
 
   // Build all valid candidate pairings
+  const designNames = designFiles.map((d) => path.basename(d, path.extname(d)));
   const candidates: MatchCandidate[] = [];
   for (const designPath of designFiles) {
     const designDir = path.dirname(designPath);
     const designName = path.basename(designPath, path.extname(designPath));
 
     for (const datSet of datSets) {
-      if (isDescendantOrEqual(datSet.directory, designDir)) {
-        candidates.push({
-          designPath,
-          datSet,
-          score: scoreDatSetMatch(designDir, designName, datSet),
-        });
+      if (!isDescendantOrEqual(datSet.directory, designDir)) continue;
+      // Cadence records which design it generated a netlist from. When that
+      // says another design in scope, this set is not a candidate at all: a
+      // shared directory left over from before per-design exports would
+      // otherwise be handed to whichever sibling happened to be left over,
+      // and that sibling would answer every query with another design's
+      // circuit and no error to show for it.
+      const rootDrawing = rootDrawings.get(datSet.directory);
+      if (
+        rootDrawing !== undefined &&
+        !rootDrawingNames(rootDrawing, designName) &&
+        designNames.some((n) => rootDrawingNames(rootDrawing, n))
+      ) {
+        continue;
       }
+      candidates.push({
+        designPath,
+        datSet,
+        score: scoreDatSetMatch(designDir, designName, datSet),
+      });
     }
   }
 
@@ -317,7 +352,8 @@ const consumedDirectories = (assignments: Map<string, DatFileSet | null>): Set<s
  */
 const buildStandaloneDesigns = async (
   datSets: DatFileSet[],
-  consumedDatDirs: Set<string>
+  consumedDatDirs: Set<string>,
+  takenNames: ReadonlySet<string> = new Set()
 ): Promise<CadenceDiscoveredDesign[]> => {
   const unmatchedSets = datSets.filter((ds) => !consumedDatDirs.has(ds.directory));
 
@@ -333,16 +369,21 @@ const buildStandaloneDesigns = async (
   );
 
   // Detect duplicate names and disambiguate
+  // A name is ambiguous if another leftover set answers to it, and equally if a
+  // real design already does: a shared directory orphaned by per-design exports
+  // records the design it came from, so it arrives here carrying that design's
+  // name and would otherwise appear twice in the listing with no way to tell
+  // the stale entry from the live one.
   const nameCounts = new Map<string, number>();
   for (const entry of nameEntries) {
     nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
   }
 
   return nameEntries.map((entry) => {
-    const finalName =
-      nameCounts.get(entry.name)! > 1
-        ? `${entry.name}_${shortPathHash(entry.datSet.directory)}`
-        : entry.name;
+    const ambiguous = nameCounts.get(entry.name)! > 1 || takenNames.has(entry.name);
+    const finalName = ambiguous
+      ? `${entry.name}_${shortPathHash(entry.datSet.directory)}`
+      : entry.name;
 
     return {
       name: finalName,
@@ -370,8 +411,21 @@ export const discoverCadenceDesigns = async (
   const absoluteRootDir = path.resolve(normalizeSeparators(rootDir));
   const { designFiles, datSets } = await walkForCadenceFiles(absoluteRootDir, options?.maxDepth);
 
+  // Which design each netlist was generated from, straight from Cadence.
+  const rootDrawings = new Map<string, string>();
+  await Promise.all(
+    datSets.map(async (ds) => {
+      try {
+        const name = await extractRootDrawing(ds.pstxprt);
+        if (name) rootDrawings.set(ds.directory, name);
+      } catch {
+        // Unreadable pstxprt just means no signal; matching falls back to paths.
+      }
+    })
+  );
+
   // Match dat sets to designs
-  const assignments = matchDatSetsToDesigns(designFiles, datSets);
+  const assignments = matchDatSetsToDesigns(designFiles, datSets, rootDrawings);
 
   const designs: CadenceDiscoveredDesign[] = [];
 
@@ -402,7 +456,11 @@ export const discoverCadenceDesigns = async (
   }
 
   // Append standalone designs from unmatched dat trios
-  const standalones = await buildStandaloneDesigns(datSets, consumedDirectories(assignments));
+  const standalones = await buildStandaloneDesigns(
+    datSets,
+    consumedDirectories(assignments),
+    new Set(designs.map((d) => d.name))
+  );
   designs.push(...standalones);
 
   return designs;
@@ -437,7 +495,12 @@ export const findCadenceDatFiles = async (designFilePath: string): Promise<Caden
     datSet: ds,
     score: scoreDatSetMatch(designDir, designName, ds),
   }));
-  scored.sort((a, b) => b.score - a.score);
+  // Same ordering as matchDatSetsToDesigns, so the two agree for one design.
+  // Without the tiebreak the winner of a tie came down to readdir order, and
+  // list_designs could report a different netlist than this function returned.
+  scored.sort(
+    (a, b) => b.score - a.score || a.datSet.directory.localeCompare(b.datSet.directory)
+  );
   const best = scored[0].datSet;
 
   return {

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -167,7 +167,13 @@ const designNameInRelativePath = (relPath: string, designName: string): boolean 
   if (relPath === "" || relPath === ".") return false;
   const components = relPath.split(path.sep);
   const lowerName = designName.toLowerCase();
-  return components.some((c) => c.toLowerCase() === lowerName);
+  // `<design>_netlist` is the directory `export_cadence_netlist` writes to, and
+  // it names the design as surely as a bare `<design>` component does.
+  const exported = `${lowerName}_netlist`;
+  return components.some((c) => {
+    const lower = c.toLowerCase();
+    return lower === lowerName || lower === exported;
+  });
 };
 
 /**

--- a/src/parsers/cadence/index.ts
+++ b/src/parsers/cadence/index.ts
@@ -186,8 +186,12 @@ const parseCadenceDesign = async (designPath: string): Promise<ParsedNetlist> =>
     return { nets: raw.nets, components };
   }
 
+  // export_cadence_netlist drives pstswp, which needs the .DSN schematic, so
+  // naming it to an HDL design sent the caller to a tool that refuses the input.
   throw new Error(
-    `Missing netlist files for ${path.basename(designPath)}. Run export_cadence_netlist to generate them.`
+    ext === ".cpm"
+      ? `Missing netlist files for ${path.basename(designPath)}. Design Entry HDL writes them from Cadence: Tools → Create Netlist → PCB Editor format. export_cadence_netlist cannot do it, it drives pstswp, which needs a .DSN schematic.`
+      : `Missing netlist files for ${path.basename(designPath)}. Run export_cadence_netlist to generate them.`
   );
 };
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -64,9 +64,22 @@ vi.mock("fs", async () => {
         }));
       }),
       mkdir: vi.fn(async () => undefined),
+      // resolveExportDir confirms a candidate is a directory, and the export
+      // compares .dat timestamps before and after to tell a fresh netlist from
+      // a previous run's. A rising clock models a run that wrote all three.
+      stat: vi.fn(async (target: string) => {
+        const base = String(target).split(/[\\/]/).pop() ?? "";
+        return {
+          isDirectory: () => !base.includes("."),
+          isFile: () => base.includes("."),
+          mtimeMs: statClock++,
+        };
+      }),
     },
   };
 });
+
+let statClock = 1;
 
 vi.mock("./parsers/index.js", () => ({
   discoverDesigns: vi.fn(),

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -45,16 +45,23 @@ vi.mock("fs", async () => {
     existsSync: vi.fn(() => true),
     promises: {
       ...actual.promises,
-      readdir: vi.fn(async (target?: string) => {
+      readdir: vi.fn(async (target?: string, options?: { withFileTypes?: boolean }) => {
         const normalized = String(target ?? "").toLowerCase();
-        if (normalized.includes("cadence")) {
-          return ["SPB_17.4"];
-        }
-        if (normalized.endsWith("allegro")) {
-          return ["pstchip.dat", "pstxnet.dat", "pstxprt.dat"];
-        }
-        // Schematic directory: contains DSN file and Allegro output folder
-        return ["Board.dsn", "Allegro"];
+        const names = normalized.includes("cadence")
+          ? ["SPB_17.4"]
+          : normalized.endsWith("allegro")
+            ? ["pstchip.dat", "pstxnet.dat", "pstxprt.dat"]
+            : // Schematic directory: one DSN file and the Allegro output folder
+              ["Board.dsn", "Allegro"];
+
+        if (!options?.withFileTypes) return names;
+        // resolveExportDir needs to tell a directory from a file: a plain file
+        // named `allegro` must not be chosen as the output directory.
+        return names.map((name) => ({
+          name,
+          isFile: () => name.includes("."),
+          isDirectory: () => !name.includes("."),
+        }));
       }),
       mkdir: vi.fn(async () => undefined),
     },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -54,3 +54,12 @@ export const netlistDirName = (designName: string): string => `${designName}${NE
 /** Does this directory name look like `<design>`'s export directory? */
 export const isNetlistDirFor = (dirName: string, designName: string): boolean =>
   dirName.toLowerCase() === netlistDirName(designName).toLowerCase();
+
+/**
+ * The three files a netlist export must produce for any consumer to use it.
+ *
+ * Here for the same reason as the suffix above: the exporter decides an export
+ * succeeded by finding them and discovery decides a directory holds a netlist by
+ * finding them, and a list retyped on each side agrees only by coincidence.
+ */
+export const REQUIRED_DAT_FILES = ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"] as const;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -36,3 +36,22 @@ export const resolvePath = (inputPath: string): string => {
  */
 export const getDesignName = (design: string): string =>
   path.basename(design, path.extname(design));
+
+/**
+ * Suffix of the directory `export_cadence_netlist` writes a design's netlist to.
+ *
+ * Lives here because the exporter that creates these directories and the
+ * discovery that has to recognise them sit in different layers, and `service`
+ * may import `parsers` but not the reverse. Retyping the literal in both left
+ * the writer and the reader agreeing only by coincidence: renaming it on one
+ * side would leave every new export unrecognised with nothing failing.
+ */
+export const NETLIST_DIR_SUFFIX = "_netlist";
+
+/** Name of the export directory belonging to a design. */
+export const netlistDirName = (designName: string): string =>
+  `${designName}${NETLIST_DIR_SUFFIX}`;
+
+/** Does this directory name look like `<design>`'s export directory? */
+export const isNetlistDirFor = (dirName: string, designName: string): boolean =>
+  dirName.toLowerCase() === netlistDirName(designName).toLowerCase();

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -49,8 +49,7 @@ export const getDesignName = (design: string): string =>
 export const NETLIST_DIR_SUFFIX = "_netlist";
 
 /** Name of the export directory belonging to a design. */
-export const netlistDirName = (designName: string): string =>
-  `${designName}${NETLIST_DIR_SUFFIX}`;
+export const netlistDirName = (designName: string): string => `${designName}${NETLIST_DIR_SUFFIX}`;
 
 /** Does this directory name look like `<design>`'s export directory? */
 export const isNetlistDirFor = (dirName: string, designName: string): boolean =>

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -15,7 +15,8 @@ export {
   exportCadenceNetlist,
   detectCadenceVersions,
   getLatestCadence,
-  resolveAllegroDir,
+  resolveExportDir,
+  netlistDirName,
   relocateLockFile,
   restoreLockFile,
 } from "./tools/cadence-export.js";

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -16,7 +16,6 @@ export {
   detectCadenceVersions,
   getLatestCadence,
   resolveExportDir,
-  netlistDirName,
   relocateLockFile,
   restoreLockFile,
 } from "./tools/cadence-export.js";

--- a/src/service/tools/cadence-export.test.ts
+++ b/src/service/tools/cadence-export.test.ts
@@ -219,12 +219,21 @@ describe("resolveExportDir", () => {
     expect((await resolveExportDir(only)).dirName).toBe("allegro");
   });
 
-  it("prefers Allegro/ over allegro/ when both exist", async () => {
-    await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
-    await fs.promises.mkdir(path.join(tmpDir, "allegro2"));
+  it("recognises an existing ALLEGRO/ whatever its case", async () => {
+    // Real projects ship Allegro/, allegro/ and ALLEGRO/ alike.
+    await fs.promises.mkdir(path.join(tmpDir, "ALLEGRO"));
     const only = await withDesigns("BOARD.DSN");
 
-    expect((await resolveExportDir(only)).dirName).toBe("Allegro");
+    const result = await resolveExportDir(only);
+    expect(result.dirName).toBe("ALLEGRO");
+    expect(result.outputDir).toBe(path.join(tmpDir, "ALLEGRO"));
+  });
+
+  it("does not mistake a similarly named directory for the legacy one", async () => {
+    await fs.promises.mkdir(path.join(tmpDir, "allegro_old"));
+    const only = await withDesigns("BOARD.DSN");
+
+    expect((await resolveExportDir(only)).dirName).toBe("BOARD_netlist");
   });
 
   it("creates the per-design directory when no legacy directory exists", async () => {

--- a/src/service/tools/cadence-export.test.ts
+++ b/src/service/tools/cadence-export.test.ts
@@ -5,9 +5,9 @@ import {
   relocateLockFile,
   restoreLockFile,
   resolveExportDir,
-  netlistDirName,
 } from "./cadence-export.js";
 import type { ErrorResult } from "../../types.js";
+import { netlistDirName } from "../../paths.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -164,13 +164,15 @@ describe("resolveExportDir", () => {
     await fs.promises.rm(dir, { recursive: true, force: true });
   };
 
-  /** Create .DSN files in the temp dir and return the path of the first. */
+  /** Create files in the temp dir and return the path of the first. */
   const withDesigns = async (...names: string[]): Promise<string> => {
     for (const name of names) await fs.promises.writeFile(path.join(tmpDir, name), "");
     return path.join(tmpDir, names[0]);
   };
 
   beforeEach(async () => {
+    // The describes above install persistent readdir/mkdir spies. Restoring here
+    // keeps these real-filesystem tests from silently passing against a mock.
     vi.restoreAllMocks();
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netlist-test-"));
   });
@@ -194,16 +196,31 @@ describe("resolveExportDir", () => {
   });
 
   it("separates designs even when the folder has a legacy Allegro/ directory", async () => {
-    // A shared Allegro/ is exactly what overwrote the files, so a second design
-    // in the folder must not keep using it.
     await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
     const first = await withDesigns("BOARD_A.DSN", "BOARD_B.DSN");
 
     expect((await resolveExportDir(first)).dirName).toBe("BOARD_A_netlist");
   });
 
+  it("counts an HDL sibling as a design", async () => {
+    // Design Entry HDL's netlister writes the same three filenames into the same
+    // directory pstswp does, so a .cpm neighbour collides just as a .DSN does.
+    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+    const first = await withDesigns("BOARD.DSN", "OTHER.cpm");
+
+    expect((await resolveExportDir(first)).dirName).toBe("BOARD_netlist");
+  });
+
+  it("does not count an AppleDouble sidecar as a design", async () => {
+    // macOS writes ._NAME.DSN beside real files on SMB and NFS shares, and a
+    // Windows workstation exporting from that share sees both entries.
+    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+    const first = await withDesigns("BOARD.DSN", "._BOARD.DSN");
+
+    expect((await resolveExportDir(first)).dirName).toBe("allegro");
+  });
+
   it("keeps using an existing Allegro/ for a folder with one design", async () => {
-    // An established layout a PCB editor or build script may point at.
     await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
     const only = await withDesigns("BOARD.DSN");
 
@@ -212,21 +229,37 @@ describe("resolveExportDir", () => {
     expect(result.outputDir).toBe(path.join(tmpDir, "Allegro"));
   });
 
-  it("keeps using an existing lowercase allegro/ for a folder with one design", async () => {
+  it("recognises an existing ALLEGRO/ whatever its case", async () => {
+    await fs.promises.mkdir(path.join(tmpDir, "ALLEGRO"));
+    const only = await withDesigns("BOARD.DSN");
+
+    expect((await resolveExportDir(only)).dirName).toBe("ALLEGRO");
+  });
+
+  it("picks the allegro directory that already holds a netlist", async () => {
+    // Several spellings can only coexist on a case-sensitive filesystem, which
+    // macOS and Windows are not. Skipped rather than deleted, because Linux CI
+    // is exactly where a share like this shows up.
+    await fs.promises.mkdir(path.join(tmpDir, "ALLEGRO"));
+    const caseInsensitive = await fs.promises
+      .access(path.join(tmpDir, "allegro"))
+      .then(() => true)
+      .catch(() => false);
+    if (caseInsensitive) return;
+
     await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+    await fs.promises.writeFile(path.join(tmpDir, "allegro", "pstxnet.dat"), "");
     const only = await withDesigns("BOARD.DSN");
 
     expect((await resolveExportDir(only)).dirName).toBe("allegro");
   });
 
-  it("recognises an existing ALLEGRO/ whatever its case", async () => {
-    // Real projects ship Allegro/, allegro/ and ALLEGRO/ alike.
-    await fs.promises.mkdir(path.join(tmpDir, "ALLEGRO"));
+  it("ignores a plain file named allegro", async () => {
+    // It would otherwise be chosen and the mkdir would fail.
+    await fs.promises.writeFile(path.join(tmpDir, "allegro"), "not a directory");
     const only = await withDesigns("BOARD.DSN");
 
-    const result = await resolveExportDir(only);
-    expect(result.dirName).toBe("ALLEGRO");
-    expect(result.outputDir).toBe(path.join(tmpDir, "ALLEGRO"));
+    expect((await resolveExportDir(only)).dirName).toBe("BOARD_netlist");
   });
 
   it("does not mistake a similarly named directory for the legacy one", async () => {
@@ -241,16 +274,14 @@ describe("resolveExportDir", () => {
 
     const result = await resolveExportDir(only);
     expect(result.dirName).toBe("BOARD_netlist");
-    expect(result.outputDir).toBe(path.join(tmpDir, "BOARD_netlist"));
     const stat = await fs.promises.stat(result.outputDir);
     expect(stat.isDirectory()).toBe(true);
   });
 
-  it("counts designs case-insensitively", async () => {
-    const first = await withDesigns("BOARD_A.DSN", "board_b.dsn");
-    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+  it("uses the per-design directory for a design alone in an empty folder", async () => {
+    const only = path.join(tmpDir, "BOARD.DSN");
 
-    expect((await resolveExportDir(first)).dirName).toBe("BOARD_A_netlist");
+    expect((await resolveExportDir(only)).dirName).toBe("BOARD_netlist");
   });
 
   it("keeps the design's own spelling in the directory name", () => {

--- a/src/service/tools/cadence-export.test.ts
+++ b/src/service/tools/cadence-export.test.ts
@@ -5,6 +5,7 @@ import {
   relocateLockFile,
   restoreLockFile,
   resolveExportDir,
+  relocateLockFile,
 } from "./cadence-export.js";
 import type { ErrorResult } from "../../types.js";
 import { netlistDirName } from "../../paths.js";
@@ -286,5 +287,56 @@ describe("resolveExportDir", () => {
 
   it("keeps the design's own spelling in the directory name", () => {
     expect(netlistDirName("reServer J401 v1.1")).toBe("reServer J401 v1.1_netlist");
+  });
+});
+
+describe("relocateLockFile", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netlist-lock-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("moves the lock file aside for a .DSN", async () => {
+    const design = path.join(tmpDir, "BOARD.DSN");
+    await fs.promises.writeFile(design, "design");
+    await fs.promises.writeFile(path.join(tmpDir, "BOARD.DSNlck"), "lock");
+
+    const moved = await relocateLockFile(design);
+
+    expect(moved).toBeDefined();
+    expect(path.basename(moved!)).toContain("BOARD.DSNlck");
+    // The design itself is untouched.
+    expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
+  });
+
+  it("never moves the design when the path is not a .DSN", async () => {
+    // `replace` returns the string unchanged when the pattern does not match, so
+    // the lock path WAS the design path and this moved the user's design into
+    // the temp directory. list_designs hands out pstxnet.dat for a dat-only
+    // design and the .cpm for an HDL one, so following the documented workflow
+    // reached it, and the restore is a cross-volume rename that fails on the
+    // network shares these designs live on.
+    for (const name of ["BOARD.cpm", "pstxnet.dat", "BOARD.DSN.bak"]) {
+      const design = path.join(tmpDir, name);
+      await fs.promises.writeFile(design, "design");
+
+      expect(await relocateLockFile(design)).toBeUndefined();
+      expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
+    }
+  });
+});
+
+describe("exportCadenceNetlist input validation", () => {
+  it("refuses a path that is not a .DSN before touching the filesystem", async () => {
+    const result = await exportCadenceNetlist("/tmp/whatever/BOARD.cpm");
+
+    expect(result).toHaveProperty("error");
+    expect((result as ErrorResult).error).toContain(".DSN");
   });
 });

--- a/src/service/tools/cadence-export.test.ts
+++ b/src/service/tools/cadence-export.test.ts
@@ -5,7 +5,6 @@ import {
   relocateLockFile,
   restoreLockFile,
   resolveExportDir,
-  relocateLockFile,
 } from "./cadence-export.js";
 import type { ErrorResult } from "../../types.js";
 import { netlistDirName } from "../../paths.js";
@@ -48,7 +47,7 @@ describe("relocateLockFile", () => {
     expect(result).toBeUndefined();
   });
 
-  it("moves lock file to temp dir and returns temp path", async () => {
+  it("moves the lock file aside and returns where it went", async () => {
     const dsnPath = path.join(tmpDir, "design.DSN");
     const lockPath = path.join(tmpDir, "design.DSNlck");
     await fs.promises.writeFile(dsnPath, "");
@@ -60,6 +59,25 @@ describe("relocateLockFile", () => {
     await expect(fs.promises.access(lockPath)).rejects.toThrow();
     const content = await fs.promises.readFile(tempPath!, "utf-8");
     expect(content).toBe("lock-content");
+
+    await fs.promises.unlink(tempPath!);
+  });
+
+  it("keeps the relocated lock beside the design rather than in the temp directory", async () => {
+    // These designs live on mapped and UNC shares. A rename into tmpdir() crosses
+    // volumes there and raises EXDEV, which surfaced as "Close the design in
+    // Cadence and try again" for a design nobody had open, and no design on a
+    // share could be exported at all.
+    const dsnPath = path.join(tmpDir, "design.DSN");
+    await fs.promises.writeFile(dsnPath, "");
+    await fs.promises.writeFile(path.join(tmpDir, "design.DSNlck"), "lock");
+
+    const tempPath = await relocateLockFile(dsnPath);
+
+    expect(path.dirname(tempPath!)).toBe(tmpDir);
+    expect(tempPath!.startsWith(os.tmpdir() + path.sep)).toBe(
+      tmpDir.startsWith(os.tmpdir() + path.sep)
+    );
 
     await fs.promises.unlink(tempPath!);
   });
@@ -76,6 +94,33 @@ describe("relocateLockFile", () => {
     await expect(fs.promises.access(lockPath)).rejects.toThrow();
 
     await fs.promises.unlink(tempPath!);
+  });
+
+  it("moves the lock file aside for a .DSN without touching the design", async () => {
+    const design = path.join(tmpDir, "BOARD.DSN");
+    await fs.promises.writeFile(design, "design");
+    await fs.promises.writeFile(path.join(tmpDir, "BOARD.DSNlck"), "lock");
+
+    const moved = await relocateLockFile(design);
+
+    expect(moved).toBeDefined();
+    expect(path.basename(moved!)).toContain("BOARD.DSNlck");
+    expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
+  });
+
+  it("never moves the design when the path is not a .DSN", async () => {
+    // `replace` returns the string unchanged when the pattern does not match, so
+    // the lock path WAS the design path and this moved the user's design into
+    // the temp directory. list_designs hands out pstxnet.dat for a dat-only
+    // design and the .cpm for an HDL one, so following the documented workflow
+    // reached it.
+    for (const name of ["BOARD.cpm", "pstxnet.dat", "BOARD.DSN.bak"]) {
+      const design = path.join(tmpDir, name);
+      await fs.promises.writeFile(design, "design");
+
+      expect(await relocateLockFile(design)).toBeUndefined();
+      expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
+    }
   });
 });
 
@@ -221,6 +266,28 @@ describe("resolveExportDir", () => {
     expect((await resolveExportDir(first)).dirName).toBe("allegro");
   });
 
+  it("writes to an existing <design>_netlist even when a legacy allegro/ is there", async () => {
+    // Discovery ranks <design>_netlist/ above a bare allegro/ by the whole export
+    // bonus. Checking allegro/ first meant the exporter wrote to one directory
+    // while every reader read the other: each re-export reported success and
+    // every query kept answering from a netlist that had stopped updating.
+    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+    await fs.promises.mkdir(path.join(tmpDir, "BOARD_netlist"));
+    const only = await withDesigns("BOARD.DSN");
+
+    expect((await resolveExportDir(only)).dirName).toBe("BOARD_netlist");
+  });
+
+  it("reports whether the output directory already existed", async () => {
+    // A failed export may only remove a directory it brought into being: nothing
+    // of the caller's can be inside one that did not exist a moment ago, and a
+    // half-written trio left behind outranks the intact netlist beside it.
+    const only = await withDesigns("BOARD.DSN");
+
+    expect((await resolveExportDir(only)).created).toBe(true);
+    expect((await resolveExportDir(only)).created).toBe(false);
+  });
+
   it("keeps using an existing Allegro/ for a folder with one design", async () => {
     await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
     const only = await withDesigns("BOARD.DSN");
@@ -237,16 +304,20 @@ describe("resolveExportDir", () => {
     expect((await resolveExportDir(only)).dirName).toBe("ALLEGRO");
   });
 
-  it("picks the allegro directory that already holds a netlist", async () => {
+  it("picks the allegro directory that already holds a netlist", async (ctx) => {
     // Several spellings can only coexist on a case-sensitive filesystem, which
     // macOS and Windows are not. Skipped rather than deleted, because Linux CI
     // is exactly where a share like this shows up.
+    //
+    // ctx.skip(), not a bare return: returning early reports a pass, so on the
+    // two platforms where the condition holds this read as covered while
+    // asserting nothing at all.
     await fs.promises.mkdir(path.join(tmpDir, "ALLEGRO"));
     const caseInsensitive = await fs.promises
       .access(path.join(tmpDir, "allegro"))
       .then(() => true)
       .catch(() => false);
-    if (caseInsensitive) return;
+    if (caseInsensitive) ctx.skip();
 
     await fs.promises.mkdir(path.join(tmpDir, "allegro"));
     await fs.promises.writeFile(path.join(tmpDir, "allegro", "pstxnet.dat"), "");
@@ -287,48 +358,6 @@ describe("resolveExportDir", () => {
 
   it("keeps the design's own spelling in the directory name", () => {
     expect(netlistDirName("reServer J401 v1.1")).toBe("reServer J401 v1.1_netlist");
-  });
-});
-
-describe("relocateLockFile", () => {
-  let tmpDir: string;
-
-  beforeEach(async () => {
-    vi.restoreAllMocks();
-    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netlist-lock-"));
-  });
-
-  afterEach(async () => {
-    await fs.promises.rm(tmpDir, { recursive: true, force: true });
-  });
-
-  it("moves the lock file aside for a .DSN", async () => {
-    const design = path.join(tmpDir, "BOARD.DSN");
-    await fs.promises.writeFile(design, "design");
-    await fs.promises.writeFile(path.join(tmpDir, "BOARD.DSNlck"), "lock");
-
-    const moved = await relocateLockFile(design);
-
-    expect(moved).toBeDefined();
-    expect(path.basename(moved!)).toContain("BOARD.DSNlck");
-    // The design itself is untouched.
-    expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
-  });
-
-  it("never moves the design when the path is not a .DSN", async () => {
-    // `replace` returns the string unchanged when the pattern does not match, so
-    // the lock path WAS the design path and this moved the user's design into
-    // the temp directory. list_designs hands out pstxnet.dat for a dat-only
-    // design and the .cpm for an HDL one, so following the documented workflow
-    // reached it, and the restore is a cross-volume rename that fails on the
-    // network shares these designs live on.
-    for (const name of ["BOARD.cpm", "pstxnet.dat", "BOARD.DSN.bak"]) {
-      const design = path.join(tmpDir, name);
-      await fs.promises.writeFile(design, "design");
-
-      expect(await relocateLockFile(design)).toBeUndefined();
-      expect(await fs.promises.readFile(design, "utf-8")).toBe("design");
-    }
   });
 });
 

--- a/src/service/tools/cadence-export.test.ts
+++ b/src/service/tools/cadence-export.test.ts
@@ -4,7 +4,8 @@ import {
   detectCadenceVersions,
   relocateLockFile,
   restoreLockFile,
-  resolveAllegroDir,
+  resolveExportDir,
+  netlistDirName,
 } from "./cadence-export.js";
 import type { ErrorResult } from "../../types.js";
 import * as fs from "fs";
@@ -156,11 +157,17 @@ describe("detectCadenceVersions", () => {
   });
 });
 
-describe("resolveAllegroDir", () => {
+describe("resolveExportDir", () => {
   let tmpDir: string;
 
   const cleanup = async (dir: string) => {
     await fs.promises.rm(dir, { recursive: true, force: true });
+  };
+
+  /** Create .DSN files in the temp dir and return the path of the first. */
+  const withDesigns = async (...names: string[]): Promise<string> => {
+    for (const name of names) await fs.promises.writeFile(path.join(tmpDir, name), "");
+    return path.join(tmpDir, names[0]);
   };
 
   beforeEach(async () => {
@@ -172,35 +179,72 @@ describe("resolveAllegroDir", () => {
     await cleanup(tmpDir);
   });
 
-  it("uses existing Allegro/ directory", async () => {
+  it("gives each design in a shared folder its own directory", async () => {
+    // The reported bug: pstswp writes pstxnet.dat under a fixed name, so two
+    // designs exporting to one directory leave only the second design's netlist.
+    const first = await withDesigns("BOARD_A.DSN", "BOARD_B.DSN");
+    const second = path.join(tmpDir, "BOARD_B.DSN");
+
+    const a = await resolveExportDir(first);
+    const b = await resolveExportDir(second);
+
+    expect(a.dirName).toBe("BOARD_A_netlist");
+    expect(b.dirName).toBe("BOARD_B_netlist");
+    expect(a.outputDir).not.toBe(b.outputDir);
+  });
+
+  it("separates designs even when the folder has a legacy Allegro/ directory", async () => {
+    // A shared Allegro/ is exactly what overwrote the files, so a second design
+    // in the folder must not keep using it.
     await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
-    const result = await resolveAllegroDir(tmpDir);
+    const first = await withDesigns("BOARD_A.DSN", "BOARD_B.DSN");
+
+    expect((await resolveExportDir(first)).dirName).toBe("BOARD_A_netlist");
+  });
+
+  it("keeps using an existing Allegro/ for a folder with one design", async () => {
+    // An established layout a PCB editor or build script may point at.
+    await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
+    const only = await withDesigns("BOARD.DSN");
+
+    const result = await resolveExportDir(only);
     expect(result.dirName).toBe("Allegro");
     expect(result.outputDir).toBe(path.join(tmpDir, "Allegro"));
   });
 
-  it("uses existing allegro/ directory", async () => {
+  it("keeps using an existing lowercase allegro/ for a folder with one design", async () => {
     await fs.promises.mkdir(path.join(tmpDir, "allegro"));
-    const result = await resolveAllegroDir(tmpDir);
-    expect(result.dirName).toBe("allegro");
-    expect(result.outputDir).toBe(path.join(tmpDir, "allegro"));
+    const only = await withDesigns("BOARD.DSN");
+
+    expect((await resolveExportDir(only)).dirName).toBe("allegro");
   });
 
   it("prefers Allegro/ over allegro/ when both exist", async () => {
-    vi.spyOn(fs.promises, "readdir")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockResolvedValueOnce(["Allegro", "allegro"] as any);
-    vi.spyOn(fs.promises, "mkdir").mockResolvedValueOnce(undefined);
+    await fs.promises.mkdir(path.join(tmpDir, "Allegro"));
+    await fs.promises.mkdir(path.join(tmpDir, "allegro2"));
+    const only = await withDesigns("BOARD.DSN");
 
-    const result = await resolveAllegroDir(tmpDir);
-    expect(result.dirName).toBe("Allegro");
+    expect((await resolveExportDir(only)).dirName).toBe("Allegro");
   });
 
-  it("creates allegro/ when neither exists", async () => {
-    const result = await resolveAllegroDir(tmpDir);
-    expect(result.dirName).toBe("allegro");
-    expect(result.outputDir).toBe(path.join(tmpDir, "allegro"));
+  it("creates the per-design directory when no legacy directory exists", async () => {
+    const only = await withDesigns("BOARD.DSN");
+
+    const result = await resolveExportDir(only);
+    expect(result.dirName).toBe("BOARD_netlist");
+    expect(result.outputDir).toBe(path.join(tmpDir, "BOARD_netlist"));
     const stat = await fs.promises.stat(result.outputDir);
     expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("counts designs case-insensitively", async () => {
+    const first = await withDesigns("BOARD_A.DSN", "board_b.dsn");
+    await fs.promises.mkdir(path.join(tmpDir, "allegro"));
+
+    expect((await resolveExportDir(first)).dirName).toBe("BOARD_A_netlist");
+  });
+
+  it("keeps the design's own spelling in the directory name", () => {
+    expect(netlistDirName("reServer J401 v1.1")).toBe("reServer J401 v1.1_netlist");
   });
 });

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -94,11 +94,12 @@ export const resolveExportDir = async (
   // the collision this whole function exists to prevent. AppleDouble sidecars
   // (`._NAME.DSN`, written by macOS onto SMB and NFS shares) are not designs.
   const designCount = entries.filter(
-    (e) => e.isFile() && !e.name.startsWith("._") && /\.(dsn|cpm)$/i.test(e.name)
+    (e) => !e.isDirectory() && !e.name.startsWith("._") && /\.(dsn|cpm)$/i.test(e.name)
   ).length;
 
   const dirName =
-    designCount <= 1 ? ((await legacyExportDir(dsnDir, entries)) ?? netlistDirName(designName))
+    designCount <= 1
+      ? ((await legacyExportDir(dsnDir, entries)) ?? netlistDirName(designName))
       : netlistDirName(designName);
 
   const outputDir = path.join(dsnDir, dirName);
@@ -117,12 +118,27 @@ export const resolveExportDir = async (
  * kept reading the real one.
  */
 const legacyExportDir = async (dsnDir: string, entries: Dirent[]): Promise<string | undefined> => {
-  const candidates = entries
-    .filter((e) => e.isDirectory() && e.name.toLowerCase() === "allegro")
+  const named = entries
+    .filter((e) => e.name.toLowerCase() === "allegro")
     .map((e) => e.name)
     .sort();
+
+  // stat, not Dirent.isDirectory(): a symlink or a Windows directory junction
+  // reports false there, and pointing `allegro` at a shared netlist drop is a
+  // normal way to set up exactly the layout this branch exists to preserve.
+  const candidates: string[] = [];
+  for (const name of named) {
+    try {
+      if ((await fs.promises.stat(path.join(dsnDir, name))).isDirectory()) candidates.push(name);
+    } catch {
+      // Broken link or vanished entry; not a usable output directory.
+    }
+  }
   if (candidates.length <= 1) return candidates[0];
 
+  // Several spellings can only coexist on a case-sensitive filesystem. The one
+  // already holding a netlist is the live one; an empty stray would silently
+  // become the export target while consumers kept reading the real directory.
   for (const name of candidates) {
     try {
       await fs.promises.access(path.join(dsnDir, name, "pstxnet.dat"));
@@ -134,12 +150,47 @@ const legacyExportDir = async (dsnDir: string, entries: Dirent[]): Promise<strin
   return candidates[0];
 };
 
+/** The three files a netlist export must produce for any consumer to use it. */
+const REQUIRED_DAT_FILES = ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"] as const;
+
+/** Modification time of each required .dat file present in a directory. */
+const datFileTimestamps = async (dir: string): Promise<Map<string, number>> => {
+  const stamps = new Map<string, number>();
+  await Promise.all(
+    REQUIRED_DAT_FILES.map(async (name) => {
+      try {
+        const st = await fs.promises.stat(path.join(dir, name));
+        stamps.set(name, st.mtimeMs);
+      } catch {
+        // Absent, which is what an unwritten file looks like.
+      }
+    })
+  );
+  return stamps;
+};
+
+/** pstswp at -v 3 -l 255 can emit megabytes; an error message carries the tail. */
+const truncateLog = (log: string): string => (log.length <= 2000 ? log : `...${log.slice(-2000)}`);
+
+/** The lock file OrCAD Capture holds beside an open design, if this is a .DSN. */
+const lockFilePathFor = (dsnPath: string): string | undefined =>
+  /\.DSN$/i.test(dsnPath) ? dsnPath.replace(/\.DSN$/i, ".DSNlck") : undefined;
+
 /**
  * Temporarily relocate a .DSNlck lock file so pstswp can proceed.
  * Returns the temporary path if relocated, or undefined if no lock file exists.
+ *
+ * The path must be checked for the .DSN extension first. `replace` returns the
+ * string unchanged when the pattern does not match, so for any other path the
+ * lock path WAS the design path, and this function moved the design itself into
+ * the temp directory. `list_designs` hands out `pstxnet.dat` for a dat-only
+ * design and the `.cpm` for an HDL one, so that was reachable by following the
+ * documented workflow, and the restore is a cross-volume rename that fails on
+ * the network shares these designs live on.
  */
 export const relocateLockFile = async (dsnPath: string): Promise<string | undefined> => {
-  const lockPath = dsnPath.replace(/\.DSN$/i, ".DSNlck");
+  const lockPath = lockFilePathFor(dsnPath);
+  if (!lockPath) return undefined;
   try {
     await fs.promises.access(lockPath);
   } catch {
@@ -155,7 +206,8 @@ export const relocateLockFile = async (dsnPath: string): Promise<string | undefi
  * Logs a warning if restoration fails (e.g. temp file was cleaned up).
  */
 export const restoreLockFile = async (dsnPath: string, tempPath: string): Promise<void> => {
-  const lockPath = dsnPath.replace(/\.DSN$/i, ".DSNlck");
+  const lockPath = lockFilePathFor(dsnPath);
+  if (!lockPath) return;
   try {
     await fs.promises.rename(tempPath, lockPath);
   } catch {
@@ -173,6 +225,15 @@ export const restoreLockFile = async (dsnPath: string, tempPath: string): Promis
 export const exportCadenceNetlist = async (
   dsnPath: string
 ): Promise<ExportNetlistResult | ErrorResult> => {
+  // Argument validation first: it does not depend on the platform, and every
+  // path below assumes a .DSN. pstswp needs the schematic, and the lock-file
+  // handling derives its path by substituting the .DSN extension.
+  if (!/\.DSN$/i.test(dsnPath)) {
+    return {
+      error: `export_cadence_netlist needs the .DSN schematic, not ${path.basename(dsnPath)}. For an HDL (.cpm) design, export from Cadence: Tools → Create Netlist → PCB Editor format.`,
+    };
+  }
+
   // Platform check
   if (process.platform !== "win32") {
     return {
@@ -210,8 +271,24 @@ export const exportCadenceNetlist = async (
   }
 
   return serializePstswp(async () => {
-    // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
-    const lockTempPath = await relocateLockFile(resolvedDsnPath);
+    // Everything below the mutex reports failure as an ErrorResult. Relocating
+    // the lock file is a rename that can fail on its own: the lock exists
+    // because Capture holds the design open, and a rename to the temp directory
+    // crosses volumes whenever the project lives on a mapped or UNC share.
+    let lockTempPath: string | undefined;
+    try {
+      lockTempPath = await relocateLockFile(resolvedDsnPath);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        error: `Could not move the .DSNlck lock file aside for ${dsnFile}: ${message}. Close the design in Cadence and try again.`,
+      };
+    }
+
+    // What was already in the output directory before this run. mkdir(recursive)
+    // reuses an existing directory and nothing clears it, so a previous run's
+    // netlist would otherwise make a run that wrote nothing look successful.
+    const before = await datFileTimestamps(outputDir);
 
     const command = `cd /d "${dsnDir}" && "${cadence.pstswp}" -pst -d "${dsnFile}" -n "${outputDirName}" -c "${cadence.config}" -v 3 -l 255 -j "PCB Footprint"`;
 
@@ -222,21 +299,35 @@ export const exportCadenceNetlist = async (
       });
 
       // pstswp can exit cleanly having written nothing where we expect it, and
-      // reporting success with an empty directory sends the caller to look for
-      // files that are not there. The netlist itself is the evidence.
+      // reporting success then sends the caller to read files that are missing,
+      // or worse, a previous run's. Every consumer needs the whole trio:
+      // discovery only forms a dat set when all three exist. So the evidence is
+      // all three present AND written by this run.
       let generatedFiles: string[] | undefined;
+      let listError: string | undefined;
       try {
         generatedFiles = (await fs.promises.readdir(outputDir)).sort();
-      } catch {
-        // Output directory may not exist if export failed silently
+      } catch (err: unknown) {
+        listError = err instanceof Error ? err.message : String(err);
       }
 
       const log = (stdout + stderr).trim() || undefined;
-      if (!generatedFiles?.some((f) => f.toLowerCase() === "pstxnet.dat")) {
+      if (listError !== undefined) {
+        return { error: `Could not read the export directory ${outputDir}: ${listError}` };
+      }
+
+      const after = await datFileTimestamps(outputDir);
+      const stale = REQUIRED_DAT_FILES.filter(
+        (f) => after.get(f) === undefined || after.get(f) === before.get(f)
+      );
+      if (stale.length > 0) {
+        const missing = REQUIRED_DAT_FILES.filter((f) => after.get(f) === undefined);
         return {
           error:
-            `Cadence pstswp reported success but wrote no netlist to ${outputDir}. ` +
-            `Check the log for the directory it actually used.${log ? ` Log: ${log}` : ""}`,
+            (missing.length > 0
+              ? `Cadence pstswp reported success but did not write ${missing.join(", ")} to ${outputDir}.`
+              : `Cadence pstswp reported success but left ${stale.join(", ")} in ${outputDir} unchanged, so the netlist there is from an earlier run.`) +
+            ` Check the log for the directory it actually used.${log ? ` Log: ${truncateLog(log)}` : ""}`,
         };
       }
 

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -1,11 +1,16 @@
 import { exec } from "child_process";
 import * as fs from "fs";
 import type { Dirent } from "fs";
-import { tmpdir } from "os";
 import path from "path";
 import { promisify } from "util";
 import { createMutex } from "./async-mutex.js";
-import { resolvePath, netlistDirName } from "../../paths.js";
+import {
+  resolvePath,
+  netlistDirName,
+  isNetlistDirFor,
+  getDesignName,
+  REQUIRED_DAT_FILES,
+} from "../../paths.js";
 import type { CadenceInstall, ExportNetlistResult, ErrorResult } from "../../types.js";
 
 // Serialize pstswp invocations to prevent concurrent Cadence license conflicts
@@ -77,9 +82,9 @@ export const getLatestCadence = async (): Promise<CadenceInstall | null> => {
  */
 export const resolveExportDir = async (
   dsnPath: string
-): Promise<{ outputDir: string; dirName: string }> => {
+): Promise<{ outputDir: string; dirName: string; created: boolean }> => {
   const dsnDir = path.dirname(dsnPath);
-  const designName = path.basename(dsnPath, path.extname(dsnPath));
+  const designName = getDesignName(dsnPath);
 
   let entries: Dirent[] = [];
   try {
@@ -97,14 +102,34 @@ export const resolveExportDir = async (
     (e) => !e.isDirectory() && !e.name.startsWith("._") && /\.(dsn|cpm)$/i.test(e.name)
   ).length;
 
-  const dirName =
-    designCount <= 1
-      ? ((await legacyExportDir(dsnDir, entries)) ?? netlistDirName(designName))
-      : netlistDirName(designName);
+  // An existing export directory is checked before the legacy one because that
+  // is the order discovery reads them in: `scoreDatSetMatch` ranks
+  // `<design>_netlist/` above a bare `allegro/` by the whole export bonus.
+  // Writing to `allegro/` while every reader reads `<design>_netlist/` reported
+  // success on each re-export and left every query answering from a netlist
+  // that had stopped updating.
+  const existingExportDir = entries.find(
+    (e) => !e.name.startsWith("._") && isNetlistDirFor(e.name, designName)
+  )?.name;
+
+  const dirName = cmdSafeDirName(
+    existingExportDir ??
+      (designCount <= 1
+        ? ((await legacyExportDir(dsnDir, entries)) ?? netlistDirName(designName))
+        : netlistDirName(designName))
+  );
 
   const outputDir = path.join(dsnDir, dirName);
-  await fs.promises.mkdir(outputDir, { recursive: true });
-  return { outputDir, dirName };
+  // Whether this run brought the directory into being decides whether a failed
+  // export may remove it again: nothing of the caller's can be inside a
+  // directory that did not exist a moment ago.
+  let created = false;
+  try {
+    created = (await fs.promises.mkdir(outputDir, { recursive: true })) !== undefined;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") throw err;
+  }
+  return { outputDir, dirName, created };
 };
 
 /**
@@ -150,9 +175,6 @@ const legacyExportDir = async (dsnDir: string, entries: Dirent[]): Promise<strin
   return candidates[0];
 };
 
-/** The three files a netlist export must produce for any consumer to use it. */
-const REQUIRED_DAT_FILES = ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"] as const;
-
 /** Modification time of each required .dat file present in a directory. */
 const datFileTimestamps = async (dir: string): Promise<Map<string, number>> => {
   const stamps = new Map<string, number>();
@@ -172,6 +194,17 @@ const datFileTimestamps = async (dir: string): Promise<Map<string, number>> => {
 /** pstswp at -v 3 -l 255 can emit megabytes; an error message carries the tail. */
 const truncateLog = (log: string): string => (log.length <= 2000 ? log : `...${log.slice(-2000)}`);
 
+/**
+ * A directory name cmd.exe will pass through to pstswp unchanged.
+ *
+ * The command runs through cmd.exe, which expands `%NAME%` inside double quotes.
+ * `%` is a legal character in a Windows filename, so a design called
+ * `BOARD%TEMP%.DSN` had its export directory created under one name and pstswp
+ * told to write to another. (`"` needs no handling: Windows does not allow it in
+ * a filename at all, which is what keeps the surrounding quotes intact.)
+ */
+const cmdSafeDirName = (dirName: string): string => dirName.replace(/%/g, "_");
+
 /** The lock file OrCAD Capture holds beside an open design, if this is a .DSN. */
 const lockFilePathFor = (dsnPath: string): string | undefined =>
   /\.DSN$/i.test(dsnPath) ? dsnPath.replace(/\.DSN$/i, ".DSNlck") : undefined;
@@ -185,8 +218,14 @@ const lockFilePathFor = (dsnPath: string): string | undefined =>
  * lock path WAS the design path, and this function moved the design itself into
  * the temp directory. `list_designs` hands out `pstxnet.dat` for a dat-only
  * design and the `.cpm` for an HDL one, so that was reachable by following the
- * documented workflow, and the restore is a cross-volume rename that fails on
- * the network shares these designs live on.
+ * documented workflow.
+ *
+ * The lock moves to a sibling name rather than to `tmpdir()`. These designs live
+ * on mapped and UNC shares, where a rename into the local temp directory crosses
+ * volumes and raises EXDEV, so no design on a share could be exported at all.
+ * A sibling rename stays on one filesystem, and if the process dies before the
+ * restore, what is left beside the design is an inert `.DSNlck.<ts>.bak` rather
+ * than a lock stranded in a directory the operating system may clear.
  */
 export const relocateLockFile = async (dsnPath: string): Promise<string | undefined> => {
   const lockPath = lockFilePathFor(dsnPath);
@@ -196,7 +235,7 @@ export const relocateLockFile = async (dsnPath: string): Promise<string | undefi
   } catch {
     return undefined;
   }
-  const tempPath = path.join(tmpdir(), `${path.basename(lockPath)}.${Date.now()}`);
+  const tempPath = `${lockPath}.${Date.now()}.bak`;
   await fs.promises.rename(lockPath, tempPath);
   return tempPath;
 };
@@ -261,8 +300,13 @@ export const exportCadenceNetlist = async (
   // raw MCP error and aborts the CLI's per-design loop entirely.
   let outputDir: string;
   let outputDirName: string;
+  let createdOutputDir = false;
   try {
-    ({ outputDir, dirName: outputDirName } = await resolveExportDir(resolvedDsnPath));
+    ({
+      outputDir,
+      dirName: outputDirName,
+      created: createdOutputDir,
+    } = await resolveExportDir(resolvedDsnPath));
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -270,7 +314,7 @@ export const exportCadenceNetlist = async (
     };
   }
 
-  return serializePstswp(async () => {
+  const result = await serializePstswp(async () => {
     // Everything below the mutex reports failure as an ErrorResult. Relocating
     // the lock file is a rename that can fail on its own: the lock exists
     // because Capture holds the design open, and a rename to the temp directory
@@ -296,6 +340,13 @@ export const exportCadenceNetlist = async (
       const { stdout, stderr } = await execAsync(command, {
         shell: "cmd.exe",
         timeout: 120000,
+        // -v 3 -l 255 is the most verbose setting pstswp has, and on a large
+        // board it emits megabytes. Node's default cap is 1 MiB, and it does not
+        // detach the child at the cap, it kills it: the export died partway
+        // through writing the netlist and the failure was reported as Cadence's
+        // ("stdout maxBuffer length exceeded"), deterministically, on exactly the
+        // largest designs that most need the DAT path over the DSN fallback.
+        maxBuffer: 64 * 1024 * 1024,
       });
 
       // pstswp can exit cleanly having written nothing where we expect it, and
@@ -316,10 +367,16 @@ export const exportCadenceNetlist = async (
         return { error: `Could not read the export directory ${outputDir}: ${listError}` };
       }
 
+      // Strictly newer, not merely different: a file carrying an older stamp
+      // than before the run (a timestamp-preserving copy dropped in, a clock
+      // stepping back) is not something this run wrote.
       const after = await datFileTimestamps(outputDir);
-      const stale = REQUIRED_DAT_FILES.filter(
-        (f) => after.get(f) === undefined || after.get(f) === before.get(f)
-      );
+      const stale = REQUIRED_DAT_FILES.filter((f) => {
+        const now = after.get(f);
+        if (now === undefined) return true; // never written
+        const then = before.get(f);
+        return then !== undefined && now <= then;
+      });
       if (stale.length > 0) {
         const missing = REQUIRED_DAT_FILES.filter((f) => after.get(f) === undefined);
         return {
@@ -334,7 +391,12 @@ export const exportCadenceNetlist = async (
       return {
         success: true,
         outputDir,
-        log,
+        // Truncated on the way out, not only on the error path. server.ts
+        // JSON-stringifies this straight into the MCP text content, so an
+        // untruncated log put the whole of pstswp's most verbose output into the
+        // caller's context on every successful export, for a payload whose
+        // useful content is the output directory and three filenames.
+        log: log === undefined ? undefined : truncateLog(log),
         cadenceVersion: cadence.version,
         generatedFiles,
       };
@@ -356,4 +418,19 @@ export const exportCadenceNetlist = async (
       }
     }
   });
+
+  // A directory this run brought into being holds nothing but this run's output,
+  // so a failed export takes it away again. Left behind, a half-written trio
+  // outranks the intact netlist beside it by the whole export bonus, and every
+  // later query reads the truncated files with nothing reporting a problem.
+  if ("error" in result && createdOutputDir) {
+    try {
+      await fs.promises.rm(outputDir, { recursive: true, force: true });
+    } catch {
+      // Best effort: an empty or partial directory is not worth failing over,
+      // and the error already being returned is the more useful one.
+    }
+  }
+
+  return result;
 };

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -60,25 +60,44 @@ export const getLatestCadence = async (): Promise<CadenceInstall | null> => {
   return versions[0] ?? null;
 };
 
+/** Suffix for a per-design export directory: `<design>_netlist`. */
+export const NETLIST_DIR_SUFFIX = "_netlist";
+
+/** Name of the export directory belonging to a design. */
+export const netlistDirName = (designName: string): string =>
+  `${designName}${NETLIST_DIR_SUFFIX}`;
+
 /**
- * Resolve the Allegro output directory for netlist export.
- * Uses an existing Allegro/ or allegro/ directory if present, otherwise creates allegro/.
+ * Resolve the output directory for a design's netlist export.
+ *
+ * pstswp names its output files the same way for every design (`pstxnet.dat`,
+ * `pstxprt.dat`, `pstchip.dat`), so two designs exporting to one directory
+ * leave only the second design's netlist behind. Each design therefore gets
+ * `<design>_netlist/` of its own, which discovery recognises as belonging to
+ * that design.
+ *
+ * The exception is a folder holding a single design that already has an
+ * `Allegro/` or `allegro/` directory. That is an established project layout,
+ * often pointed at by a PCB editor or a build script, and it cannot collide
+ * with anything, so exports keep going there.
  */
-export const resolveAllegroDir = async (
-  dsnDir: string
+export const resolveExportDir = async (
+  dsnPath: string
 ): Promise<{ outputDir: string; dirName: string }> => {
-  let dirName = "allegro";
+  const dsnDir = path.dirname(dsnPath);
+  const designName = path.basename(dsnPath, path.extname(dsnPath));
+
+  let entries: string[] = [];
   try {
-    const entries = await fs.promises.readdir(dsnDir);
-    for (const candidate of ["Allegro", "allegro"]) {
-      if (entries.includes(candidate)) {
-        dirName = candidate;
-        break;
-      }
-    }
+    entries = await fs.promises.readdir(dsnDir);
   } catch {
-    // parent doesn't exist or can't be read
+    // Directory doesn't exist or can't be read; fall through to the per-design name.
   }
+
+  const designCount = entries.filter((e) => /\.dsn$/i.test(e)).length;
+  const legacyDir = ["Allegro", "allegro"].find((c) => entries.includes(c));
+
+  const dirName = legacyDir && designCount <= 1 ? legacyDir : netlistDirName(designName);
   const outputDir = path.join(dsnDir, dirName);
   await fs.promises.mkdir(outputDir, { recursive: true });
   return { outputDir, dirName };
@@ -143,7 +162,7 @@ export const exportCadenceNetlist = async (
   const resolvedDsnPath = resolvePath(dsnPath);
   const dsnDir = path.dirname(resolvedDsnPath);
   const dsnFile = path.basename(dsnPath);
-  const { outputDir, dirName: outputDirName } = await resolveAllegroDir(dsnDir);
+  const { outputDir, dirName: outputDirName } = await resolveExportDir(resolvedDsnPath);
 
   return serializePstswp(async () => {
     // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -95,7 +95,9 @@ export const resolveExportDir = async (
   }
 
   const designCount = entries.filter((e) => /\.dsn$/i.test(e)).length;
-  const legacyDir = ["Allegro", "allegro"].find((c) => entries.includes(c));
+  // Matched case-insensitively and kept with its real spelling on disk: real
+  // projects ship Allegro/, allegro/ and ALLEGRO/ alike.
+  const legacyDir = entries.filter((e) => e.toLowerCase() === "allegro").sort()[0];
 
   const dirName = legacyDir && designCount <= 1 ? legacyDir : netlistDirName(designName);
   const outputDir = path.join(dsnDir, dirName);

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -1,10 +1,11 @@
 import { exec } from "child_process";
 import * as fs from "fs";
+import type { Dirent } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { promisify } from "util";
 import { createMutex } from "./async-mutex.js";
-import { resolvePath } from "../../paths.js";
+import { resolvePath, netlistDirName } from "../../paths.js";
 import type { CadenceInstall, ExportNetlistResult, ErrorResult } from "../../types.js";
 
 // Serialize pstswp invocations to prevent concurrent Cadence license conflicts
@@ -60,13 +61,6 @@ export const getLatestCadence = async (): Promise<CadenceInstall | null> => {
   return versions[0] ?? null;
 };
 
-/** Suffix for a per-design export directory: `<design>_netlist`. */
-export const NETLIST_DIR_SUFFIX = "_netlist";
-
-/** Name of the export directory belonging to a design. */
-export const netlistDirName = (designName: string): string =>
-  `${designName}${NETLIST_DIR_SUFFIX}`;
-
 /**
  * Resolve the output directory for a design's netlist export.
  *
@@ -77,9 +71,9 @@ export const netlistDirName = (designName: string): string =>
  * that design.
  *
  * The exception is a folder holding a single design that already has an
- * `Allegro/` or `allegro/` directory. That is an established project layout,
- * often pointed at by a PCB editor or a build script, and it cannot collide
- * with anything, so exports keep going there.
+ * `allegro` directory. That is an established project layout, often pointed at
+ * by a PCB editor or a build script, and it cannot collide with anything, so
+ * exports keep going there.
  */
 export const resolveExportDir = async (
   dsnPath: string
@@ -87,22 +81,57 @@ export const resolveExportDir = async (
   const dsnDir = path.dirname(dsnPath);
   const designName = path.basename(dsnPath, path.extname(dsnPath));
 
-  let entries: string[] = [];
+  let entries: Dirent[] = [];
   try {
-    entries = await fs.promises.readdir(dsnDir);
+    entries = await fs.promises.readdir(dsnDir, { withFileTypes: true });
   } catch {
     // Directory doesn't exist or can't be read; fall through to the per-design name.
   }
 
-  const designCount = entries.filter((e) => /\.dsn$/i.test(e)).length;
-  // Matched case-insensitively and kept with its real spelling on disk: real
-  // projects ship Allegro/, allegro/ and ALLEGRO/ alike.
-  const legacyDir = entries.filter((e) => e.toLowerCase() === "allegro").sort()[0];
+  // Both Cadence design kinds count, because Design Entry HDL's netlister writes
+  // the same three filenames into the same directory that pstswp does. Counting
+  // only .dsn left a CIS design sharing `allegro/` with an HDL sibling, which is
+  // the collision this whole function exists to prevent. AppleDouble sidecars
+  // (`._NAME.DSN`, written by macOS onto SMB and NFS shares) are not designs.
+  const designCount = entries.filter(
+    (e) => e.isFile() && !e.name.startsWith("._") && /\.(dsn|cpm)$/i.test(e.name)
+  ).length;
 
-  const dirName = legacyDir && designCount <= 1 ? legacyDir : netlistDirName(designName);
+  const dirName =
+    designCount <= 1 ? ((await legacyExportDir(dsnDir, entries)) ?? netlistDirName(designName))
+      : netlistDirName(designName);
+
   const outputDir = path.join(dsnDir, dirName);
   await fs.promises.mkdir(outputDir, { recursive: true });
   return { outputDir, dirName };
+};
+
+/**
+ * An existing `allegro` directory beside the design, whatever its case.
+ *
+ * Real projects ship `Allegro/`, `allegro/` and `ALLEGRO/` alike. It must be a
+ * directory: a plain file of that name would otherwise be chosen and the mkdir
+ * would fail. When a case-sensitive filesystem holds more than one spelling,
+ * the one already holding a netlist is the live one; the rest are strays, and a
+ * stray empty directory would silently become the export target while consumers
+ * kept reading the real one.
+ */
+const legacyExportDir = async (dsnDir: string, entries: Dirent[]): Promise<string | undefined> => {
+  const candidates = entries
+    .filter((e) => e.isDirectory() && e.name.toLowerCase() === "allegro")
+    .map((e) => e.name)
+    .sort();
+  if (candidates.length <= 1) return candidates[0];
+
+  for (const name of candidates) {
+    try {
+      await fs.promises.access(path.join(dsnDir, name, "pstxnet.dat"));
+      return name;
+    } catch {
+      // Not this one.
+    }
+  }
+  return candidates[0];
 };
 
 /**
@@ -164,7 +193,21 @@ export const exportCadenceNetlist = async (
   const resolvedDsnPath = resolvePath(dsnPath);
   const dsnDir = path.dirname(resolvedDsnPath);
   const dsnFile = path.basename(dsnPath);
-  const { outputDir, dirName: outputDirName } = await resolveExportDir(resolvedDsnPath);
+
+  // Creating the directory can fail on its own (a read-only share, an ACL, a
+  // name already taken by something that is not a directory). This function
+  // promises an ErrorResult rather than a rejection: a rejection escapes as a
+  // raw MCP error and aborts the CLI's per-design loop entirely.
+  let outputDir: string;
+  let outputDirName: string;
+  try {
+    ({ outputDir, dirName: outputDirName } = await resolveExportDir(resolvedDsnPath));
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      error: `Could not create the netlist output directory beside ${dsnFile}: ${message}. Manual export: Open Cadence, then: Tools → Create Netlist → PCB Editor format.`,
+    };
+  }
 
   return serializePstswp(async () => {
     // Temporarily relocate .DSNlck lock file if present (stale locks block pstswp)
@@ -178,19 +221,29 @@ export const exportCadenceNetlist = async (
         timeout: 120000,
       });
 
-      // List generated files
+      // pstswp can exit cleanly having written nothing where we expect it, and
+      // reporting success with an empty directory sends the caller to look for
+      // files that are not there. The netlist itself is the evidence.
       let generatedFiles: string[] | undefined;
       try {
-        const files = await fs.promises.readdir(outputDir);
-        generatedFiles = files.sort();
+        generatedFiles = (await fs.promises.readdir(outputDir)).sort();
       } catch {
         // Output directory may not exist if export failed silently
+      }
+
+      const log = (stdout + stderr).trim() || undefined;
+      if (!generatedFiles?.some((f) => f.toLowerCase() === "pstxnet.dat")) {
+        return {
+          error:
+            `Cadence pstswp reported success but wrote no netlist to ${outputDir}. ` +
+            `Check the log for the directory it actually used.${log ? ` Log: ${log}` : ""}`,
+        };
       }
 
       return {
         success: true,
         outputDir,
-        log: (stdout + stderr).trim() || undefined,
+        log,
         cadenceVersion: cadence.version,
         generatedFiles,
       };

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -4,6 +4,6 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "include": ["src/**/*", "scripts/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes #29.

## Summary

`pstswp` names its output the same way for every design (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`), and the export always wrote to a single `allegro/` directory beside the `.DSN`. Two designs in one folder therefore left only the second design's netlist behind. The reporter's workaround was to give each `.DSN` a folder of its own.

Each design now exports to **`<design>_netlist/`** beside the `.DSN`.

The one exception is a folder holding a single design that already has an `Allegro/` or `allegro/` directory. That is an established project layout, often pointed at by a PCB editor or a build script, and it cannot collide with anything, so exports keep going there. Every existing single-design project is therefore untouched.

## The half that makes it work

Writing to a new directory is only useful if the design can find its netlist again. Discovery matches `.dat` sets to designs by subtree, scoring a set +1000 when the design's name appears as a component of the relative path. That match was exact, so `BOARD_A_netlist` did not count as naming `BOARD_A`; it now recognises `<design>_netlist` alongside a bare `<design>`.

Without that half, a folder mid-migration — one design re-exported, the stale shared `allegro/` still present — hands a design the stale export instead of its own. Both new discovery tests fail without it.

## Verification

- Two designs sharing a folder get `BOARD_A_netlist/` and `BOARD_B_netlist/`, and discovery attributes each to its own design even when one export sits a level deeper, where proximity alone pairs both wrongly.
- A single-design folder with `Allegro/` keeps using `Allegro/`.
- A folder with a legacy `allegro/` **and** two designs stops using it, since that directory is exactly what was overwriting the files.
- Design counting is case-insensitive (`.DSN` and `.dsn`).
- Directory naming preserves the design's own spelling, including spaces: `reServer J401 v1.1` → `reServer J401 v1.1_netlist`.

Both discovery tests were confirmed to fail against the unmodified matcher and pass after.

## Note on scope

The export itself is Windows-only and needs a Cadence SPB install, so the `pstswp` invocation is not exercised in CI on any platform. What is tested is everything around it that decides *where* output goes and *how it is found again*, which is where the bug lived.

## Test plan

- [x] `npm run type-check`, `npm run lint`
- [x] `npm test` — 660 passed (otel e2e needs to bind a local port; passes outside the sandbox)
- [x] 8 tests for the directory rule, 2 for discovery attribution
- [x] Both discovery tests verified to fail without the matcher change

## Changelog

Fixed: `export_cadence_netlist` now writes to `<design>_netlist/` beside the schematic, so several Cadence designs in one folder no longer overwrite each other's exported netlist. A folder holding a single design that already has an `allegro/` directory keeps using it.
