### PR TITLE
ci: move actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
+          # setup-node v5+ turns caching on by itself when `package.json` has a
+          # `packageManager` field, and that cache needs a lockfile. This repo
+          # commits no lockfile on purpose (vitest/rollup pull cross-platform
+          # optional deps), so the cache would fail to find one. Keep it off
+          # explicitly rather than relying on `packageManager` staying absent.
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # The review reads surrounding parser code and docs/, not just the diff.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Every version below is derived by stripping `refs/tags/v` off GITHUB_REF.
       # Dispatched against a branch that strip is a no-op, so the version would
@@ -157,7 +157,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ steps.version.outputs.version }}
           body: |
@@ -193,14 +193,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           # NOTE: Do NOT add registry-url here - it creates a .npmrc with
           # auth token placeholder that interferes with OIDC authentication
+
+          # setup-node v5+ caches on its own when `package.json` carries a
+          # `packageManager` field, and that cache requires a lockfile this
+          # repo deliberately does not commit. Keep it off explicitly.
+          package-manager-cache: false
 
       - name: Update npm to latest (OIDC requires npm 11.5.1+)
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary

Every workflow run currently logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24

The forcing is temporary. These bump the three named actions to majors that target `node24` natively.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v7` |
| `actions/setup-node` | `v4` | `v7` |
| `softprops/action-gh-release` | `v2` | `v3` |

`oven-sh/setup-bun@v2` and `anthropics/claude-code-action@v1` are deliberately left alone: the first already targets `node24` (v2.2.0), the second is a composite action with no Node runtime. That is why the deprecation warning named neither.

## Why the caching flag

`setup-node` v5 introduced automatic caching whenever `package.json` carries a `packageManager` field, and that cache requires a lockfile. This repo commits none on purpose, since vitest/rollup pull cross-platform optional deps (see `CLAUDE.md`). Today `packageManager` is absent so the cache stays off by accident; `package-manager-cache: false` makes it off on purpose, so adding that field later cannot break CI with a confusing "Dependencies lock file is not found".

## Breaking changes checked, none apply

- **checkout v7** blocks fork-PR checkout for `pull_request_target` and `workflow_run`. No workflow here uses either trigger.
- **checkout v6** moves credentials to a separate file. Nothing here reads them.
- **setup-node v6** limits automatic caching to npm. Moot, caching is off.
- **setup-node v7** removes a dummy `NODE_AUTH_TOKEN` export, which only applied when `registry-url` is set. This repo must not set it (it breaks OIDC), so it never applied.
- **action-gh-release v3** is only the Node 24 runtime move; inputs are unchanged.

Every input still in use (`submodules`, `fetch-depth`, `node-version`, `name`, `body`, `files`, `draft`, `prerelease`) was confirmed present in the target versions' `action.yml`.

## Test plan

- [ ] `build` and `claude-review` pass on this PR, which exercises `checkout@v7` and `setup-node@v7` directly
- [ ] All four workflows parse and resolve to the intended actions (verified locally)
- [ ] `release.yml` triggers still `push`(tags) + `workflow_dispatch`, and the version-derivation steps are untouched

Note `release.yml` cannot be fully exercised without cutting a release. Its risk is contained: `action-gh-release@v3` changes runtime only, and `#112` left the workflow manually dispatchable against a tag if a run ever needs restarting.