### PR TITLE
ci: let the release workflow be started by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  # A tag push is a webhook delivery like any other, and when Actions throttles
+  # webhooks to recover from an incident those deliveries are dropped. The tag
+  # then exists with no release built from it, and nothing in this repo could
+  # start the run by hand, so the only way back was deleting and re-pushing a
+  # public tag. Dispatch this against the tag (not a branch) to run it manually.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -15,6 +21,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # Every version below is derived by stripping `refs/tags/v` off GITHUB_REF.
+      # Dispatched against a branch that strip is a no-op, so the version would
+      # silently become the ref itself; fail here instead, before anything is
+      # built, signed, released or published.
+      - name: Validate the ref is a version tag
+        run: |
+          case "$GITHUB_REF" in
+            refs/tags/v*)
+              echo "Releasing from $GITHUB_REF"
+              ;;
+            *)
+              echo "::error::Release must run on a v* tag, got $GITHUB_REF. Re-run this workflow with the tag as the ref."
+              exit 1
+              ;;
+          esac
 
       - name: Validate CHANGELOG has release notes
         run: |


### PR DESCRIPTION
## Summary

`release.yml` triggered only on `push: tags: v*`, and no workflow in this repo declared `workflow_dispatch`.

A tag push is a webhook delivery. When Actions throttles webhooks to recover from an incident (as it is doing right now, per [githubstatus.com](https://www.githubstatus.com): *"many push and pull request events are not yet triggering new workflow runs"*), that delivery is dropped. The tag then exists with no release built from it, and there was no way to start the run by hand. The only recovery was deleting and re-pushing a public tag.

Dispatching against the **tag** leaves `GITHUB_REF` as `refs/tags/vX.Y.Z`, so all six `${GITHUB_REF#refs/tags/v}` derivations behave exactly as they do on a tag push.

Dispatched against a **branch**, that strip is a no-op and the version would silently become the ref itself (`refs/heads/main`), so a guard refuses anything but a `v*` tag before the run builds, signs, releases or publishes anything.

## Changelog

None — CI only, no user-visible change.

## Test plan

- [x] `push: tags: v*` trigger left intact
- [x] Guard verified against three refs: `refs/tags/v1.5.0` proceeds with `version=1.5.0`; `refs/heads/main` and `refs/tags/nightly` are refused
- [x] File has no tabs; all six version derivations unchanged
- [ ] Confirmed end to end by dispatching against the `v1.5.0` tag if the tag push itself is dropped