### PR TITLE
fix(altium): trace nets through signal harnesses by bundle, not by name

### DIFF
--- a/docs/altium-format.md
+++ b/docs/altium-format.md
@@ -156,28 +156,47 @@ the whole bundle between objects, and behaves like a bus for connectivity purpos
 ### Entries inherit their position from the connector
 
 An entry carries no coordinate of its own, only a `DistanceFromTop`, so nothing lands on it
-until it is given one. `positionHarnessEntries()` places each entry at the connector's
-`Location.X`, and at `Location.Y - DistanceFromTop * 10`.
+until it is given one. `readHarnessConnectors()` places each entry at
+
+```
+x = Location.X + (entry on the right edge ? XSize : 0)
+y = Location.Y - (DistanceFromTop + DistanceFromTop_Frac1 / 1e6) * 10
+```
 
 That pitch of 10 grid units comes from `HELIOS-R`'s main sheet: its connector sits at
 `Location.Y=670` with entries at `DistanceFromTop` 1, 2, 9, 10 and 13, and the five wires that
-land on it end at y = 660, 650, 580, 570 and 540 — exactly `Location.Y - n * 10`.
+land on it end at y = 660, 650, 580, 570 and 540 — exactly `Location.Y - n * 10`. The step
+count is fixed-point: `channel.SchDoc` writes `DistanceFromTop=1 | DistanceFromTop_Frac1=500000`
+for an entry whose wire ends 15 units below the top, so 500000 is half a step. An entry on the
+top edge writes no whole part at all.
+
+Which edge the entries sit on is written twice, from opposite ends, and never both at once:
+
+| Written | Entries | Bundle leaves from |
+|---|---|---|
+| `HarnessConnectorSide=1` on the connector | left edge | right edge |
+| `Side=1` on each entry | right edge | left edge |
+
+The two forms split the fixture corpus almost evenly — 53 of 115 connectors declare
+`HarnessConnectorSide`, the other 62 mark their entries instead — so reading only one of them
+leaves half the harness entries of a design unplaced. Together the rules put 364 of the 365
+entries in `qfsae/pcb` and `pulp-bio/HELIOS-R` exactly on the end of a wire.
 
 Ownership is taken from stream order, an entry belonging to the connector that precedes it,
 for two reasons. `OwnerIndex` is often simply absent: across the two harness fixtures 330 of
 365 entries carry it and 35 do not, and all five entries of the `HELIOS-R` main sheet are in
 the second group. And where it is present it numbers the `Additional` stream's own record
-list, which stops meaning anything once those records are appended to `FileHeader`'s. So
-positioning runs on the `Additional` records alone, before the two lists are joined.
+list, so it is rebased by the number of `FileHeader` records when the two lists are joined.
+Positioning runs on the `Additional` records alone, before that join.
 
-Only `HarnessConnectorSide=1` is positioned, that being the arrangement confirmed against a
-real design; 53 of the 115 connectors in the fixture corpus declare it and the remaining 62
-omit the field. An entry on an unconfirmed side is left without coordinates, so it takes no
-part in connectivity rather than inventing a connection that may not exist.
+An entry whose connector has no coordinates at all is left unpositioned, and the net extractor
+skips it: placed at the origin instead, every such entry in a document would appear to touch
+every other.
 
-Once positioned, an entry is a connectable device like a wire or a pin, and also a naming
-device: a net reaching an entry takes that entry's `Name`, ranked alongside power ports, net
-labels and ports in `assignNetName()`.
+The bundle leaves the connector from the opposite edge, at
+`Location.Y - PrimaryConnectionPosition` — note the plain units here, not the entries' grid
+steps. That point meets either a signal harness line or a harness-typed port; all 115
+connectors in the corpus attach at one or the other.
 
 ### Harness type definitions live outside the `.SchDoc`
 
@@ -209,8 +228,42 @@ entry's type to its members and classifies every member the same way the entry i
 classified, so a shared harness keeps its members shared instead of handing each channel a
 private copy that connects to nothing.
 
-The `PORT` side of the same boundary is read as a plain named port; its `HarnessType` is
-recorded in the file but not yet consulted.
+A harness-typed sheet entry is also placed the way a harness entry is, inheriting position
+from the sheet symbol (`RECORD=15`) that precedes it in the stream, taking the left edge
+unless `Side=1` puts it on the right, and sitting `DistanceFromTop` grid steps below the
+symbol's top. All 44 of them in the corpus land exactly on a harness line vertex.
+
+### Which nets a harness carries, and what they are called
+
+Altium is explicit that these objects resolve connectivity and do not name it: the harness
+type and its entries are "names of the containers that carry the nets, not the names of the
+nets themselves". Two consequences follow, and both matter.
+
+A member name is unique only inside its own bundle. `qfsae/pcb` draws one `3WIRE_PSG_SENSOR`
+harness per sensor, each with an entry called `SIGNAL`; naming nets after entries would put
+every sensor's signal on one net. So a bundle is identified by what its connector's outgoing
+connection reaches:
+
+- a **harness-typed port** — the bundle takes that port's name, which is global, so the sheet
+  on the other side arrives at the same identity;
+- a **signal harness line** — everything meeting that line is one bundle, and connectors,
+  ports and sheet entries on it share an identity;
+- neither — the bundle is local to its sheet and identified by the sheet.
+
+Entries of one bundle sharing a name are then one net, whatever the wires reaching them are
+labelled, which is the whole point of the mechanism. Where the two ends are on different
+sheets the nets are matched by the same identity after both sheets are parsed
+(`mergeHarnessSignalNets()`), and the surviving name is the one the designer wrote, preferring
+whichever is already on more pins.
+
+One bundle is rarely called the same thing at both ends — a bulkhead sheet takes in
+`TRANSPONDER_POWER_UL` and passes on `TRANSPONDER_POWER`. The parent sheet is where they are
+shown to be one bundle, by a harness line drawn between the two sheet entries that name them;
+`resolveBundleNames()` folds such names together across the project.
+
+The exception to harness objects not naming nets is a **net label placed on the signal harness
+line**. That names the harness, and every net it carries is then called
+`<harness label>.<entry name>` in place of the wire's own label.
 
 ### Harness types nest
 
@@ -244,11 +297,22 @@ stops at the repeat rather than recursing forever.
 
 ### Scope
 
-Within a sheet, positioned harness entries join nets by geometry on every design.
+Within a sheet, positioned harness entries join nets by geometry, and entries carrying one
+signal of one bundle join whatever the wires are labelled.
 
-Across a sheet boundary, member resolution runs only where a repeated sheet is expanded into
-channels. A single-instance sheet reached through a harness-typed sheet entry is parsed and
-merged like any other sheet, without its bundle being expanded into member signals.
+Across a sheet boundary, a bundle is followed by matching signal identities between documents,
+including through a harness line drawn on a parent sheet between two sheet entries. Bundle
+names are matched project-wide, as ports already are elsewhere in this parser, so two sheets
+that reuse a harness port name are read as sharing that bundle.
+
+Repeated sheets are the exception: channel expansion renames a repeated sheet's nets per
+channel, so signals collected there would no longer name the nets carrying them. Those sheets
+reach the rest of the design through `classifySheetEntries()`, which carries the bundle's
+members across instead.
+
+The nesting relationship is read from the entry records, but a nested bundle is not yet given
+its own identity: its members resolve as names, and its connectivity depends on the enclosing
+bundle.
 
 ### Designs used for testing
 

--- a/src/parsers/altium/connectivity.ts
+++ b/src/parsers/altium/connectivity.ts
@@ -235,6 +235,17 @@ export const isConnected = (deviceA: AltiumRecord, deviceB: AltiumRecord): boole
     }
   }
 
+  // Harness entries carrying the same signal of the same bundle are the two ends
+  // of one net, however the wires reaching them are labelled.
+  if (
+    deviceA.RECORD === RECORD_TYPES.HARNESS_ENTRY &&
+    deviceB.RECORD === RECORD_TYPES.HARNESS_ENTRY &&
+    typeof deviceA.harnessSignal === "string" &&
+    deviceA.harnessSignal === deviceB.harnessSignal
+  ) {
+    return true;
+  }
+
   // Special case: globally-named devices (power ports, net labels, ports)
   // with the same name are connected globally.
   // Note: SHEET_ENTRY is NOT globally-named; it connects via wires on the parent sheet.
@@ -301,6 +312,20 @@ export const findAllConnectedComponents = (devices: AltiumRecord[]): AltiumRecor
     }
   }
 
+  // Collect harness entries by the signal they carry. Two entries of one bundle
+  // named alike are the same net wherever they are drawn, so a wire label that
+  // differs from one end of the harness to the other does not split it.
+  const harnessSignals = new Map<string, number[]>();
+  for (const device of devices) {
+    if (device.RECORD !== RECORD_TYPES.HARNESS_ENTRY) continue;
+    const signal = device.harnessSignal;
+    if (typeof signal !== "string" || !signal) continue;
+    if (!harnessSignals.has(signal)) {
+      harnessSignals.set(signal, []);
+    }
+    harnessSignals.get(signal)!.push(device.index);
+  }
+
   // Union devices sharing exact coordinates
   for (const deviceIndices of spatialIndex.getPointToDevices().values()) {
     if (deviceIndices.length > 1) {
@@ -324,6 +349,16 @@ export const findAllConnectedComponents = (devices: AltiumRecord[]): AltiumRecor
 
   // Union globally-named devices (power ports/net labels with same text)
   for (const indices of globalLabels.values()) {
+    if (indices.length > 1) {
+      const first = indices[0];
+      for (let i = 1; i < indices.length; i++) {
+        uf.union(first, indices[i]);
+      }
+    }
+  }
+
+  // Union the harness entries that carry one signal
+  for (const indices of harnessSignals.values()) {
     if (indices.length > 1) {
       const first = indices[0];
       for (let i = 1; i < indices.length; i++) {

--- a/src/parsers/altium/harness.test.ts
+++ b/src/parsers/altium/harness.test.ts
@@ -227,16 +227,16 @@ describe("readHarnessConnectors", () => {
     expect(records[3]["Location.Y"]).toBe("780");
   });
 
-  it("leaves an entry unpositioned when its connector has no coordinates", () => {
-    // Better to contribute no connectivity than to place it at the origin,
-    // where every other unplaceable entry would appear to touch it.
+  it("passes over a connector that has no coordinates", () => {
+    // Read as written it would sit at the origin, where its entries would all
+    // appear to touch each other and its outgoing connection could be taken for
+    // any harness line reaching that point.
     const records: HarnessRecord[] = [
       { RECORD: "215", XSize: "50" },
       { RECORD: "216", Name: "X", DistanceFromTop: "1" },
     ];
 
-    readHarnessConnectors(records);
-
+    expect(readHarnessConnectors(records)).toEqual([]);
     expect(records[1]["Location.Y"]).toBeUndefined();
   });
 
@@ -373,6 +373,27 @@ describe("assignHarnessSignals", () => {
     });
 
     expect(links).toEqual([["TRANSPONDER_POWER_UL", "TRANSPONDER_POWER"]]);
+  });
+
+  it("ignores a harness sheet entry on an edge whose geometry is unknown", () => {
+    // Side counts round the symbol: 0 left, 1 right, 2 top, 3 bottom. No
+    // harness-typed entry on a horizontal edge has been seen, so one is left out
+    // rather than placed where a vertical entry would go.
+    // ON_TOP would land on the same line vertex as ON_LEFT if it were placed as
+    // a left-edge entry, so its absence from the link is the whole assertion.
+    const links = assignHarnessSignals([], {
+      records: [
+        { RECORD: "15", ...at(520, 630), XSize: "370" },
+        { RECORD: "16", Name: "ON_TOP", Side: "2", DistanceFromTop: "2", HarnessType: "P" },
+        { RECORD: "16", Name: "ON_LEFT", DistanceFromTop: "2", HarnessType: "P" },
+        { RECORD: "15", ...at(450, 720), XSize: "80" },
+        { RECORD: "16", Name: "ON_RIGHT", Side: "1", DistanceFromTop: "2", HarnessType: "P" },
+      ],
+      buses: [harnessLine(520, 610, 530, 700)],
+      sheetKey: "TOP.SchDoc",
+    });
+
+    expect(links).toEqual([["ON_LEFT", "ON_RIGHT"]]);
   });
 
   it("leaves a connector that reaches no harness line or port alone", () => {

--- a/src/parsers/altium/harness.test.ts
+++ b/src/parsers/altium/harness.test.ts
@@ -3,8 +3,11 @@ import {
   parseHarnessDefinitions,
   resolveHarnessMembers,
   collectNestedHarnessTypes,
-  positionHarnessEntries,
+  readHarnessConnectors,
+  assignHarnessSignals,
+  harnessSignalKey,
 } from "./harness.js";
+import type { HarnessRecord } from "./harness.js";
 
 /**
  * The sample definitions are the verbatim contents of
@@ -134,11 +137,11 @@ describe("collectNestedHarnessTypes", () => {
   });
 });
 
-describe("positionHarnessEntries", () => {
+describe("readHarnessConnectors", () => {
   it("places entries on the connector's left edge at the verified pitch", () => {
     // Geometry taken from pulp-bio/HELIOS-R main.SchDoc, where the five wires
     // landing on this connector end at y = 660, 650, 580, 570 and 540.
-    const records = [
+    const records: HarnessRecord[] = [
       {
         RECORD: "215",
         "Location.X": "410",
@@ -153,7 +156,10 @@ describe("positionHarnessEntries", () => {
       { RECORD: "216", Name: "VDD5_A", DistanceFromTop: "13" },
     ];
 
-    expect(positionHarnessEntries(records)).toBe(5);
+    const connectors = readHarnessConnectors(records);
+
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].entries).toHaveLength(5);
     expect(records.map((r) => r["Location.Y"]).slice(1)).toEqual([
       "660",
       "650",
@@ -164,17 +170,56 @@ describe("positionHarnessEntries", () => {
     expect(records[1]["Location.X"]).toBe("410");
   });
 
+  it("places entries on the right edge when the entry says so", () => {
+    // qfsae/pcb DASH_BULKHEAD.SchDoc: the connector writes no
+    // HarnessConnectorSide and each entry carries Side=1, which is the same
+    // arrangement mirrored. Its four wires end at x = 330.
+    const records: HarnessRecord[] = [
+      { RECORD: "215", "Location.X": "230", "Location.Y": "250", XSize: "100" },
+      { RECORD: "216", Name: "DRIVER_SWITCH_1", Side: "1", DistanceFromTop: "1" },
+      { RECORD: "216", Name: "DRIVER_SWITCH_2", Side: "1", DistanceFromTop: "2" },
+    ];
+
+    readHarnessConnectors(records);
+
+    expect(records[1]["Location.X"]).toBe("330");
+    expect(records[1]["Location.Y"]).toBe("240");
+    expect(records[2]["Location.Y"]).toBe("230");
+  });
+
+  it("reads a fractional distance from the top", () => {
+    // HELIOS-R channel.SchDoc puts an entry half a step down, and its wire ends
+    // at y = 450 rather than 455.
+    const records: HarnessRecord[] = [
+      { RECORD: "215", "Location.X": "815", "Location.Y": "465", XSize: "70" },
+      {
+        RECORD: "216",
+        Name: "V_LASER",
+        Side: "1",
+        DistanceFromTop: "1",
+        DistanceFromTop_Frac1: "500000",
+      },
+      // An entry on the top edge writes no whole part at all.
+      { RECORD: "216", Name: "PGND", Side: "1", DistanceFromTop_Frac1: "500000" },
+    ];
+
+    readHarnessConnectors(records);
+
+    expect(records[1]["Location.Y"]).toBe("450");
+    expect(records[2]["Location.Y"]).toBe("460");
+  });
+
   it("assigns entries to the most recent connector, not by OwnerIndex", () => {
     // OwnerIndex is present on some entries and absent on others in real files,
     // so stream order is what links an entry to its connector.
-    const records = [
+    const records: HarnessRecord[] = [
       { RECORD: "215", "Location.X": "100", "Location.Y": "500", HarnessConnectorSide: "1" },
       { RECORD: "216", Name: "A", DistanceFromTop: "1" },
       { RECORD: "215", "Location.X": "300", "Location.Y": "800", HarnessConnectorSide: "1" },
       { RECORD: "216", Name: "B", DistanceFromTop: "2" },
     ];
 
-    positionHarnessEntries(records);
+    readHarnessConnectors(records);
 
     expect(records[1]["Location.X"]).toBe("100");
     expect(records[1]["Location.Y"]).toBe("490");
@@ -182,22 +227,167 @@ describe("positionHarnessEntries", () => {
     expect(records[3]["Location.Y"]).toBe("780");
   });
 
-  it("leaves entries on an unverified connector side unpositioned", () => {
-    // Better to contribute no connectivity than to invent a connection whose
-    // geometry has not been confirmed against a real design.
-    const records = [
-      { RECORD: "215", "Location.X": "10", "Location.Y": "20", HarnessConnectorSide: "2" },
+  it("leaves an entry unpositioned when its connector has no coordinates", () => {
+    // Better to contribute no connectivity than to place it at the origin,
+    // where every other unplaceable entry would appear to touch it.
+    const records: HarnessRecord[] = [
+      { RECORD: "215", XSize: "50" },
       { RECORD: "216", Name: "X", DistanceFromTop: "1" },
     ];
 
-    expect(positionHarnessEntries(records)).toBe(0);
+    readHarnessConnectors(records);
+
     expect(records[1]["Location.Y"]).toBeUndefined();
   });
 
   it("ignores an entry with no preceding connector", () => {
-    const records = [{ RECORD: "216", Name: "orphan", DistanceFromTop: "1" }];
+    const records: HarnessRecord[] = [{ RECORD: "216", Name: "orphan", DistanceFromTop: "1" }];
 
-    expect(positionHarnessEntries(records)).toBe(0);
+    expect(readHarnessConnectors(records)).toEqual([]);
+  });
+
+  it("puts the bundle's outgoing connection on the edge opposite the entries", () => {
+    // HELIOS-R channel.SchDoc: this connector's harness line runs from (760,400).
+    const records: HarnessRecord[] = [
+      {
+        RECORD: "215",
+        "Location.X": "690",
+        "Location.Y": "430",
+        XSize: "70",
+        PrimaryConnectionPosition: "30",
+        HarnessConnectorSide: "1",
+      },
+    ];
+
+    expect(readHarnessConnectors(records)[0].primary).toEqual([760 * 10000, 400 * 10000]);
+  });
+});
+
+describe("assignHarnessSignals", () => {
+  const at = (x: number, y: number) => ({ "Location.X": String(x), "Location.Y": String(y) });
+
+  /** Two connectors of one type, wired to each other by a harness line. */
+  const bundlePair = (): HarnessRecord[] => [
+    // Bundles: entries on the left, line leaves from the right at (760,400).
+    {
+      RECORD: "215",
+      ...at(690, 430),
+      XSize: "70",
+      PrimaryConnectionPosition: "30",
+      HarnessConnectorSide: "1",
+    },
+    { RECORD: "216", Name: "OP_OUT", DistanceFromTop: "1" },
+    // Unbundles: line arrives at the left (815,400), entries on the right.
+    { RECORD: "215", ...at(815, 465), XSize: "70", PrimaryConnectionPosition: "65" },
+    { RECORD: "216", Name: "OP_OUT", Side: "1", DistanceFromTop: "1" },
+  ];
+
+  const harnessLine = (x1: number, y1: number, x2: number, y2: number): HarnessRecord => ({
+    RECORD: "218",
+    LocationCount: "2",
+    X1: String(x1),
+    Y1: String(y1),
+    X2: String(x2),
+    Y2: String(y2),
+  });
+
+  it("gives both ends of a harness line the same signal", () => {
+    const records = bundlePair();
+    const connectors = readHarnessConnectors(records);
+
+    assignHarnessSignals(connectors, {
+      records: [],
+      buses: [harnessLine(760, 400, 815, 400)],
+      sheetKey: "channel.SchDoc",
+    });
+
+    expect(records[1].harnessSignal).toBeDefined();
+    expect(records[3].harnessSignal).toBe(records[1].harnessSignal);
+  });
+
+  it("keeps two harnesses of the same type apart", () => {
+    // qfsae/pcb draws one 3WIRE_PSG_SENSOR harness per sensor, each entry named
+    // SIGNAL. Only the port they leave through tells them apart.
+    const records: HarnessRecord[] = [
+      { RECORD: "215", ...at(240, 180), XSize: "60", PrimaryConnectionPosition: "20" },
+      { RECORD: "216", Name: "SIGNAL", Side: "1", DistanceFromTop: "2" },
+      { RECORD: "215", ...at(240, 120), XSize: "60", PrimaryConnectionPosition: "20" },
+      { RECORD: "216", Name: "SIGNAL", Side: "1", DistanceFromTop: "2" },
+    ];
+    const connectors = readHarnessConnectors(records);
+
+    assignHarnessSignals(connectors, {
+      records: [
+        { RECORD: "18", Name: "FL_DAMPER_POT", ...at(80, 160), Width: "160", HarnessType: "S" },
+        { RECORD: "18", Name: "FR_DAMPER_POT", ...at(80, 100), Width: "160", HarnessType: "S" },
+      ],
+      buses: [],
+      sheetKey: "DASH_BULKHEAD.SchDoc",
+    });
+
+    expect(records[1].harnessSignal).toBe(harnessSignalKey("FL_DAMPER_POT", "SIGNAL"));
+    expect(records[3].harnessSignal).toBe(harnessSignalKey("FR_DAMPER_POT", "SIGNAL"));
+  });
+
+  it("names the nets of a labelled harness after the label and the entry", () => {
+    // Altium: "the net is named based on the Net Label placed on the Signal
+    // Harness line + the Harness Entry".
+    const records = bundlePair();
+    const connectors = readHarnessConnectors(records);
+
+    assignHarnessSignals(connectors, {
+      records: [{ RECORD: "25", Text: "HARD", ...at(790, 400) }],
+      buses: [harnessLine(760, 400, 815, 400)],
+      sheetKey: "channel.SchDoc",
+    });
+
+    expect(records[1].harnessNetName).toBe("HARD.OP_OUT");
+    expect(records[3].harnessNetName).toBe("HARD.OP_OUT");
+  });
+
+  it("leaves an unlabelled harness with no net name of its own", () => {
+    const records = bundlePair();
+    const connectors = readHarnessConnectors(records);
+
+    assignHarnessSignals(connectors, {
+      records: [],
+      buses: [harnessLine(760, 400, 815, 400)],
+      sheetKey: "channel.SchDoc",
+    });
+
+    expect(records[1].harnessNetName).toBeUndefined();
+  });
+
+  it("reports the sheet entries a harness line joins as one bundle", () => {
+    // qfsae/pcb TOP.SchDoc joins a bulkhead's bundle to the sheet that feeds it,
+    // where the same bundle goes by a different port name.
+    const links = assignHarnessSignals([], {
+      records: [
+        { RECORD: "15", ...at(520, 630), XSize: "370" },
+        { RECORD: "16", Name: "TRANSPONDER_POWER_UL", DistanceFromTop: "2", HarnessType: "P" },
+        { RECORD: "15", ...at(310, 730), XSize: "220" },
+        { RECORD: "16", Name: "TRANSPONDER_POWER", Side: "1", DistanceFromTop: "3", HarnessType: "P" },
+      ],
+      buses: [harnessLine(520, 610, 530, 700)],
+      sheetKey: "TOP.SchDoc",
+    });
+
+    expect(links).toEqual([["TRANSPONDER_POWER_UL", "TRANSPONDER_POWER"]]);
+  });
+
+  it("leaves a connector that reaches no harness line or port alone", () => {
+    const records: HarnessRecord[] = [
+      { RECORD: "215", ...at(10, 20), XSize: "50", PrimaryConnectionPosition: "5" },
+      { RECORD: "216", Name: "X", Side: "1", DistanceFromTop: "1" },
+    ];
+
+    assignHarnessSignals(readHarnessConnectors(records), {
+      records: [],
+      buses: [],
+      sheetKey: "lonely.SchDoc",
+    });
+
+    expect(records[1].harnessSignal).toBeUndefined();
   });
 });
 

--- a/src/parsers/altium/harness.ts
+++ b/src/parsers/altium/harness.ts
@@ -131,55 +131,461 @@ export const collectNestedHarnessTypes = (
  */
 const HARNESS_ENTRY_PITCH = 10;
 
-/** Connector side whose geometry is verified against a real design. */
-const HARNESS_SIDE_ENTRIES_LEFT = "1";
+/**
+ * Denominator of `DistanceFromTop_Frac1`.
+ *
+ * An entry may sit half a step down: HELIOS-R's `channel.SchDoc` writes
+ * `DistanceFromTop=1 | DistanceFromTop_Frac1=500000` for an entry whose wire
+ * ends 15 grid units below the connector's top, so 500000 is half a step.
+ */
+const DISTANCE_FRACTION_SCALE = 1_000_000;
 
-interface PositionedRecord {
-  RECORD?: string;
-  Name?: string;
-  DistanceFromTop?: string;
-  "Location.X"?: string;
-  "Location.Y"?: string;
-  XSize?: string;
-  HarnessConnectorSide?: string;
-}
+/** Units per whole coordinate, matching the `_Frac` fields on Location records. */
+const COORDINATE_SCALE = 10000;
 
 /**
- * Give every harness entry the coordinate at which wires meet it.
+ * Value of `Side` on an entry, and of `HarnessConnectorSide` on a connector.
  *
- * Entries carry only a `DistanceFromTop` and inherit their position from the
- * harness connector that owns them. `OwnerIndex` is present on some entries and
- * absent on others, so ownership is taken from stream order: entries follow
- * their connector.
- *
- * Only `HarnessConnectorSide=1` is positioned, because that is the arrangement
- * confirmed against a real design. Entries on an unverified side are left
- * without coordinates, so they simply do not participate in connectivity rather
- * than inventing a connection that may not exist.
+ * The two fields describe the same arrangement from opposite ends and are never
+ * both written: an entry marked `Side=1` sits on the connector's right edge,
+ * while a connector marked `HarnessConnectorSide=1` puts its entries on the left
+ * edge and the bundle's outgoing connection on the right.
  */
-export const positionHarnessEntries = (records: PositionedRecord[]): number => {
-  let connector: PositionedRecord | undefined;
-  let positioned = 0;
+const SIDE_FLAG = "1";
+
+export interface HarnessRecord {
+  RECORD?: string;
+  Name?: string;
+  Text?: string;
+  HarnessType?: string;
+  DistanceFromTop?: string;
+  DistanceFromTop_Frac1?: string;
+  PrimaryConnectionPosition?: string;
+  "Location.X"?: string;
+  "Location.Y"?: string;
+  "Location.X_Frac"?: string;
+  "Location.Y_Frac"?: string;
+  Width?: string;
+  XSize?: string;
+  Side?: string;
+  HarnessConnectorSide?: string;
+  LocationCount?: string;
+  /** Which signal of which bundle this entry carries; see assignHarnessSignals. */
+  harnessSignal?: string;
+  /** The name Altium gives this entry's net when the harness line itself is labelled. */
+  harnessNetName?: string;
+  [key: string]: unknown;
+}
+
+/** A point in the same scaled units the net extractor works in. */
+type Point = readonly [number, number];
+
+/** One harness connector together with the entries drawn on its edge. */
+export interface HarnessConnector {
+  /** The RECORD=215 connector itself. */
+  connector: HarnessRecord;
+  /** Its RECORD=216 entries, in stream order. */
+  entries: HarnessRecord[];
+  /** Where the bundle leaves the connector, meeting a harness or a port. */
+  primary: Point;
+}
+
+const toNumber = (value: unknown): number => {
+  if (value === undefined || value === null || value === "") return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const scaled = (base: unknown, frac: unknown): number =>
+  Math.round(toNumber(base) * COORDINATE_SCALE + toNumber(frac));
+
+const pointKey = (point: Point): string => `${point[0]},${point[1]}`;
+
+/** Write a scaled coordinate back onto a record as Altium's base/fraction pair. */
+const setScaledLocation = (record: HarnessRecord, x: number, y: number): void => {
+  const baseX = Math.trunc(x / COORDINATE_SCALE);
+  const baseY = Math.trunc(y / COORDINATE_SCALE);
+  record["Location.X"] = String(baseX);
+  record["Location.Y"] = String(baseY);
+  record["Location.X_Frac"] = String(x - baseX * COORDINATE_SCALE);
+  record["Location.Y_Frac"] = String(y - baseY * COORDINATE_SCALE);
+};
+
+/**
+ * How far below the connector's top edge an entry sits, in whole grid steps.
+ *
+ * The step count is a fixed-point value: `DistanceFromTop` counts whole steps and
+ * `DistanceFromTop_Frac1` the fraction of one. Both are absent for an entry on
+ * the top edge itself.
+ */
+const entryDistanceFromTop = (entry: HarnessRecord): number =>
+  toNumber(entry.DistanceFromTop) +
+  toNumber(entry.DistanceFromTop_Frac1) / DISTANCE_FRACTION_SCALE;
+
+/**
+ * Whether a connector's entries are drawn on its right edge rather than its left.
+ *
+ * The entry's own `Side` is authoritative where it is written; otherwise the
+ * connector's `HarnessConnectorSide` says it, inverted, because that field names
+ * the side the bundle leaves from. Verified on 364 of the 365 entries across
+ * pulp-bio/HELIOS-R and qfsae/pcb: each lands exactly on a wire end.
+ */
+const entriesOnRightEdge = (connector: HarnessRecord, entry: HarnessRecord): boolean =>
+  entry.Side === SIDE_FLAG || connector.HarnessConnectorSide !== SIDE_FLAG;
+
+/**
+ * Read the harness connectors of a sheet, giving every entry the coordinate at
+ * which wires meet it.
+ *
+ * Entries carry only a distance below the connector's top edge and inherit the
+ * rest of their position from the connector that owns them. `OwnerIndex` is
+ * present on some entries and absent on others, so ownership is taken from
+ * stream order: entries follow their connector.
+ *
+ * An entry whose connector has no coordinates is left unpositioned, and the net
+ * extractor skips it, rather than being placed at the origin where every other
+ * such entry would appear to touch it.
+ */
+export const readHarnessConnectors = (records: HarnessRecord[]): HarnessConnector[] => {
+  const connectors: HarnessConnector[] = [];
+  let current: HarnessConnector | undefined;
 
   for (const record of records) {
     if (record.RECORD === "215") {
-      connector = record;
+      const originX = scaled(record["Location.X"], record["Location.X_Frac"]);
+      const originY = scaled(record["Location.Y"], record["Location.Y_Frac"]);
+      const width = scaled(record.XSize, undefined);
+      // The bundle leaves from the edge opposite the entries, at the height
+      // `PrimaryConnectionPosition` gives below the connector's top.
+      const leavesRight = record.HarnessConnectorSide === SIDE_FLAG;
+      current = {
+        connector: record,
+        entries: [],
+        primary: [
+          leavesRight ? originX + width : originX,
+          originY - scaled(record.PrimaryConnectionPosition, undefined),
+        ],
+      };
+      connectors.push(current);
       continue;
     }
-    if (record.RECORD !== "216" || !connector) continue;
-    if (connector.HarnessConnectorSide !== HARNESS_SIDE_ENTRIES_LEFT) continue;
 
-    const originX = Number(connector["Location.X"]);
-    const originY = Number(connector["Location.Y"]);
-    const distance = Number(record.DistanceFromTop);
-    if (!Number.isFinite(originX) || !Number.isFinite(originY) || !Number.isFinite(distance)) {
-      continue;
-    }
+    if (record.RECORD !== "216" || !current) continue;
+    current.entries.push(record);
 
-    record["Location.X"] = String(originX);
-    record["Location.Y"] = String(originY - distance * HARNESS_ENTRY_PITCH);
-    positioned++;
+    const connector = current.connector;
+    const originX = scaled(connector["Location.X"], connector["Location.X_Frac"]);
+    const originY = scaled(connector["Location.Y"], connector["Location.Y_Frac"]);
+    if (connector["Location.X"] === undefined || connector["Location.Y"] === undefined) continue;
+
+    const width = entriesOnRightEdge(connector, record) ? scaled(connector.XSize, undefined) : 0;
+    setScaledLocation(
+      record,
+      originX + width,
+      originY - entryDistanceFromTop(record) * HARNESS_ENTRY_PITCH * COORDINATE_SCALE
+    );
   }
 
-  return positioned;
+  return connectors;
+};
+
+/**
+ * Whether a point lies on the segment between two others.
+ *
+ * Harness lines are drawn on the grid, so the test is exact rather than
+ * tolerant: a point is on the segment when it is collinear with the ends and
+ * between them.
+ */
+const pointOnSegment = (point: Point, start: Point, end: Point): boolean => {
+  const cross =
+    (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (point[0] - start[0]);
+  if (cross !== 0) return false;
+  return (
+    point[0] >= Math.min(start[0], end[0]) &&
+    point[0] <= Math.max(start[0], end[0]) &&
+    point[1] >= Math.min(start[1], end[1]) &&
+    point[1] <= Math.max(start[1], end[1])
+  );
+};
+
+/** The vertices of a polyline record, in scaled units. */
+const polylinePoints = (record: HarnessRecord): Point[] => {
+  const points: Point[] = [];
+  const count = toNumber(record.LocationCount);
+  for (let i = 1; i <= count; i++) {
+    points.push([
+      scaled(record[`X${i}`], record[`X${i}_Frac`]),
+      scaled(record[`Y${i}`], record[`Y${i}_Frac`]),
+    ]);
+  }
+  return points;
+};
+
+/** A record's own position, in scaled units. */
+const recordLocation = (record: HarnessRecord): Point => [
+  scaled(record["Location.X"], record["Location.X_Frac"]),
+  scaled(record["Location.Y"], record["Location.Y_Frac"]),
+];
+
+/**
+ * The two ends of a port, in scaled units.
+ *
+ * A port is drawn as a horizontal box `Width` wide, and whichever end faces the
+ * harness connector is the end the bundle meets, so both count.
+ */
+const portEnds = (port: HarnessRecord): Point[] => {
+  const [x, y] = recordLocation(port);
+  return [
+    [x, y],
+    [x + scaled(port.Width, undefined), y],
+  ];
+};
+
+/**
+ * Where a sheet entry meets a harness line on the parent sheet.
+ *
+ * A sheet entry is placed the way a harness entry is: it inherits its position
+ * from the sheet symbol it belongs to, sits `DistanceFromTop` grid steps below
+ * that symbol's top edge, and takes the left edge unless `Side` puts it on the
+ * right. Verified against all 44 harness-typed sheet entries in qfsae/pcb and
+ * pulp-bio/HELIOS-R, each of which lands exactly on a harness line vertex.
+ */
+const sheetEntryLocation = (symbol: HarnessRecord, entry: HarnessRecord): Point => {
+  const [originX, originY] = recordLocation(symbol);
+  const width = entry.Side === SIDE_FLAG ? scaled(symbol.XSize, undefined) : 0;
+  return [
+    originX + width,
+    originY - entryDistanceFromTop(entry) * HARNESS_ENTRY_PITCH * COORDINATE_SCALE,
+  ];
+};
+
+/** Separates a bundle name from a member name; neither can contain it. */
+const SIGNAL_SEPARATOR = "\u0000";
+
+/** Build the signal key a harness member is known by. */
+export const harnessSignalKey = (bundle: string, member: string): string =>
+  `${bundle}${SIGNAL_SEPARATOR}${member}`;
+
+/** Split a signal key back into the bundle and member it was built from. */
+export const splitHarnessSignalKey = (key: string): { bundle: string; member: string } => {
+  const separator = key.indexOf(SIGNAL_SEPARATOR);
+  if (separator < 0) return { bundle: key, member: "" };
+  return { bundle: key.slice(0, separator), member: key.slice(separator + 1) };
+};
+
+class BundleGroups {
+  private parent = new Map<number, number>();
+
+  find(x: number): number {
+    if (!this.parent.has(x)) this.parent.set(x, x);
+    const seen = this.parent.get(x)!;
+    if (seen !== x) this.parent.set(x, this.find(seen));
+    return this.parent.get(x)!;
+  }
+
+  union(x: number, y: number): void {
+    const rootX = this.find(x);
+    const rootY = this.find(y);
+    if (rootX !== rootY) this.parent.set(rootY, rootX);
+  }
+}
+
+/**
+ * Pick the smaller of two candidate names, so a bundle reached from several
+ * places settles on one regardless of the order the records were read in.
+ */
+const preferredName = (current: string | undefined, candidate: string): string =>
+  current === undefined || candidate < current ? candidate : current;
+
+/**
+ * Everything a sheet draws that a bundle can be identified or named by.
+ */
+export interface HarnessSheetObjects {
+  /**
+   * The `FileHeader` records in stream order.
+   *
+   * Ports, net labels, sheet symbols and their entries are read from here.
+   * Order matters: a sheet entry inherits its position from the sheet symbol it
+   * follows, exactly as a harness entry does from its connector.
+   */
+  records: readonly HarnessRecord[];
+  /** RECORD=218 signal harness lines, from the `Additional` stream. */
+  buses: readonly HarnessRecord[];
+  /** Identifies bundles that never leave this sheet. */
+  sheetKey: string;
+}
+
+/**
+ * Say which signal every harness entry carries, and what Altium calls its net.
+ *
+ * A harness connector bundles its entries and hands the bundle off from its
+ * primary connection point, which meets either a signal harness polyline
+ * (RECORD=218) or a harness-typed port (RECORD=18 with a `HarnessType`).
+ * Connectors reaching the same polyline, or the same port, carry the same
+ * bundle, so their entries of a given name are one signal — which is what lets
+ * a net be traced through a harness whatever the wires either side are
+ * labelled, the harness elements being, in Altium's words, "names of the
+ * containers that carry the nets, not the names of the nets themselves".
+ *
+ * A bundle is identified by the port it reaches, because a port name is global:
+ * the sheet on the other side names its own connectors from the same port and
+ * arrives at the same signal keys, which is how a harness crosses a sheet
+ * boundary. A bundle reaching no port is local to its sheet and identified by
+ * `sheetKey`.
+ *
+ * Naming follows Altium's rule that harness elements do not name nets, with one
+ * exception: a net label placed on the signal harness line names the harness,
+ * and every net it carries is then called `<harness label>.<entry name>` in
+ * place of whatever the wire itself was labelled.
+ *
+ * Entries of a connector that reaches neither a harness line nor a port are
+ * left alone: they connect through geometry only, as they did before.
+ */
+export const assignHarnessSignals = (
+  connectors: HarnessConnector[],
+  sheet: HarnessSheetObjects
+): string[][] => {
+  // Group everything that meets the same signal harness line. Each line is a
+  // node of its own, so a harness drawn as several joined lines, or one with
+  // three or more objects on it, still forms a single bundle.
+  const groups = new BundleGroups();
+  const lineNode = (offset: number): number => connectors.length + offset;
+  const pointToLine = new Map<string, number>();
+  const lineShapes: { node: number; points: Point[] }[] = [];
+  sheet.buses.forEach((bus, offset) => {
+    const points = polylinePoints(bus);
+    lineShapes.push({ node: lineNode(offset), points });
+    for (const point of points) {
+      const key = pointKey(point);
+      // A line meeting another line at a vertex is the same harness.
+      const met = pointToLine.get(key);
+      if (met !== undefined) groups.union(met, lineNode(offset));
+      else pointToLine.set(key, lineNode(offset));
+    }
+  });
+
+  /**
+   * The harness line a point touches.
+   *
+   * Objects meet a line at one of its vertices, which is how every connector,
+   * port and sheet entry in the sampled designs attaches. A net label naming the
+   * harness instead sits somewhere along it, so the whole run has to be walked.
+   */
+  const lineAt = (point: Point): number | undefined => {
+    const vertex = pointToLine.get(pointKey(point));
+    if (vertex !== undefined) return vertex;
+    for (const shape of lineShapes) {
+      for (let i = 0; i + 1 < shape.points.length; i++) {
+        if (pointOnSegment(point, shape.points[i], shape.points[i + 1])) return shape.node;
+      }
+    }
+    return undefined;
+  };
+
+  /** Bundle names that reach a harness line, and the line group they reach. */
+  const namesByNode = new Map<number, Set<string>>();
+  const nameAt = (node: number, name: string): void => {
+    const names = namesByNode.get(node) ?? new Set<string>();
+    names.add(name);
+    namesByNode.set(node, names);
+  };
+  const labelByNode = new Map<number, string>();
+  const portByPoint = new Map<string, string>();
+
+  let symbol: HarnessRecord | undefined;
+  for (const record of sheet.records) {
+    if (record.RECORD === "15") {
+      symbol = record;
+      continue;
+    }
+
+    if (record.RECORD === "25") {
+      // A net label sitting on a harness line names that harness.
+      const text = record.Text ?? record.Name;
+      const node = lineAt(recordLocation(record));
+      if (text && node !== undefined) {
+        labelByNode.set(node, preferredName(labelByNode.get(node), String(text)));
+      }
+      continue;
+    }
+
+    if (record.RECORD === "18" && record.HarnessType) {
+      const name = record.Name ?? record.Text;
+      if (!name) continue;
+      for (const end of portEnds(record)) {
+        const key = pointKey(end);
+        portByPoint.set(key, String(name));
+        const node = lineAt(end);
+        if (node !== undefined) nameAt(node, String(name));
+      }
+      continue;
+    }
+
+    // A harness-typed sheet entry is the parent sheet's end of a bundle that a
+    // child sheet knows by the port of the same name. Two of them joined by a
+    // harness line are two names for one bundle.
+    if (record.RECORD === "16" && record.HarnessType && symbol) {
+      const name = record.Name ?? record.Text;
+      if (!name) continue;
+      const node = lineAt(sheetEntryLocation(symbol, record));
+      if (node !== undefined) nameAt(node, String(name));
+    }
+  }
+
+  const attached = new Set<number>();
+  const portNames = new Map<number, string>();
+  connectors.forEach((connector, id) => {
+    const key = pointKey(connector.primary);
+
+    const line = lineAt(connector.primary);
+    if (line !== undefined) {
+      groups.union(line, id);
+      attached.add(id);
+    }
+
+    const portName = portByPoint.get(key);
+    if (portName !== undefined) {
+      portNames.set(id, portName);
+      attached.add(id);
+    }
+  });
+
+  // Resolve every name against the final groups: a connector joined to a port
+  // through a harness line shares that line's group, and so its name.
+  const identityByRoot = new Map<number, string>();
+  const labelByRoot = new Map<number, string>();
+  const linkedByRoot = new Map<number, Set<string>>();
+  for (const [id, name] of portNames) {
+    const root = groups.find(id);
+    identityByRoot.set(root, preferredName(identityByRoot.get(root), name));
+  }
+  for (const [node, label] of labelByNode) {
+    const root = groups.find(node);
+    labelByRoot.set(root, preferredName(labelByRoot.get(root), label));
+  }
+  for (const [node, names] of namesByNode) {
+    const root = groups.find(node);
+    const linked = linkedByRoot.get(root) ?? new Set<string>();
+    for (const name of names) {
+      linked.add(name);
+      identityByRoot.set(root, preferredName(identityByRoot.get(root), name));
+    }
+    linkedByRoot.set(root, linked);
+  }
+
+  connectors.forEach((connector, id) => {
+    if (!attached.has(id)) return;
+    const root = groups.find(id);
+    const bundle = identityByRoot.get(root) ?? `${sheet.sheetKey}#${root}`;
+    const harnessLabel = labelByRoot.get(root);
+
+    for (const entry of connector.entries) {
+      const member = entry.Name ?? entry.Text;
+      if (!member) continue;
+      entry.harnessSignal = harnessSignalKey(bundle, String(member));
+      if (harnessLabel !== undefined) entry.harnessNetName = `${harnessLabel}.${String(member)}`;
+    }
+  });
+
+  return [...linkedByRoot.values()].filter((names) => names.size > 1).map((names) => [...names]);
 };

--- a/src/parsers/altium/harness.ts
+++ b/src/parsers/altium/harness.ts
@@ -231,7 +231,9 @@ const entryDistanceFromTop = (entry: HarnessRecord): number =>
  * pulp-bio/HELIOS-R and qfsae/pcb: each lands exactly on a wire end.
  */
 const entriesOnRightEdge = (connector: HarnessRecord, entry: HarnessRecord): boolean =>
-  entry.Side === SIDE_FLAG || connector.HarnessConnectorSide !== SIDE_FLAG;
+  entry.Side !== undefined
+    ? entry.Side === SIDE_FLAG
+    : connector.HarnessConnectorSide !== SIDE_FLAG;
 
 /**
  * Read the harness connectors of a sheet, giving every entry the coordinate at
@@ -242,9 +244,10 @@ const entriesOnRightEdge = (connector: HarnessRecord, entry: HarnessRecord): boo
  * present on some entries and absent on others, so ownership is taken from
  * stream order: entries follow their connector.
  *
- * An entry whose connector has no coordinates is left unpositioned, and the net
- * extractor skips it, rather than being placed at the origin where every other
- * such entry would appear to touch it.
+ * A connector that carries no coordinates is passed over altogether, entries and
+ * all. Read as written it would sit at the origin, where its outgoing connection
+ * could be taken for any harness line or port that happens to reach that point,
+ * and a bundle identity drawn from there travels across the whole project.
  */
 export const readHarnessConnectors = (records: HarnessRecord[]): HarnessConnector[] => {
   const connectors: HarnessConnector[] = [];
@@ -252,6 +255,9 @@ export const readHarnessConnectors = (records: HarnessRecord[]): HarnessConnecto
 
   for (const record of records) {
     if (record.RECORD === "215") {
+      current = undefined;
+      if (record["Location.X"] === undefined || record["Location.Y"] === undefined) continue;
+
       const originX = scaled(record["Location.X"], record["Location.X_Frac"]);
       const originY = scaled(record["Location.Y"], record["Location.Y_Frac"]);
       const width = scaled(record.XSize, undefined);
@@ -276,8 +282,6 @@ export const readHarnessConnectors = (records: HarnessRecord[]): HarnessConnecto
     const connector = current.connector;
     const originX = scaled(connector["Location.X"], connector["Location.X_Frac"]);
     const originY = scaled(connector["Location.Y"], connector["Location.Y_Frac"]);
-    if (connector["Location.X"] === undefined || connector["Location.Y"] === undefined) continue;
-
     const width = entriesOnRightEdge(connector, record) ? scaled(connector.XSize, undefined) : 0;
     setScaledLocation(
       record,
@@ -342,6 +346,16 @@ const portEnds = (port: HarnessRecord): Point[] => {
 };
 
 /**
+ * Sides a sheet entry can be drawn on, of which only two are placed here.
+ *
+ * `Side` counts round the sheet symbol: 0 left, 1 right, 2 top, 3 bottom. All 44
+ * harness-typed sheet entries in the fixture corpus are on a vertical edge; the
+ * seven on a horizontal one carry no `HarnessType`, so the geometry a top or
+ * bottom entry uses has not been seen and is not guessed at.
+ */
+const SHEET_ENTRY_VERTICAL_SIDES = new Set([undefined, "0", "1"]);
+
+/**
  * Where a sheet entry meets a harness line on the parent sheet.
  *
  * A sheet entry is placed the way a harness entry is: it inherits its position
@@ -349,8 +363,13 @@ const portEnds = (port: HarnessRecord): Point[] => {
  * that symbol's top edge, and takes the left edge unless `Side` puts it on the
  * right. Verified against all 44 harness-typed sheet entries in qfsae/pcb and
  * pulp-bio/HELIOS-R, each of which lands exactly on a harness line vertex.
+ *
+ * An entry on the top or bottom edge has no known position and returns none, so
+ * it joins no bundle rather than being placed somewhere it may not be.
  */
-const sheetEntryLocation = (symbol: HarnessRecord, entry: HarnessRecord): Point => {
+const sheetEntryLocation = (symbol: HarnessRecord, entry: HarnessRecord): Point | undefined => {
+  if (!SHEET_ENTRY_VERTICAL_SIDES.has(entry.Side)) return undefined;
+
   const [originX, originY] = recordLocation(symbol);
   const width = entry.Side === SIDE_FLAG ? scaled(symbol.XSize, undefined) : 0;
   return [
@@ -526,8 +545,9 @@ export const assignHarnessSignals = (
     // harness line are two names for one bundle.
     if (record.RECORD === "16" && record.HarnessType && symbol) {
       const name = record.Name ?? record.Text;
-      if (!name) continue;
-      const node = lineAt(sheetEntryLocation(symbol, record));
+      const location = name ? sheetEntryLocation(symbol, record) : undefined;
+      if (!name || !location) continue;
+      const node = lineAt(location);
       if (node !== undefined) nameAt(node, String(name));
     }
   }

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -28,7 +28,10 @@ import { parseRecords, findRecords } from "./record-parser.js";
 import { buildHierarchy, getPartsList, flattenHierarchy, findRecordByIndex } from "./hierarchy.js";
 import { extractNets, determineNetList, classifyNets } from "./net-extractor.js";
 import {
-  positionHarnessEntries,
+  readHarnessConnectors,
+  assignHarnessSignals,
+  harnessSignalKey,
+  splitHarnessSignalKey,
   parseHarnessDefinitions,
   resolveHarnessMembers,
   collectNestedHarnessTypes,
@@ -142,8 +145,19 @@ const convertNets = (nets: AltiumNet[], schematic: AltiumSchematic): NetConnecti
     }
 
     // Only add net if it has pin connections
-    if (Object.keys(pinsByComponent).length > 0) {
+    if (Object.keys(pinsByComponent).length === 0) continue;
+
+    // Two connected groups can end up under one name — a harness member named
+    // by its entry alongside a net label of the same text, say. They are one
+    // net, so fold them together instead of letting the later one replace the
+    // earlier and drop its pins.
+    const existing = result[netName];
+    if (!existing) {
       result[netName] = pinsByComponent;
+      continue;
+    }
+    for (const [refdes, pins] of Object.entries(pinsByComponent)) {
+      existing[refdes] = [...new Set([...(existing[refdes] ?? []), ...pins])];
     }
   }
 
@@ -389,8 +403,16 @@ export const extractComponents = (schematic: AltiumSchematic): ComponentDetails 
  * 215-218) are written to a separate `Additional` stream. A document parsed from
  * `FileHeader` alone has no harness connectors, entries or types in it at all, so
  * any net reaching a harness simply ends there.
+ *
+ * The two streams number their records independently, and `buildHierarchy`
+ * renumbers the concatenation by position, so an `OwnerIndex` written in the
+ * `Additional` stream is shifted by the number of `FileHeader` records to keep
+ * pointing at the record it names.
  */
-export const readSchematicRecords = (schdocPath: string, headerBuffer: Buffer): AltiumSchematic => {
+export const readSchematicRecords = (
+  schdocPath: string,
+  headerBuffer: Buffer
+): AltiumSchematic & { bundleLinks?: string[][] } => {
   const schematic = parseRecords(headerBuffer);
 
   const additional = readOptionalOleStream(schdocPath, ALTIUM_ADDITIONAL_STREAM);
@@ -399,20 +421,80 @@ export const readSchematicRecords = (schdocPath: string, headerBuffer: Buffer): 
   const extra = parseRecords(additional);
   if (extra.records.length === 0) return schematic;
 
-  positionHarnessEntries(extra.records as never);
+  const connectors = readHarnessConnectors(extra.records as never);
+  const bundleLinks = assignHarnessSignals(connectors, {
+    records: schematic.records as never,
+    buses: extra.records.filter(
+      (record) => record.RECORD === RECORD_TYPES.SIGNAL_HARNESS
+    ) as never,
+    sheetKey: path.basename(schdocPath),
+  });
+
+  const ownerOffset = schematic.records.length;
+  for (const record of extra.records) {
+    const owner = record.OwnerIndex ?? record.OWNERINDEX;
+    if (owner === undefined || owner === null || owner === "") continue;
+    const ownerIndex = parseInt(String(owner), 10);
+    if (!Number.isFinite(ownerIndex)) continue;
+    record.OwnerIndex = String(ownerOffset + ownerIndex);
+    delete record.OWNERINDEX;
+  }
 
   return {
     header: schematic.header,
     records: [...schematic.records, ...extra.records],
+    bundleLinks,
   };
 };
 
 /**
- * Parse Altium .SchDoc file into unified ParsedNetlist schema.
+ * One document's netlist, plus which net carries each harness signal it draws.
  *
- * This is the main entry point for integration with NetlistService.
+ * A harness signal is keyed by its bundle and member name, and a bundle that
+ * leaves the sheet is named after the port it leaves through, so the same key
+ * names the same signal on every sheet the bundle reaches. That is what lets a
+ * harness be traced from one sheet to another, where geometry cannot reach.
  */
-export const parseAltium = async (schdocPath: string): Promise<ParsedNetlist> => {
+interface ParsedDocument {
+  netlist: ParsedNetlist;
+  /** Harness signal key -> the name of the net carrying it on this sheet. */
+  harnessSignals: Map<string, string>;
+  /** Net names that came from the design rather than being derived from a pin. */
+  designedNames: Set<string>;
+  /** Bundle names this sheet joins, each group being one bundle under many names. */
+  bundleLinks: string[][];
+}
+
+/**
+ * Collect, for each harness signal drawn on a sheet, the net that carries it.
+ *
+ * Only nets that survived into the netlist are reported: a signal whose net has
+ * no pins on this sheet connects nothing here.
+ */
+const collectHarnessSignals = (
+  nets: AltiumNet[],
+  parsedNets: NetConnections
+): Map<string, string> => {
+  const signals = new Map<string, string>();
+
+  for (const net of nets) {
+    if (!net.name || !parsedNets[net.name]) continue;
+    for (const device of net.devices) {
+      if (device.RECORD !== RECORD_TYPES.HARNESS_ENTRY) continue;
+      const signal = device.harnessSignal;
+      if (typeof signal === "string" && signal && !signals.has(signal)) {
+        signals.set(signal, net.name);
+      }
+    }
+  }
+
+  return signals;
+};
+
+/**
+ * Parse one Altium .SchDoc document.
+ */
+const parseAltiumDocument = (schdocPath: string): ParsedDocument => {
   // 1. Read OLE file and extract FileHeader stream
   const buffer = readOleStream(schdocPath);
 
@@ -432,11 +514,26 @@ export const parseAltium = async (schdocPath: string): Promise<ParsedNetlist> =>
   // 6. Populate component pin-to-net mappings from the nets data
   populatePinNets(components, parsedNets);
 
+  const designedNames = new Set<string>();
+  for (const net of nets) {
+    if (net.name && net.nameSource && net.nameSource !== "pin") designedNames.add(net.name);
+  }
+
   return {
-    nets: parsedNets,
-    components,
+    netlist: { nets: parsedNets, components },
+    harnessSignals: collectHarnessSignals(nets, parsedNets),
+    designedNames,
+    bundleLinks: schematic.bundleLinks ?? [],
   };
 };
+
+/**
+ * Parse Altium .SchDoc file into unified ParsedNetlist schema.
+ *
+ * This is the main entry point for integration with NetlistService.
+ */
+export const parseAltium = async (schdocPath: string): Promise<ParsedNetlist> =>
+  parseAltiumDocument(schdocPath).netlist;
 
 /**
  * Parse Altium file with a specific output format (matching Python API).
@@ -517,6 +614,141 @@ const mergeResult = (
       allComponents[refdes] = component;
     }
   }
+};
+
+/**
+ * Resolve the many names one bundle goes by into a single one.
+ *
+ * A bundle is identified by the port it leaves its sheet through, and that port
+ * is rarely called the same thing at both ends: a bulkhead sheet takes in
+ * `TRANSPONDER_POWER_UL` and passes on `TRANSPONDER_POWER`. The parent sheet is
+ * where the two are shown to be one bundle, by a harness line drawn between the
+ * sheet entries that name them.
+ *
+ * Names are matched across the project, as ports already are elsewhere in this
+ * parser, so two sheets that reuse one harness port name are read as sharing
+ * that bundle.
+ */
+const resolveBundleNames = (linkGroups: string[][]): Map<string, string> => {
+  const parent = new Map<string, string>();
+  const find = (name: string): string => {
+    const seen = parent.get(name);
+    if (seen === undefined) {
+      parent.set(name, name);
+      return name;
+    }
+    if (seen === name) return name;
+    const root = find(seen);
+    parent.set(name, root);
+    return root;
+  };
+
+  for (const group of linkGroups) {
+    for (const name of group) {
+      const rootA = find(group[0]);
+      const rootB = find(name);
+      if (rootA === rootB) continue;
+      // Keep the smaller name as the root so the choice is stable whatever
+      // order the documents were read in.
+      if (rootA < rootB) parent.set(rootB, rootA);
+      else parent.set(rootA, rootB);
+    }
+  }
+
+  const resolved = new Map<string, string>();
+  for (const name of parent.keys()) resolved.set(name, find(name));
+  return resolved;
+};
+
+/**
+ * Choose the name a group of merged nets keeps.
+ *
+ * A name the designer wrote — a label, a port, a power port — beats one the
+ * parser derived from a pin, because the derived name says nothing about the
+ * signal. Between two written names the one already on more pins wins, so a
+ * signal keeps the name most of the design calls it by. Ties go to the first in
+ * sort order, so the result does not depend on the order the documents happened
+ * to be read in.
+ */
+const canonicalNetName = (
+  names: Iterable<string>,
+  designed: ReadonlySet<string>,
+  allNets: NetConnections
+): string => {
+  const pinCount = (name: string): number =>
+    Object.values(allNets[name] ?? {}).reduce((total, pins) => total + pins.length, 0);
+
+  return [...names].sort((a, b) => {
+    const written = Number(designed.has(b)) - Number(designed.has(a));
+    if (written !== 0) return written;
+    const pins = pinCount(b) - pinCount(a);
+    if (pins !== 0) return pins;
+    return a < b ? -1 : a > b ? 1 : 0;
+  })[0];
+};
+
+/**
+ * Join the nets that a signal harness carries from one sheet to another.
+ *
+ * Within a sheet the two ends of a harness are already one net, because both
+ * entries carry the same signal key. Across sheets there is no geometry to join
+ * them: each sheet names its end after whatever label its own wires carry, and
+ * two different labels leave the ends looking like two nets. Matching the signal
+ * keys is what shows they are one, and the surviving name is the same on every
+ * sheet so that a component's pins agree with the netlist.
+ *
+ * Returns the renaming that was applied, empty when no harness spans sheets.
+ */
+const mergeHarnessSignalNets = (
+  allNets: NetConnections,
+  allComponents: ComponentDetails,
+  signalNets: Map<string, Set<string>>,
+  designedNames: ReadonlySet<string>
+): Map<string, string> => {
+  const renames = new Map<string, string>();
+
+  for (const netNames of signalNets.values()) {
+    if (netNames.size < 2) continue;
+    // A net already folded into another group joins that group's name, so a
+    // signal shared with a third sheet does not split it off again.
+    const resolved = new Set([...netNames].map((name) => renames.get(name) ?? name));
+    if (resolved.size < 2) continue;
+
+    const canonical = canonicalNetName(resolved, designedNames, allNets);
+    for (const [from, to] of renames) {
+      if (resolved.has(to)) renames.set(from, canonical);
+    }
+    for (const name of resolved) {
+      if (name !== canonical) renames.set(name, canonical);
+    }
+  }
+
+  if (renames.size === 0) return renames;
+
+  for (const [from, to] of renames) {
+    const connections = allNets[from];
+    if (!connections) continue;
+    delete allNets[from];
+
+    const target = (allNets[to] ??= {});
+    for (const [refdes, pins] of Object.entries(connections)) {
+      target[refdes] = [...new Set([...(target[refdes] ?? []), ...pins])];
+    }
+  }
+
+  for (const component of Object.values(allComponents)) {
+    for (const [pinNumber, entry] of Object.entries(component.pins)) {
+      if (typeof entry === "string") {
+        const renamed = renames.get(entry);
+        if (renamed) component.pins[pinNumber] = renamed;
+      } else {
+        const renamed = renames.get(entry.net);
+        if (renamed) entry.net = renamed;
+      }
+    }
+  }
+
+  return renames;
 };
 
 /**
@@ -926,6 +1158,10 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
   const allNets: NetConnections = {};
   const allComponents: ComponentDetails = {};
   const expandedFiles = new Set<string>();
+  // Harness signal key -> every net name carrying it, across all sheets.
+  const signalNets = new Map<string, Set<string>>();
+  const designedNames = new Set<string>();
+  const bundleLinks: string[][] = [];
 
   for (const schdocPath of schdocPaths) {
     const schdocBase = path.basename(schdocPath).toLowerCase();
@@ -955,7 +1191,11 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       const harnessDefinitions = parentDocument
         ? await readHarnessDefinitions(parentDocument)
         : new Map();
-      const nestedHarnessTypes = collectNestedHarnessTypes(channelParent.records as never);
+      // Entries are nested under their connector once the parent's OwnerIndex
+      // values resolve, so the whole tree has to be walked to find them.
+      const nestedHarnessTypes = collectNestedHarnessTypes(
+        flattenHierarchy(channelParent) as never
+      );
 
       const entryClassification = classifySheetEntries(
         channelParent,
@@ -974,10 +1214,36 @@ const parseAltiumProject = async (projectPath: string): Promise<ParsedNetlist> =
       );
       mergeResult(expanded, allNets, allComponents);
     } else {
-      const result = await parseAltium(schdocPath);
-      mergeResult(result, allNets, allComponents);
+      const document = parseAltiumDocument(schdocPath);
+      mergeResult(document.netlist, allNets, allComponents);
+      for (const [signal, netName] of document.harnessSignals) {
+        const carriers = signalNets.get(signal) ?? new Set<string>();
+        carriers.add(netName);
+        signalNets.set(signal, carriers);
+      }
+      for (const name of document.designedNames) designedNames.add(name);
+      bundleLinks.push(...document.bundleLinks);
     }
   }
+
+  // One bundle is known by a different port name on each sheet it reaches, so
+  // fold every name onto the one the whole project agrees on before matching
+  // the signals up.
+  const bundleNames = resolveBundleNames(bundleLinks);
+  const resolvedSignalNets = new Map<string, Set<string>>();
+  for (const [signal, carriers] of signalNets) {
+    const { bundle, member } = splitHarnessSignalKey(signal);
+    const key = harnessSignalKey(bundleNames.get(bundle) ?? bundle, member);
+    const resolved = resolvedSignalNets.get(key) ?? new Set<string>();
+    for (const name of carriers) resolved.add(name);
+    resolvedSignalNets.set(key, resolved);
+  }
+
+  // Channel expansion renames a repeated sheet's nets per channel, so a harness
+  // signal collected from one would no longer name the net that carries it.
+  // Those sheets reach the rest of the design through their sheet entries,
+  // which classifySheetEntries already carries the bundle's members across.
+  mergeHarnessSignalNets(allNets, allComponents, resolvedSignalNets, designedNames);
 
   return {
     nets: allNets,

--- a/src/parsers/altium/net-extractor.test.ts
+++ b/src/parsers/altium/net-extractor.test.ts
@@ -479,3 +479,113 @@ describe("determineNetList", () => {
     expect(Array.isArray(result.nets)).toBe(true);
   });
 });
+
+describe("signal harnesses", () => {
+  /**
+   * The topology of issue #115: two components joined through a harness, with a
+   * different net label on the wire at each end.
+   *
+   *   U1.1 --[FROM_U1]-- (entry SIG) [connector] ==harness== [connector] (entry SIG) --[TO_U2]-- U2.1
+   */
+  const harnessJoinedComponents = (leftLabel: string, rightLabel: string): AltiumSchematic => {
+    const component = (index: number, refdes: string, x: number): AltiumRecord =>
+      ({
+        index,
+        RECORD: RECORD_TYPES.COMPONENT,
+        children: [
+          {
+            index: index + 1,
+            RECORD: RECORD_TYPES.PIN,
+            Designator: "1",
+            "Location.X": String(x),
+            "Location.Y": "100",
+            PinLength: "0",
+            PinConglomerate: "0",
+          } as AltiumRecord,
+          { index: index + 2, RECORD: RECORD_TYPES.DESIGNATOR, Text: refdes } as AltiumRecord,
+        ],
+      }) as AltiumRecord;
+
+    return {
+      header: [],
+      records: [
+        component(0, "U1", 100),
+        component(3, "U2", 500),
+        // U1's wire runs into the left connector's entry at x = 200.
+        { index: 6, RECORD: RECORD_TYPES.WIRE, X1: "100", Y1: "100", X2: "200", Y2: "100" },
+        { index: 7, RECORD: RECORD_TYPES.NET_LABEL, Text: leftLabel, "Location.X": "150", "Location.Y": "100" },
+        // U2's wire runs into the right connector's entry at x = 400.
+        { index: 8, RECORD: RECORD_TYPES.WIRE, X1: "400", Y1: "100", X2: "500", Y2: "100" },
+        { index: 9, RECORD: RECORD_TYPES.NET_LABEL, Text: rightLabel, "Location.X": "450", "Location.Y": "100" },
+        // Both entries carry the same signal of the same bundle, as
+        // assignHarnessSignals would have marked them.
+        {
+          index: 10,
+          RECORD: RECORD_TYPES.HARNESS_ENTRY,
+          Name: "SIG",
+          "Location.X": "200",
+          "Location.Y": "100",
+          harnessSignal: "BUNDLE.SIG",
+        },
+        {
+          index: 11,
+          RECORD: RECORD_TYPES.HARNESS_ENTRY,
+          Name: "SIG",
+          "Location.X": "400",
+          "Location.Y": "100",
+          harnessSignal: "BUNDLE.SIG",
+        },
+      ] as AltiumRecord[],
+    };
+  };
+
+  const refdesOf = (schematic: AltiumSchematic, net: { devices: AltiumRecord[] }): string[] =>
+    net.devices
+      .filter((device) => device.RECORD === RECORD_TYPES.PIN)
+      .map((pin) => {
+        const owner = schematic.records.find((record) =>
+          record.children?.some((child) => child.index === pin.index)
+        );
+        const designator = owner?.children?.find((c) => c.RECORD === RECORD_TYPES.DESIGNATOR);
+        return String(designator?.Text);
+      })
+      .sort();
+
+  it("joins the two ends of a harness whose wires are labelled differently", () => {
+    const schematic = harnessJoinedComponents("FROM_U1", "TO_U2");
+
+    const joined = extractNets(schematic).filter((net) => refdesOf(schematic, net).length === 2);
+
+    expect(joined).toHaveLength(1);
+    expect(refdesOf(schematic, joined[0])).toEqual(["U1", "U2"]);
+  });
+
+  it("names such a net from a wire label, never from the harness entry", () => {
+    // A harness entry names a member of a bundle, not the net, so "SIG" must not
+    // become a net name: it is only unique within its own harness.
+    const schematic = harnessJoinedComponents("FROM_U1", "TO_U2");
+
+    const names = extractNets(schematic).map((net) => net.name);
+
+    expect(names).toContain("FROM_U1");
+    expect(names).not.toContain("SIG");
+  });
+
+  it("skips a harness entry that was never positioned", () => {
+    // Two unpositioned entries would otherwise both sit at the origin and look
+    // like one point, wiring unrelated nets together.
+    const schematic = harnessJoinedComponents("FROM_U1", "TO_U2");
+    for (const record of schematic.records) {
+      if (record.RECORD !== RECORD_TYPES.HARNESS_ENTRY) continue;
+      delete record["Location.X"];
+      delete record["Location.Y"];
+    }
+
+    const nets = extractNets(schematic);
+
+    expect(nets.every((net) => refdesOf(schematic, net).length <= 1)).toBe(true);
+    expect(nets.some((net) => net.devices.some((d) => d.RECORD === RECORD_TYPES.HARNESS_ENTRY))).toBe(
+      false
+    );
+  });
+});

--- a/src/parsers/altium/net-extractor.ts
+++ b/src/parsers/altium/net-extractor.ts
@@ -95,6 +95,12 @@ const findConnectableDevices = (schematic: AltiumSchematic): AltiumRecord[] => {
       if (record.RECORD === RECORD_TYPES.PIN && !pinMatchesCurrentPart(record, schematic)) {
         continue;
       }
+      // An entry whose connector had no coordinates was never positioned. Leaving
+      // it out keeps it from sitting at the origin, where every other such entry
+      // would appear to touch it.
+      if (record.RECORD === RECORD_TYPES.HARNESS_ENTRY && record["Location.X"] === undefined) {
+        continue;
+      }
       if (record.RECORD && connectableTypes.has(record.RECORD)) {
         devices.push(record);
       }
@@ -295,26 +301,61 @@ const collectPinCandidates = (
 };
 
 /**
+ * Naming devices, strongest claim on the net's name first.
+ *
+ * A power port names a global net and outranks everything. A labelled signal
+ * harness comes next: Altium replaces the wire's own label with
+ * `<harness label>.<entry name>` for every net the harness carries. Otherwise
+ * the net label the designer wrote on the wire wins, ahead of a port, which
+ * only names the signal where it crosses a sheet boundary.
+ *
+ * A harness entry never names a net. Its name belongs to a member of a bundle,
+ * not to the net, so it is only unique within its harness: naming nets after
+ * entries would put every sensor's `SIGNAL` under one name.
+ */
+const NAMING_PRIORITY: readonly { type: string; source: NonNullable<AltiumNet["nameSource"]> }[] = [
+  { type: RECORD_TYPES.POWER_PORT, source: "power" },
+  { type: RECORD_TYPES.HARNESS_ENTRY, source: "harness" },
+  { type: RECORD_TYPES.NET_LABEL, source: "label" },
+  { type: RECORD_TYPES.PORT, source: "port" },
+];
+
+/**
+ * The name a device claims for its net, or undefined when it claims none.
+ *
+ * A harness entry claims one only where the harness line it belongs to carries
+ * a net label, which is the case Altium names from.
+ */
+const claimedNetName = (device: AltiumRecord): string | undefined => {
+  if (device.RECORD === RECORD_TYPES.HARNESS_ENTRY) {
+    const harnessNetName = device.harnessNetName;
+    return typeof harnessNetName === "string" && harnessNetName ? harnessNetName : undefined;
+  }
+  return getDeviceNetName(device);
+};
+
+/**
  * Assign a name to a net.
  *
  * Priority:
  * 1. Power port TEXT value
- * 2. Net label TEXT value
- * 3. Pin-derived name (Net<Refdes>_<Pin>) using the lowest refdes/pin in the net
+ * 2. Labelled harness: <net label on the harness line>.<harness entry name>
+ * 3. Net label TEXT value
+ * 4. Port NAME value
+ * 5. Pin-derived name (Net<Refdes>_<Pin>) using the lowest refdes/pin in the net
+ *
+ * Where a net carries two names of the same rank — two net labels either side of
+ * a harness, say — the first in the device order wins, which is the order the
+ * records appear in the file.
  */
 const assignNetName = (net: AltiumNet, schematic: AltiumSchematic): void => {
-  // Try power ports, net labels, ports, and sheet entries first
-  const namingTypes = new Set<string>([
-    RECORD_TYPES.POWER_PORT,
-    RECORD_TYPES.NET_LABEL,
-    RECORD_TYPES.PORT,
-    RECORD_TYPES.HARNESS_ENTRY,
-  ]);
-  for (const device of net.devices) {
-    if (device.RECORD && namingTypes.has(device.RECORD)) {
-      const nameValue = getDeviceNetName(device);
+  for (const naming of NAMING_PRIORITY) {
+    for (const device of net.devices) {
+      if (device.RECORD !== naming.type) continue;
+      const nameValue = claimedNetName(device);
       if (nameValue) {
         net.name = unescapeAltiumOverbar(nameValue);
+        net.nameSource = naming.source;
         return;
       }
     }
@@ -335,6 +376,7 @@ const assignNetName = (net: AltiumNet, schematic: AltiumSchematic): void => {
   pinNumbers.sort(comparePinNumbers);
   const selectedPin = pinNumbers[0];
   net.name = `Net${selectedRefdes}_${selectedPin}`;
+  net.nameSource = "pin";
 };
 
 /**

--- a/src/parsers/altium/types.ts
+++ b/src/parsers/altium/types.ts
@@ -241,6 +241,8 @@ export interface AltiumSchematic {
 export interface AltiumNet {
   /** Net name (from power port, label, or pin) */
   name: string | null;
+  /** Which kind of object the name came from; "pin" means the parser derived it */
+  nameSource?: "power" | "harness" | "label" | "port" | "pin";
   /** All devices connected to this net */
   devices: AltiumRecord[];
 }

--- a/test/golden/altium/aberrant_sound_module.json
+++ b/test/golden/altium/aberrant_sound_module.json
@@ -266,7 +266,12 @@
       ]
     },
     "CS_AY1": {
+      "DD5": [
+        "15"
+      ],
       "DD8": [
+        "10",
+        "9",
         "8"
       ],
       "R2": [
@@ -285,6 +290,9 @@
       ]
     },
     "CS_AY3": {
+      "DD5": [
+        "13"
+      ],
       "DD6": [
         "6"
       ],
@@ -301,7 +309,11 @@
       ]
     },
     "CS_AY2": {
+      "DD5": [
+        "11"
+      ],
       "DD6": [
+        "11",
         "8"
       ],
       "DD12_AY2": [
@@ -438,14 +450,19 @@
       ]
     },
     "DIN": {
+      "DD7": [
+        "13",
+        "2",
+        "1"
+      ],
       "DD8": [
+        "11",
         "13",
         "12",
         "4"
       ],
-      "DD7": [
-        "2",
-        "1"
+      "R3": [
+        "2"
       ]
     },
     "+5": {
@@ -621,11 +638,15 @@
       "P2": [
         "38"
       ],
+      "DD1": [
+        "3",
+        "17"
+      ],
+      "DR1": [
+        "3"
+      ],
       "P1": [
         "B18"
-      ],
-      "DD1": [
-        "17"
       ]
     },
     "NetDD4_2": {
@@ -649,11 +670,15 @@
       "P2": [
         "44"
       ],
+      "DD3": [
+        "8",
+        "12"
+      ],
+      "DR2": [
+        "8"
+      ],
       "P1": [
         "A20"
-      ],
-      "DD3": [
-        "12"
       ]
     },
     "AD2": {
@@ -672,11 +697,15 @@
       "P2": [
         "46"
       ],
+      "DD3": [
+        "7",
+        "13"
+      ],
+      "DR2": [
+        "7"
+      ],
       "P1": [
         "B20"
-      ],
-      "DD3": [
-        "13"
       ]
     },
     "DOUT": {
@@ -742,11 +771,15 @@
       "P2": [
         "50"
       ],
+      "DD3": [
+        "5",
+        "15"
+      ],
+      "DR2": [
+        "5"
+      ],
       "P1": [
         "B21"
-      ],
-      "DD3": [
-        "15"
       ]
     },
     "AD1": {
@@ -762,11 +795,15 @@
       "P2": [
         "48"
       ],
+      "DD3": [
+        "6",
+        "14"
+      ],
+      "DR2": [
+        "6"
+      ],
       "P1": [
         "A21"
-      ],
-      "DD3": [
-        "14"
       ]
     },
     "AD4": {
@@ -782,11 +819,15 @@
       "P2": [
         "30"
       ],
+      "DD1": [
+        "7",
+        "13"
+      ],
+      "DR1": [
+        "7"
+      ],
       "P1": [
         "B16"
-      ],
-      "DD1": [
-        "13"
       ]
     },
     "AD5": {
@@ -802,11 +843,15 @@
       "P2": [
         "28"
       ],
+      "DD1": [
+        "8",
+        "12"
+      ],
+      "DR1": [
+        "8"
+      ],
       "P1": [
         "A16"
-      ],
-      "DD1": [
-        "12"
       ]
     },
     "AD6": {
@@ -822,11 +867,15 @@
       "P2": [
         "34"
       ],
+      "DD1": [
+        "5",
+        "15"
+      ],
+      "DR1": [
+        "5"
+      ],
       "P1": [
         "B17"
-      ],
-      "DD1": [
-        "15"
       ]
     },
     "AD7": {
@@ -842,11 +891,15 @@
       "P2": [
         "32"
       ],
+      "DD1": [
+        "6",
+        "14"
+      ],
+      "DR1": [
+        "6"
+      ],
       "P1": [
         "A17"
-      ],
-      "DD1": [
-        "14"
       ]
     },
     "L_AY1": {
@@ -1018,29 +1071,41 @@
       "P2": [
         "26"
       ],
+      "DD1": [
+        "9",
+        "11"
+      ],
+      "DR1": [
+        "9"
+      ],
       "P1": [
         "A2"
-      ],
-      "DD1": [
-        "11"
       ]
     },
     "AD9": {
       "P2": [
         "36"
       ],
+      "DD1": [
+        "4",
+        "16"
+      ],
+      "DR1": [
+        "4"
+      ],
       "P1": [
         "A18"
-      ],
-      "DD1": [
-        "16"
       ]
     },
     "AD11": {
       "P2": [
         "40"
       ],
+      "P1": [
+        "A19"
+      ],
       "DD1": [
+        "18",
         "2"
       ],
       "DR1": [
@@ -1051,44 +1116,60 @@
       "P2": [
         "42"
       ],
+      "DD3": [
+        "9",
+        "11"
+      ],
+      "DR2": [
+        "9"
+      ],
       "P1": [
         "B19"
-      ],
-      "DD3": [
-        "11"
       ]
     },
     "AD13": {
       "P2": [
         "52"
       ],
+      "DD3": [
+        "4",
+        "16"
+      ],
+      "DR2": [
+        "4"
+      ],
       "P1": [
         "A22"
-      ],
-      "DD3": [
-        "16"
       ]
     },
     "AD12": {
       "P2": [
         "54"
       ],
+      "DD3": [
+        "3",
+        "17"
+      ],
+      "DR2": [
+        "3"
+      ],
       "P1": [
         "B22"
-      ],
-      "DD3": [
-        "17"
       ]
     },
     "AD14": {
       "P2": [
         "56"
       ],
+      "DD3": [
+        "2",
+        "18"
+      ],
+      "DR2": [
+        "2"
+      ],
       "P1": [
         "B23"
-      ],
-      "DD3": [
-        "18"
       ]
     },
     "NetC38_2": {
@@ -1353,7 +1434,6 @@
   },
   "components": {
     "DD5": {
-      "description": "ÈÄ7 3 to 8 DEMUX",
       "pins": {
         "1": "A3",
         "2": "A2",
@@ -1391,7 +1471,7 @@
         },
         "11": {
           "name": "Y\\4\\",
-          "net": ""
+          "net": "CS_AY2"
         },
         "12": {
           "name": "Y\\3\\",
@@ -1399,7 +1479,7 @@
         },
         "13": {
           "name": "Y\\2\\",
-          "net": ""
+          "net": "CS_AY3"
         },
         "14": {
           "name": "Y\\1\\",
@@ -1407,18 +1487,18 @@
         },
         "15": {
           "name": "Y\\0\\",
-          "net": ""
+          "net": "CS_AY1"
         },
         "16": {
           "name": "+5",
           "net": ""
         }
       },
+      "description": "ÈÄ7 3 to 8 DEMUX",
       "comment": "74x138",
       "value": "*"
     },
     "DD9": {
-      "description": "ËÀ2 8NAND",
       "pins": {
         "1": "",
         "2": "A4",
@@ -1438,11 +1518,11 @@
           "net": ""
         }
       },
+      "description": "ËÀ2 8NAND",
       "comment": "74x30",
       "value": "*"
     },
     "DD6": {
-      "description": "ËÅ4 3x3NOR",
       "pins": {
         "2": "A8",
         "3": "NetDD6_3",
@@ -1456,18 +1536,18 @@
         "8": "CS_AY2",
         "9": "",
         "10": "",
-        "11": "",
+        "11": "CS_AY2",
         "12": "ADDR_DT",
         "14": {
           "name": "+5V",
           "net": ""
         }
       },
+      "description": "ËÅ4 3x3NOR",
       "comment": "74x27",
       "value": "*"
     },
     "DD7": {
-      "description": "ËÈ1 4x2AND",
       "pins": {
         "1": "DIN",
         "2": "DIN",
@@ -1483,11 +1563,13 @@
         "9": "DINOUT",
         "10": "WTBT",
         "12": "ADDR_DT",
+        "13": "DIN",
         "14": {
           "name": "+5V",
           "net": ""
         }
       },
+      "description": "ËÈ1 4x2AND",
       "comment": "74x08",
       "value": "*"
     },
@@ -1499,7 +1581,6 @@
       "comment": "2.2K"
     },
     "DD4": {
-      "description": "ÈÐ22 transparent latch",
       "pins": {
         "1": {
           "name": "E\\O\\",
@@ -1582,11 +1663,11 @@
           "net": ""
         }
       },
+      "description": "ÈÐ22 transparent latch",
       "comment": "74x573",
       "value": "*"
     },
     "DD10": {
-      "description": "ÈÐ22 transparent latch",
       "pins": {
         "1": {
           "name": "E\\O\\",
@@ -1669,11 +1750,11 @@
           "net": ""
         }
       },
+      "description": "ÈÐ22 transparent latch",
       "comment": "74x573",
       "value": "*"
     },
     "DD8": {
-      "description": "ËÀ13 4x2NAND O.C.",
       "pins": {
         "1": "DLDIO",
         "2": "ADDR_DT",
@@ -1686,6 +1767,9 @@
           "net": ""
         },
         "8": "CS_AY1",
+        "9": "CS_AY1",
+        "10": "CS_AY1",
+        "11": "DIN",
         "12": "DIN",
         "13": "DIN",
         "14": {
@@ -1693,18 +1777,18 @@
           "net": ""
         }
       },
+      "description": "ËÀ13 4x2NAND O.C.",
       "comment": "74x38",
       "value": "*"
     },
     "R3": {
       "pins": {
         "1": "+5",
-        "2": ""
+        "2": "DIN"
       },
       "comment": "2.2K"
     },
     "DD11": {
-      "description": "ÈÅ19",
       "pins": {
         "1": "NetDD11_1",
         "2": "GND",
@@ -1734,15 +1818,16 @@
           "net": "GND"
         }
       },
+      "description": "ÈÅ19",
       "comment": "74x393",
       "value": "*"
     },
     "C14": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "SYNC"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "200"
     },
     "G1": {
@@ -1764,99 +1849,99 @@
       "comment": "CXO"
     },
     "C9": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C10": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C11": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C12": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C15": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C16": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C18": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C19": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C20": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C21": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C22": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C23": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "VD1": {
@@ -1867,11 +1952,11 @@
       "comment": "D9B"
     },
     "C13": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "DLDIO"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "62"
     },
     "R14": {
@@ -1882,51 +1967,51 @@
       "comment": "10K"
     },
     "C40": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C41": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C42": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C43": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "C44": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "0.1u"
     },
     "C45": {
-      "description": "Murata ceramic capacitor",
       "pins": {
         "1": "GND",
         "2": "+5"
       },
+      "description": "Murata ceramic capacitor",
       "comment": "4.7u"
     },
     "R2": {
@@ -2914,7 +2999,7 @@
         },
         "A19": {
           "name": "A\\D\\1\\1\\",
-          "net": ""
+          "net": "AD11"
         },
         "A20": {
           "name": "A\\D\\3\\",
@@ -2952,31 +3037,31 @@
         },
         "3": {
           "name": "1",
-          "net": ""
+          "net": "AD8"
         },
         "4": {
           "name": "2",
-          "net": ""
+          "net": "AD9"
         },
         "5": {
           "name": "3",
-          "net": ""
+          "net": "AD6"
         },
         "6": {
           "name": "4",
-          "net": ""
+          "net": "AD7"
         },
         "7": {
           "name": "5",
-          "net": ""
+          "net": "AD4"
         },
         "8": {
           "name": "6",
-          "net": ""
+          "net": "AD5"
         },
         "9": {
           "name": "7",
-          "net": ""
+          "net": "AD15"
         },
         "10": {
           "name": "GND",
@@ -3012,7 +3097,7 @@
         },
         "18": {
           "name": "0",
-          "net": ""
+          "net": "AD11"
         },
         "19": {
           "name": "E\\O\\",
@@ -3034,35 +3119,35 @@
         },
         "2": {
           "name": "0",
-          "net": ""
+          "net": "AD14"
         },
         "3": {
           "name": "1",
-          "net": ""
+          "net": "AD12"
         },
         "4": {
           "name": "2",
-          "net": ""
+          "net": "AD13"
         },
         "5": {
           "name": "3",
-          "net": ""
+          "net": "AD0"
         },
         "6": {
           "name": "4",
-          "net": ""
+          "net": "AD1"
         },
         "7": {
           "name": "5",
-          "net": ""
+          "net": "AD2"
         },
         "8": {
           "name": "6",
-          "net": ""
+          "net": "AD3"
         },
         "9": {
           "name": "7",
-          "net": ""
+          "net": "AD10"
         },
         "10": {
           "name": "GND",
@@ -3177,14 +3262,14 @@
     "DR2": {
       "pins": {
         "1": "+5",
-        "2": "",
-        "3": "",
-        "4": "",
-        "5": "",
-        "6": "",
-        "7": "",
-        "8": "",
-        "9": ""
+        "2": "AD14",
+        "3": "AD12",
+        "4": "AD13",
+        "5": "AD0",
+        "6": "AD1",
+        "7": "AD2",
+        "8": "AD3",
+        "9": "AD10"
       },
       "comment": "RNA8"
     },
@@ -3192,13 +3277,13 @@
       "pins": {
         "1": "+5",
         "2": "AD11",
-        "3": "",
-        "4": "",
-        "5": "",
-        "6": "",
-        "7": "",
-        "8": "",
-        "9": ""
+        "3": "AD8",
+        "4": "AD9",
+        "5": "AD6",
+        "6": "AD7",
+        "7": "AD4",
+        "8": "AD5",
+        "9": "AD15"
       },
       "comment": "RNA8"
     },

--- a/test/golden/altium/ld_harness.json
+++ b/test/golden/altium/ld_harness.json
@@ -3,6 +3,11 @@
     "V_LASER_CHAN1": {
       "J4_CHAN1": [
         "2"
+      ],
+      "J5_CHAN1": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "AGND": {
@@ -258,99 +263,58 @@
         "9_G"
       ]
     },
-    "3V3_P": {
+    "_3V3_P_CHAN1": {
       "J4_CHAN1": [
         "4"
       ],
-      "J4_CHAN2": [
-        "4"
-      ],
-      "J4_CHAN3": [
-        "4"
-      ],
-      "J4_CHAN4": [
-        "4"
-      ],
-      "J4_CHAN5": [
-        "4"
-      ],
-      "J4_CHAN6": [
-        "4"
-      ],
-      "J4_CHAN7": [
-        "4"
-      ],
-      "J4_CHAN8": [
-        "4"
-      ],
-      "J4_CHAN9": [
-        "4"
-      ],
-      "J1": [
-        "6"
-      ]
-    },
-    "OP_OUT_CHAN1": {
-      "J4_CHAN1": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN1": {
-      "J4_CHAN1": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN1": {
-      "J4_CHAN1": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN1": {
-      "J4_CHAN1": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN1": {
-      "J4_CHAN1": [
+      "J5_CHAN1": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN1": {
-      "J4_CHAN1": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN1": {
+      "J4_CHAN1": [
+        "5"
+      ],
       "J5_CHAN1": [
         "8"
       ]
     },
-    "_3V3_P_CHAN1": {
-      "J5_CHAN1": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN1": {
+      "J4_CHAN1": [
+        "6"
+      ],
       "J5_CHAN1": [
         "11"
       ]
     },
     "_P_IN_CHAN1": {
+      "J4_CHAN1": [
+        "7"
+      ],
       "J5_CHAN1": [
         "13"
       ]
     },
     "_VDD5_CHAN1": {
+      "J4_CHAN1": [
+        "9"
+      ],
       "J5_CHAN1": [
         "15"
       ]
     },
     "_STDN_CHAN1": {
+      "J4_CHAN1": [
+        "10"
+      ],
       "J5_CHAN1": [
         "16"
       ]
     },
     "_TEMP_CHAN1": {
+      "J4_CHAN1": [
+        "11"
+      ],
       "J5_CHAN1": [
         "17"
       ]
@@ -358,6 +322,11 @@
     "V_LASER_CHAN2": {
       "J4_CHAN2": [
         "2"
+      ],
+      "J5_CHAN2": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN2": {
@@ -381,67 +350,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN2": {
+    "_3V3_P_CHAN2": {
       "J4_CHAN2": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN2": {
-      "J4_CHAN2": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN2": {
-      "J4_CHAN2": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN2": {
-      "J4_CHAN2": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN2": {
-      "J4_CHAN2": [
+        "4"
+      ],
+      "J5_CHAN2": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN2": {
-      "J4_CHAN2": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN2": {
+      "J4_CHAN2": [
+        "5"
+      ],
       "J5_CHAN2": [
         "8"
       ]
     },
-    "_3V3_P_CHAN2": {
-      "J5_CHAN2": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN2": {
+      "J4_CHAN2": [
+        "6"
+      ],
       "J5_CHAN2": [
         "11"
       ]
     },
     "_P_IN_CHAN2": {
+      "J4_CHAN2": [
+        "7"
+      ],
       "J5_CHAN2": [
         "13"
       ]
     },
     "_VDD5_CHAN2": {
+      "J4_CHAN2": [
+        "9"
+      ],
       "J5_CHAN2": [
         "15"
       ]
     },
     "_STDN_CHAN2": {
+      "J4_CHAN2": [
+        "10"
+      ],
       "J5_CHAN2": [
         "16"
       ]
     },
     "_TEMP_CHAN2": {
+      "J4_CHAN2": [
+        "11"
+      ],
       "J5_CHAN2": [
         "17"
       ]
@@ -449,6 +409,11 @@
     "V_LASER_CHAN3": {
       "J4_CHAN3": [
         "2"
+      ],
+      "J5_CHAN3": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN3": {
@@ -472,67 +437,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN3": {
+    "_3V3_P_CHAN3": {
       "J4_CHAN3": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN3": {
-      "J4_CHAN3": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN3": {
-      "J4_CHAN3": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN3": {
-      "J4_CHAN3": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN3": {
-      "J4_CHAN3": [
+        "4"
+      ],
+      "J5_CHAN3": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN3": {
-      "J4_CHAN3": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN3": {
+      "J4_CHAN3": [
+        "5"
+      ],
       "J5_CHAN3": [
         "8"
       ]
     },
-    "_3V3_P_CHAN3": {
-      "J5_CHAN3": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN3": {
+      "J4_CHAN3": [
+        "6"
+      ],
       "J5_CHAN3": [
         "11"
       ]
     },
     "_P_IN_CHAN3": {
+      "J4_CHAN3": [
+        "7"
+      ],
       "J5_CHAN3": [
         "13"
       ]
     },
     "_VDD5_CHAN3": {
+      "J4_CHAN3": [
+        "9"
+      ],
       "J5_CHAN3": [
         "15"
       ]
     },
     "_STDN_CHAN3": {
+      "J4_CHAN3": [
+        "10"
+      ],
       "J5_CHAN3": [
         "16"
       ]
     },
     "_TEMP_CHAN3": {
+      "J4_CHAN3": [
+        "11"
+      ],
       "J5_CHAN3": [
         "17"
       ]
@@ -540,6 +496,11 @@
     "V_LASER_CHAN4": {
       "J4_CHAN4": [
         "2"
+      ],
+      "J5_CHAN4": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN4": {
@@ -563,67 +524,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN4": {
+    "_3V3_P_CHAN4": {
       "J4_CHAN4": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN4": {
-      "J4_CHAN4": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN4": {
-      "J4_CHAN4": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN4": {
-      "J4_CHAN4": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN4": {
-      "J4_CHAN4": [
+        "4"
+      ],
+      "J5_CHAN4": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN4": {
-      "J4_CHAN4": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN4": {
+      "J4_CHAN4": [
+        "5"
+      ],
       "J5_CHAN4": [
         "8"
       ]
     },
-    "_3V3_P_CHAN4": {
-      "J5_CHAN4": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN4": {
+      "J4_CHAN4": [
+        "6"
+      ],
       "J5_CHAN4": [
         "11"
       ]
     },
     "_P_IN_CHAN4": {
+      "J4_CHAN4": [
+        "7"
+      ],
       "J5_CHAN4": [
         "13"
       ]
     },
     "_VDD5_CHAN4": {
+      "J4_CHAN4": [
+        "9"
+      ],
       "J5_CHAN4": [
         "15"
       ]
     },
     "_STDN_CHAN4": {
+      "J4_CHAN4": [
+        "10"
+      ],
       "J5_CHAN4": [
         "16"
       ]
     },
     "_TEMP_CHAN4": {
+      "J4_CHAN4": [
+        "11"
+      ],
       "J5_CHAN4": [
         "17"
       ]
@@ -631,6 +583,11 @@
     "V_LASER_CHAN5": {
       "J4_CHAN5": [
         "2"
+      ],
+      "J5_CHAN5": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN5": {
@@ -654,67 +611,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN5": {
+    "_3V3_P_CHAN5": {
       "J4_CHAN5": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN5": {
-      "J4_CHAN5": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN5": {
-      "J4_CHAN5": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN5": {
-      "J4_CHAN5": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN5": {
-      "J4_CHAN5": [
+        "4"
+      ],
+      "J5_CHAN5": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN5": {
-      "J4_CHAN5": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN5": {
+      "J4_CHAN5": [
+        "5"
+      ],
       "J5_CHAN5": [
         "8"
       ]
     },
-    "_3V3_P_CHAN5": {
-      "J5_CHAN5": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN5": {
+      "J4_CHAN5": [
+        "6"
+      ],
       "J5_CHAN5": [
         "11"
       ]
     },
     "_P_IN_CHAN5": {
+      "J4_CHAN5": [
+        "7"
+      ],
       "J5_CHAN5": [
         "13"
       ]
     },
     "_VDD5_CHAN5": {
+      "J4_CHAN5": [
+        "9"
+      ],
       "J5_CHAN5": [
         "15"
       ]
     },
     "_STDN_CHAN5": {
+      "J4_CHAN5": [
+        "10"
+      ],
       "J5_CHAN5": [
         "16"
       ]
     },
     "_TEMP_CHAN5": {
+      "J4_CHAN5": [
+        "11"
+      ],
       "J5_CHAN5": [
         "17"
       ]
@@ -722,6 +670,11 @@
     "V_LASER_CHAN6": {
       "J4_CHAN6": [
         "2"
+      ],
+      "J5_CHAN6": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN6": {
@@ -745,67 +698,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN6": {
+    "_3V3_P_CHAN6": {
       "J4_CHAN6": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN6": {
-      "J4_CHAN6": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN6": {
-      "J4_CHAN6": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN6": {
-      "J4_CHAN6": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN6": {
-      "J4_CHAN6": [
+        "4"
+      ],
+      "J5_CHAN6": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN6": {
-      "J4_CHAN6": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN6": {
+      "J4_CHAN6": [
+        "5"
+      ],
       "J5_CHAN6": [
         "8"
       ]
     },
-    "_3V3_P_CHAN6": {
-      "J5_CHAN6": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN6": {
+      "J4_CHAN6": [
+        "6"
+      ],
       "J5_CHAN6": [
         "11"
       ]
     },
     "_P_IN_CHAN6": {
+      "J4_CHAN6": [
+        "7"
+      ],
       "J5_CHAN6": [
         "13"
       ]
     },
     "_VDD5_CHAN6": {
+      "J4_CHAN6": [
+        "9"
+      ],
       "J5_CHAN6": [
         "15"
       ]
     },
     "_STDN_CHAN6": {
+      "J4_CHAN6": [
+        "10"
+      ],
       "J5_CHAN6": [
         "16"
       ]
     },
     "_TEMP_CHAN6": {
+      "J4_CHAN6": [
+        "11"
+      ],
       "J5_CHAN6": [
         "17"
       ]
@@ -813,6 +757,11 @@
     "V_LASER_CHAN7": {
       "J4_CHAN7": [
         "2"
+      ],
+      "J5_CHAN7": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN7": {
@@ -836,67 +785,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN7": {
+    "_3V3_P_CHAN7": {
       "J4_CHAN7": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN7": {
-      "J4_CHAN7": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN7": {
-      "J4_CHAN7": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN7": {
-      "J4_CHAN7": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN7": {
-      "J4_CHAN7": [
+        "4"
+      ],
+      "J5_CHAN7": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN7": {
-      "J4_CHAN7": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN7": {
+      "J4_CHAN7": [
+        "5"
+      ],
       "J5_CHAN7": [
         "8"
       ]
     },
-    "_3V3_P_CHAN7": {
-      "J5_CHAN7": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN7": {
+      "J4_CHAN7": [
+        "6"
+      ],
       "J5_CHAN7": [
         "11"
       ]
     },
     "_P_IN_CHAN7": {
+      "J4_CHAN7": [
+        "7"
+      ],
       "J5_CHAN7": [
         "13"
       ]
     },
     "_VDD5_CHAN7": {
+      "J4_CHAN7": [
+        "9"
+      ],
       "J5_CHAN7": [
         "15"
       ]
     },
     "_STDN_CHAN7": {
+      "J4_CHAN7": [
+        "10"
+      ],
       "J5_CHAN7": [
         "16"
       ]
     },
     "_TEMP_CHAN7": {
+      "J4_CHAN7": [
+        "11"
+      ],
       "J5_CHAN7": [
         "17"
       ]
@@ -904,6 +844,11 @@
     "V_LASER_CHAN8": {
       "J4_CHAN8": [
         "2"
+      ],
+      "J5_CHAN8": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN8": {
@@ -927,67 +872,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN8": {
+    "_3V3_P_CHAN8": {
       "J4_CHAN8": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN8": {
-      "J4_CHAN8": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN8": {
-      "J4_CHAN8": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN8": {
-      "J4_CHAN8": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN8": {
-      "J4_CHAN8": [
+        "4"
+      ],
+      "J5_CHAN8": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN8": {
-      "J4_CHAN8": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN8": {
+      "J4_CHAN8": [
+        "5"
+      ],
       "J5_CHAN8": [
         "8"
       ]
     },
-    "_3V3_P_CHAN8": {
-      "J5_CHAN8": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN8": {
+      "J4_CHAN8": [
+        "6"
+      ],
       "J5_CHAN8": [
         "11"
       ]
     },
     "_P_IN_CHAN8": {
+      "J4_CHAN8": [
+        "7"
+      ],
       "J5_CHAN8": [
         "13"
       ]
     },
     "_VDD5_CHAN8": {
+      "J4_CHAN8": [
+        "9"
+      ],
       "J5_CHAN8": [
         "15"
       ]
     },
     "_STDN_CHAN8": {
+      "J4_CHAN8": [
+        "10"
+      ],
       "J5_CHAN8": [
         "16"
       ]
     },
     "_TEMP_CHAN8": {
+      "J4_CHAN8": [
+        "11"
+      ],
       "J5_CHAN8": [
         "17"
       ]
@@ -995,6 +931,11 @@
     "V_LASER_CHAN9": {
       "J4_CHAN9": [
         "2"
+      ],
+      "J5_CHAN9": [
+        "2",
+        "4",
+        "6"
       ]
     },
     "NetJ4_2_G_CHAN9": {
@@ -1018,67 +959,58 @@
         "9_G"
       ]
     },
-    "OP_OUT_CHAN9": {
+    "_3V3_P_CHAN9": {
       "J4_CHAN9": [
-        "5"
-      ]
-    },
-    "NetJ4_6_CHAN9": {
-      "J4_CHAN9": [
-        "6"
-      ]
-    },
-    "NetJ4_7_CHAN9": {
-      "J4_CHAN9": [
-        "7"
-      ]
-    },
-    "NetJ4_9_CHAN9": {
-      "J4_CHAN9": [
-        "9"
-      ]
-    },
-    "NetJ4_10_CHAN9": {
-      "J4_CHAN9": [
+        "4"
+      ],
+      "J5_CHAN9": [
         "10"
       ]
     },
-    "NetJ4_11_CHAN9": {
-      "J4_CHAN9": [
-        "11"
-      ]
-    },
     "_OP_O_CHAN9": {
+      "J4_CHAN9": [
+        "5"
+      ],
       "J5_CHAN9": [
         "8"
       ]
     },
-    "_3V3_P_CHAN9": {
-      "J5_CHAN9": [
-        "10"
-      ]
-    },
     "_P_OUT_CHAN9": {
+      "J4_CHAN9": [
+        "6"
+      ],
       "J5_CHAN9": [
         "11"
       ]
     },
     "_P_IN_CHAN9": {
+      "J4_CHAN9": [
+        "7"
+      ],
       "J5_CHAN9": [
         "13"
       ]
     },
     "_VDD5_CHAN9": {
+      "J4_CHAN9": [
+        "9"
+      ],
       "J5_CHAN9": [
         "15"
       ]
     },
     "_STDN_CHAN9": {
+      "J4_CHAN9": [
+        "10"
+      ],
       "J5_CHAN9": [
         "16"
       ]
     },
     "_TEMP_CHAN9": {
+      "J4_CHAN9": [
+        "11"
+      ],
       "J5_CHAN9": [
         "17"
       ]
@@ -1093,7 +1025,7 @@
         "1"
       ]
     },
-    "V_LASER_P": {
+    "CHANNEL_INTERFACE.V_LASER_P": {
       "J1": [
         "8",
         "10",
@@ -1101,7 +1033,12 @@
         "14"
       ]
     },
-    "VDD5_A": {
+    "CHANNEL_INTERFACE.3V3_P": {
+      "J1": [
+        "6"
+      ]
+    },
+    "CHANNEL_INTERFACE.VDD5_A": {
       "J1": [
         "2"
       ]
@@ -1259,19 +1196,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN1"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN1"
+          "net": "_OP_O_CHAN1"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN1"
+          "net": "_P_OUT_CHAN1"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN1"
+          "net": "_P_IN_CHAN1"
         },
         "8": {
           "name": "AGND",
@@ -1279,15 +1216,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN1"
+          "net": "_VDD5_CHAN1"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN1"
+          "net": "_STDN_CHAN1"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN1"
+          "net": "_TEMP_CHAN1"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN1",
@@ -1315,7 +1252,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN1"
         },
         "3": {
           "name": "PGND",
@@ -1323,7 +1260,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN1"
         },
         "5": {
           "name": "PGND",
@@ -1331,7 +1268,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN1"
         },
         "7": {
           "name": "PGND",
@@ -1401,19 +1338,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN2"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN2"
+          "net": "_OP_O_CHAN2"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN2"
+          "net": "_P_OUT_CHAN2"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN2"
+          "net": "_P_IN_CHAN2"
         },
         "8": {
           "name": "AGND",
@@ -1421,15 +1358,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN2"
+          "net": "_VDD5_CHAN2"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN2"
+          "net": "_STDN_CHAN2"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN2"
+          "net": "_TEMP_CHAN2"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN2",
@@ -1457,7 +1394,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN2"
         },
         "3": {
           "name": "PGND",
@@ -1465,7 +1402,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN2"
         },
         "5": {
           "name": "PGND",
@@ -1473,7 +1410,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN2"
         },
         "7": {
           "name": "PGND",
@@ -1543,19 +1480,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN3"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN3"
+          "net": "_OP_O_CHAN3"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN3"
+          "net": "_P_OUT_CHAN3"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN3"
+          "net": "_P_IN_CHAN3"
         },
         "8": {
           "name": "AGND",
@@ -1563,15 +1500,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN3"
+          "net": "_VDD5_CHAN3"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN3"
+          "net": "_STDN_CHAN3"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN3"
+          "net": "_TEMP_CHAN3"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN3",
@@ -1599,7 +1536,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN3"
         },
         "3": {
           "name": "PGND",
@@ -1607,7 +1544,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN3"
         },
         "5": {
           "name": "PGND",
@@ -1615,7 +1552,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN3"
         },
         "7": {
           "name": "PGND",
@@ -1685,19 +1622,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN4"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN4"
+          "net": "_OP_O_CHAN4"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN4"
+          "net": "_P_OUT_CHAN4"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN4"
+          "net": "_P_IN_CHAN4"
         },
         "8": {
           "name": "AGND",
@@ -1705,15 +1642,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN4"
+          "net": "_VDD5_CHAN4"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN4"
+          "net": "_STDN_CHAN4"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN4"
+          "net": "_TEMP_CHAN4"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN4",
@@ -1741,7 +1678,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN4"
         },
         "3": {
           "name": "PGND",
@@ -1749,7 +1686,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN4"
         },
         "5": {
           "name": "PGND",
@@ -1757,7 +1694,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN4"
         },
         "7": {
           "name": "PGND",
@@ -1827,19 +1764,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN5"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN5"
+          "net": "_OP_O_CHAN5"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN5"
+          "net": "_P_OUT_CHAN5"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN5"
+          "net": "_P_IN_CHAN5"
         },
         "8": {
           "name": "AGND",
@@ -1847,15 +1784,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN5"
+          "net": "_VDD5_CHAN5"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN5"
+          "net": "_STDN_CHAN5"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN5"
+          "net": "_TEMP_CHAN5"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN5",
@@ -1883,7 +1820,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN5"
         },
         "3": {
           "name": "PGND",
@@ -1891,7 +1828,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN5"
         },
         "5": {
           "name": "PGND",
@@ -1899,7 +1836,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN5"
         },
         "7": {
           "name": "PGND",
@@ -1969,19 +1906,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN6"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN6"
+          "net": "_OP_O_CHAN6"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN6"
+          "net": "_P_OUT_CHAN6"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN6"
+          "net": "_P_IN_CHAN6"
         },
         "8": {
           "name": "AGND",
@@ -1989,15 +1926,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN6"
+          "net": "_VDD5_CHAN6"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN6"
+          "net": "_STDN_CHAN6"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN6"
+          "net": "_TEMP_CHAN6"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN6",
@@ -2025,7 +1962,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN6"
         },
         "3": {
           "name": "PGND",
@@ -2033,7 +1970,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN6"
         },
         "5": {
           "name": "PGND",
@@ -2041,7 +1978,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN6"
         },
         "7": {
           "name": "PGND",
@@ -2111,19 +2048,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN7"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN7"
+          "net": "_OP_O_CHAN7"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN7"
+          "net": "_P_OUT_CHAN7"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN7"
+          "net": "_P_IN_CHAN7"
         },
         "8": {
           "name": "AGND",
@@ -2131,15 +2068,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN7"
+          "net": "_VDD5_CHAN7"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN7"
+          "net": "_STDN_CHAN7"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN7"
+          "net": "_TEMP_CHAN7"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN7",
@@ -2167,7 +2104,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN7"
         },
         "3": {
           "name": "PGND",
@@ -2175,7 +2112,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN7"
         },
         "5": {
           "name": "PGND",
@@ -2183,7 +2120,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN7"
         },
         "7": {
           "name": "PGND",
@@ -2253,19 +2190,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN8"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN8"
+          "net": "_OP_O_CHAN8"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN8"
+          "net": "_P_OUT_CHAN8"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN8"
+          "net": "_P_IN_CHAN8"
         },
         "8": {
           "name": "AGND",
@@ -2273,15 +2210,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN8"
+          "net": "_VDD5_CHAN8"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN8"
+          "net": "_STDN_CHAN8"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN8"
+          "net": "_TEMP_CHAN8"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN8",
@@ -2309,7 +2246,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN8"
         },
         "3": {
           "name": "PGND",
@@ -2317,7 +2254,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN8"
         },
         "5": {
           "name": "PGND",
@@ -2325,7 +2262,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN8"
         },
         "7": {
           "name": "PGND",
@@ -2395,19 +2332,19 @@
         },
         "4": {
           "name": "3V3_P",
-          "net": "3V3_P"
+          "net": "_3V3_P_CHAN9"
         },
         "5": {
           "name": "OP_OUT",
-          "net": "OP_OUT_CHAN9"
+          "net": "_OP_O_CHAN9"
         },
         "6": {
           "name": "PULSE_OUT",
-          "net": "NetJ4_6_CHAN9"
+          "net": "_P_OUT_CHAN9"
         },
         "7": {
           "name": "PULSE_IN",
-          "net": "NetJ4_7_CHAN9"
+          "net": "_P_IN_CHAN9"
         },
         "8": {
           "name": "AGND",
@@ -2415,15 +2352,15 @@
         },
         "9": {
           "name": "V5V",
-          "net": "NetJ4_9_CHAN9"
+          "net": "_VDD5_CHAN9"
         },
         "10": {
           "name": "STDN",
-          "net": "NetJ4_10_CHAN9"
+          "net": "_STDN_CHAN9"
         },
         "11": {
           "name": "TEMP",
-          "net": "NetJ4_11_CHAN9"
+          "net": "_TEMP_CHAN9"
         },
         "1_G": "PGND",
         "2_G": "NetJ4_2_G_CHAN9",
@@ -2451,7 +2388,7 @@
         },
         "2": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN9"
         },
         "3": {
           "name": "PGND",
@@ -2459,7 +2396,7 @@
         },
         "4": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN9"
         },
         "5": {
           "name": "PGND",
@@ -2467,7 +2404,7 @@
         },
         "6": {
           "name": "V_LASER",
-          "net": ""
+          "net": "V_LASER_CHAN9"
         },
         "7": {
           "name": "PGND",
@@ -2524,19 +2461,19 @@
     "J1": {
       "pins": {
         "1": "STDN_A",
-        "2": "VDD5_A",
+        "2": "CHANNEL_INTERFACE.VDD5_A",
         "3": "PGND",
         "4": "PULSE_IN_A",
         "5": "PGND",
-        "6": "3V3_P",
+        "6": "CHANNEL_INTERFACE.3V3_P",
         "7": "PGND",
-        "8": "V_LASER_P",
+        "8": "CHANNEL_INTERFACE.V_LASER_P",
         "9": "PGND",
-        "10": "V_LASER_P",
+        "10": "CHANNEL_INTERFACE.V_LASER_P",
         "11": "PGND",
-        "12": "V_LASER_P",
+        "12": "CHANNEL_INTERFACE.V_LASER_P",
         "13": "PGND",
-        "14": "V_LASER_P"
+        "14": "CHANNEL_INTERFACE.V_LASER_P"
       },
       "description": "Connector FPC, 14 pin, 1mm pitch",
       "comment": "FPC_conn"

--- a/test/golden/altium/pca10056.json
+++ b/test/golden/altium/pca10056.json
@@ -690,6 +690,15 @@
     "P1.10": {
       "U1": [
         "A20"
+      ],
+      "P16": [
+        "2"
+      ],
+      "P10": [
+        "1"
+      ],
+      "P4": [
+        "1"
       ]
     },
     "P0.00/XL1": {
@@ -717,6 +726,18 @@
     "P0.28/AIN4": {
       "U1": [
         "B11"
+      ],
+      "P14": [
+        "6"
+      ],
+      "TP44": [
+        "1"
+      ],
+      "P2": [
+        "3"
+      ],
+      "P8": [
+        "3"
       ]
     },
     "NetL2_2": {
@@ -758,11 +779,29 @@
     "P1.01": {
       "U1": [
         "Y23"
+      ],
+      "P15": [
+        "2"
+      ],
+      "P9": [
+        "1"
+      ],
+      "P3": [
+        "1"
       ]
     },
     "D_N": {
       "U1": [
         "AD4"
+      ],
+      "J3": [
+        "2"
+      ],
+      "D60": [
+        "2"
+      ],
+      "TP13": [
+        "1"
       ]
     },
     "P0.19": {
@@ -832,6 +871,15 @@
     "D_P": {
       "U1": [
         "AD6"
+      ],
+      "J3": [
+        "3"
+      ],
+      "D60": [
+        "3"
+      ],
+      "TP14": [
+        "1"
       ]
     },
     "P0.20": {
@@ -884,6 +932,9 @@
       ],
       "SW3": [
         "2"
+      ],
+      "P24": [
+        "14"
       ]
     },
     "P0.09/NFC1": {
@@ -900,6 +951,12 @@
     "P1.09": {
       "U1": [
         "R1"
+      ],
+      "P25": [
+        "20"
+      ],
+      "P24": [
+        "17"
       ]
     },
     "P0.25": {
@@ -908,6 +965,9 @@
       ],
       "SW4": [
         "2"
+      ],
+      "P24": [
+        "15"
       ]
     },
     "P1.00": {
@@ -921,7 +981,11 @@
         "6"
       ],
       "P25": [
-        "6"
+        "6",
+        "14"
+      ],
+      "P24": [
+        "16"
       ]
     },
     "P0.26": {
@@ -952,6 +1016,18 @@
       ],
       "U8": [
         "15"
+      ],
+      "P14": [
+        "4"
+      ],
+      "TP43": [
+        "1"
+      ],
+      "P2": [
+        "2"
+      ],
+      "P8": [
+        "2"
       ]
     },
     "P0.05/AIN3": {
@@ -960,6 +1036,15 @@
       ],
       "SB51": [
         "1"
+      ],
+      "P17": [
+        "6"
+      ],
+      "P12": [
+        "3"
+      ],
+      "P6": [
+        "3"
       ]
     },
     "P0.06": {
@@ -968,6 +1053,15 @@
       ],
       "SB53": [
         "1"
+      ],
+      "P17": [
+        "8"
+      ],
+      "P12": [
+        "4"
+      ],
+      "P6": [
+        "4"
       ]
     },
     "P0.07": {
@@ -976,6 +1070,18 @@
       ],
       "U8": [
         "1"
+      ],
+      "P25": [
+        "12"
+      ],
+      "P17": [
+        "10"
+      ],
+      "P12": [
+        "5"
+      ],
+      "P6": [
+        "5"
       ]
     },
     "P0.08": {
@@ -984,6 +1090,15 @@
       ],
       "SB52": [
         "1"
+      ],
+      "P17": [
+        "12"
+      ],
+      "P12": [
+        "6"
+      ],
+      "P6": [
+        "6"
       ]
     },
     "P1.08": {
@@ -992,6 +1107,15 @@
       ],
       "U8": [
         "7"
+      ],
+      "P15": [
+        "16"
+      ],
+      "P9": [
+        "8"
+      ],
+      "P3": [
+        "8"
       ]
     },
     "P0.13": {
@@ -1000,6 +1124,9 @@
       ],
       "SB5": [
         "1"
+      ],
+      "P24": [
+        "3"
       ]
     },
     "P0.14": {
@@ -1008,6 +1135,9 @@
       ],
       "SB6": [
         "1"
+      ],
+      "P24": [
+        "4"
       ]
     },
     "P0.15": {
@@ -1016,6 +1146,9 @@
       ],
       "SB7": [
         "1"
+      ],
+      "P24": [
+        "5"
       ]
     },
     "P0.16": {
@@ -1024,6 +1157,9 @@
       ],
       "SB8": [
         "1"
+      ],
+      "P24": [
+        "6"
       ]
     },
     "P0.11": {
@@ -1032,6 +1168,12 @@
       ],
       "U8": [
         "5"
+      ],
+      "P25": [
+        "18"
+      ],
+      "P24": [
+        "1"
       ]
     },
     "P0.12": {
@@ -1040,6 +1182,12 @@
       ],
       "U8": [
         "9"
+      ],
+      "P25": [
+        "16"
+      ],
+      "P24": [
+        "2"
       ]
     },
     "P0.17": {
@@ -1074,6 +1222,9 @@
       ],
       "P25": [
         "10"
+      ],
+      "P24": [
+        "8"
       ]
     },
     "NetC9_1": {
@@ -1098,51 +1249,153 @@
     "P0.03/AIN1": {
       "U1": [
         "B13"
+      ],
+      "P14": [
+        "2"
+      ],
+      "TP42": [
+        "1"
+      ],
+      "P2": [
+        "1"
+      ],
+      "P8": [
+        "1"
       ]
     },
     "P0.02/AIN0": {
       "U1": [
         "A12"
+      ],
+      "P16": [
+        "16"
+      ],
+      "P10": [
+        "8"
+      ],
+      "P4": [
+        "8"
       ]
     },
     "P0.29/AIN5": {
       "U1": [
         "A10"
+      ],
+      "P14": [
+        "8"
+      ],
+      "TP45": [
+        "1"
+      ],
+      "P2": [
+        "4"
+      ],
+      "P8": [
+        "4"
       ]
     },
     "P0.30/AIN6": {
       "U1": [
         "B9"
+      ],
+      "P14": [
+        "10"
+      ],
+      "TP46": [
+        "1"
+      ],
+      "P2": [
+        "5"
+      ],
+      "P8": [
+        "5"
       ]
     },
     "P0.31/AIN7": {
       "U1": [
         "A8"
+      ],
+      "P14": [
+        "12"
+      ],
+      "TP47": [
+        "1"
+      ],
+      "P2": [
+        "6"
+      ],
+      "P8": [
+        "6"
       ]
     },
     "P1.02": {
       "U1": [
         "W24"
+      ],
+      "P15": [
+        "4"
+      ],
+      "P9": [
+        "2"
+      ],
+      "P3": [
+        "2"
       ]
     },
     "P1.03": {
       "U1": [
         "V23"
+      ],
+      "P15": [
+        "6"
+      ],
+      "P9": [
+        "3"
+      ],
+      "P3": [
+        "3"
       ]
     },
     "P1.04": {
       "U1": [
         "U24"
+      ],
+      "P15": [
+        "8"
+      ],
+      "P9": [
+        "4"
+      ],
+      "P3": [
+        "4"
       ]
     },
     "P1.05": {
       "U1": [
         "T23"
+      ],
+      "P15": [
+        "10"
+      ],
+      "P9": [
+        "5"
+      ],
+      "P3": [
+        "5"
       ]
     },
     "P1.06": {
       "U1": [
         "R24"
+      ],
+      "P15": [
+        "12"
+      ],
+      "P9": [
+        "6"
+      ],
+      "P3": [
+        "6"
       ]
     },
     "P1.07": {
@@ -1151,31 +1404,103 @@
       ],
       "U8": [
         "3"
+      ],
+      "P15": [
+        "14"
+      ],
+      "P9": [
+        "7"
+      ],
+      "P3": [
+        "7"
       ]
     },
     "P1.11": {
       "U1": [
         "B19"
+      ],
+      "P16": [
+        "4"
+      ],
+      "P10": [
+        "2"
+      ],
+      "P4": [
+        "2"
       ]
     },
     "P1.12": {
       "U1": [
         "B17"
+      ],
+      "P16": [
+        "6"
+      ],
+      "P10": [
+        "3"
+      ],
+      "P4": [
+        "3"
       ]
     },
     "P1.13": {
       "U1": [
         "A16"
+      ],
+      "P11": [
+        "4"
+      ],
+      "P16": [
+        "8"
+      ],
+      "P5": [
+        "4"
+      ],
+      "P10": [
+        "4"
+      ],
+      "P4": [
+        "4"
       ]
     },
     "P1.14": {
       "U1": [
         "B15"
+      ],
+      "P11": [
+        "1"
+      ],
+      "P16": [
+        "10"
+      ],
+      "P5": [
+        "1"
+      ],
+      "P10": [
+        "5"
+      ],
+      "P4": [
+        "5"
       ]
     },
     "P1.15": {
       "U1": [
         "A14"
+      ],
+      "P11": [
+        "3"
+      ],
+      "P16": [
+        "12"
+      ],
+      "P5": [
+        "3"
+      ],
+      "P10": [
+        "6"
+      ],
+      "P4": [
+        "6"
       ]
     },
     "NetC13_1": {
@@ -1219,46 +1544,77 @@
     "P0.01": {
       "SB3": [
         "2"
+      ],
+      "P17": [
+        "4"
+      ],
+      "P12": [
+        "2"
+      ],
+      "P6": [
+        "2"
       ]
     },
     "P0.00": {
       "SB4": [
         "2"
-      ]
-    },
-    "NetSB23_2": {
-      "SB23": [
+      ],
+      "P17": [
         "2"
+      ],
+      "P12": [
+        "1"
+      ],
+      "P6": [
+        "1"
       ]
     },
     "NetSB15_2": {
       "SB15": [
         "2"
+      ],
+      "U3": [
+        "3"
       ]
     },
     "NetSB11_2": {
       "SB11": [
         "2"
+      ],
+      "U3": [
+        "6"
       ]
     },
     "NetSB12_2": {
       "SB12": [
         "2"
+      ],
+      "U3": [
+        "5"
       ]
     },
     "NetSB13_2": {
       "SB13": [
         "2"
+      ],
+      "U3": [
+        "1"
       ]
     },
     "NetSB14_2": {
       "SB14": [
+        "2"
+      ],
+      "U3": [
         "2"
       ]
     },
     "NetSB10_2": {
       "SB10": [
         "2"
+      ],
+      "U3": [
+        "7"
       ]
     },
     "SDA": {
@@ -1267,6 +1623,15 @@
       ],
       "U7": [
         "8"
+      ],
+      "P16": [
+        "18"
+      ],
+      "P10": [
+        "9"
+      ],
+      "P4": [
+        "9"
       ]
     },
     "SCL": {
@@ -1275,41 +1640,15 @@
       ],
       "U7": [
         "12"
-      ]
-    },
-    "NetSB21_2": {
-      "SB21": [
-        "2"
-      ]
-    },
-    "NetSB22_2": {
-      "SB22": [
-        "2"
-      ]
-    },
-    "NetSB24_2": {
-      "SB24": [
-        "2"
-      ]
-    },
-    "NetSB20_2": {
-      "SB20": [
-        "2"
-      ]
-    },
-    "NetSB25_2": {
-      "SB25": [
-        "2"
-      ]
-    },
-    "NetR43_1": {
-      "R43": [
-        "1"
-      ]
-    },
-    "NetR45_1": {
-      "R45": [
-        "1"
+      ],
+      "P16": [
+        "20"
+      ],
+      "P10": [
+        "10"
+      ],
+      "P4": [
+        "10"
       ]
     },
     "VCOM_CTS": {
@@ -1372,11 +1711,6 @@
         "AK30"
       ]
     },
-    "NetR16_2": {
-      "R16": [
-        "2"
-      ]
-    },
     "SWD1_CLK": {
       "R17": [
         "1"
@@ -1393,14 +1727,6 @@
         "AK24"
       ]
     },
-    "NetQ3_1": {
-      "R20": [
-        "1"
-      ],
-      "Q3": [
-        "1"
-      ]
-    },
     "SWD1_SWO": {
       "R18": [
         "1"
@@ -1415,21 +1741,6 @@
       ],
       "U2": [
         "AK22"
-      ]
-    },
-    "NetR17_2": {
-      "R17": [
-        "2"
-      ]
-    },
-    "NetR18_2": {
-      "R18": [
-        "2"
-      ]
-    },
-    "NetR19_2": {
-      "R19": [
-        "2"
       ]
     },
     "SWD3_IO": {
@@ -1484,11 +1795,6 @@
         "B16"
       ]
     },
-    "NetR11_2": {
-      "R11": [
-        "2"
-      ]
-    },
     "SWD0_CLK": {
       "R12": [
         "1"
@@ -1521,29 +1827,32 @@
         "3"
       ]
     },
-    "NetR12_2": {
-      "R12": [
-        "2"
-      ]
-    },
-    "NetR14_2": {
-      "R14": [
-        "2"
-      ]
-    },
-    "NetR15_2": {
-      "R15": [
-        "2"
-      ]
-    },
     "IMCU_N": {
       "U2": [
         "B4"
+      ],
+      "D61": [
+        "2"
+      ],
+      "TP10": [
+        "1"
+      ],
+      "J2": [
+        "2"
       ]
     },
     "IMCU_P": {
       "U2": [
         "B2"
+      ],
+      "D61": [
+        "3"
+      ],
+      "TP9": [
+        "1"
+      ],
+      "J2": [
+        "3"
       ]
     },
     "NetC29_2": {
@@ -2272,6 +2581,12 @@
       ],
       "C47": [
         "2"
+      ],
+      "J5": [
+        "4"
+      ],
+      "TP18": [
+        "1"
       ]
     },
     "NFC1": {
@@ -2279,6 +2594,12 @@
         "1"
       ],
       "C46": [
+        "1"
+      ],
+      "J5": [
+        "2"
+      ],
+      "TP17": [
         "1"
       ]
     },
@@ -2406,57 +2727,6 @@
         "8"
       ]
     },
-    "NetP10_5": {
-      "P11": [
-        "1"
-      ],
-      "P16": [
-        "10"
-      ],
-      "P5": [
-        "1"
-      ],
-      "P10": [
-        "5"
-      ],
-      "P4": [
-        "5"
-      ]
-    },
-    "NetP10_6": {
-      "P11": [
-        "3"
-      ],
-      "P16": [
-        "12"
-      ],
-      "P5": [
-        "3"
-      ],
-      "P10": [
-        "6"
-      ],
-      "P4": [
-        "6"
-      ]
-    },
-    "NetP10_4": {
-      "P11": [
-        "4"
-      ],
-      "P16": [
-        "8"
-      ],
-      "P5": [
-        "4"
-      ],
-      "P10": [
-        "4"
-      ],
-      "P4": [
-        "4"
-      ]
-    },
     "NetP11_6": {
       "P11": [
         "6"
@@ -2471,299 +2741,6 @@
         "6"
       ]
     },
-    "NetP14_2": {
-      "P14": [
-        "2"
-      ],
-      "TP42": [
-        "1"
-      ],
-      "P2": [
-        "1"
-      ],
-      "P8": [
-        "1"
-      ]
-    },
-    "NetP14_4": {
-      "P14": [
-        "4"
-      ],
-      "TP43": [
-        "1"
-      ],
-      "P2": [
-        "2"
-      ],
-      "P8": [
-        "2"
-      ]
-    },
-    "NetP14_8": {
-      "P14": [
-        "8"
-      ],
-      "TP45": [
-        "1"
-      ],
-      "P2": [
-        "4"
-      ],
-      "P8": [
-        "4"
-      ]
-    },
-    "NetP14_10": {
-      "P14": [
-        "10"
-      ],
-      "TP46": [
-        "1"
-      ],
-      "P2": [
-        "5"
-      ],
-      "P8": [
-        "5"
-      ]
-    },
-    "NetP14_12": {
-      "P14": [
-        "12"
-      ],
-      "TP47": [
-        "1"
-      ],
-      "P2": [
-        "6"
-      ],
-      "P8": [
-        "6"
-      ]
-    },
-    "NetP14_6": {
-      "P14": [
-        "6"
-      ],
-      "TP44": [
-        "1"
-      ],
-      "P2": [
-        "3"
-      ],
-      "P8": [
-        "3"
-      ]
-    },
-    "NetP15_2": {
-      "P15": [
-        "2"
-      ],
-      "P9": [
-        "1"
-      ],
-      "P3": [
-        "1"
-      ]
-    },
-    "NetP15_4": {
-      "P15": [
-        "4"
-      ],
-      "P9": [
-        "2"
-      ],
-      "P3": [
-        "2"
-      ]
-    },
-    "NetP15_8": {
-      "P15": [
-        "8"
-      ],
-      "P9": [
-        "4"
-      ],
-      "P3": [
-        "4"
-      ]
-    },
-    "NetP15_10": {
-      "P15": [
-        "10"
-      ],
-      "P9": [
-        "5"
-      ],
-      "P3": [
-        "5"
-      ]
-    },
-    "NetP15_12": {
-      "P15": [
-        "12"
-      ],
-      "P9": [
-        "6"
-      ],
-      "P3": [
-        "6"
-      ]
-    },
-    "NetP15_14": {
-      "P15": [
-        "14"
-      ],
-      "P9": [
-        "7"
-      ],
-      "P3": [
-        "7"
-      ]
-    },
-    "NetP15_6": {
-      "P15": [
-        "6"
-      ],
-      "P9": [
-        "3"
-      ],
-      "P3": [
-        "3"
-      ]
-    },
-    "NetP15_16": {
-      "P15": [
-        "16"
-      ],
-      "P9": [
-        "8"
-      ],
-      "P3": [
-        "8"
-      ]
-    },
-    "NetP10_1": {
-      "P16": [
-        "2"
-      ],
-      "P10": [
-        "1"
-      ],
-      "P4": [
-        "1"
-      ]
-    },
-    "NetP10_2": {
-      "P16": [
-        "4"
-      ],
-      "P10": [
-        "2"
-      ],
-      "P4": [
-        "2"
-      ]
-    },
-    "NetP10_3": {
-      "P16": [
-        "6"
-      ],
-      "P10": [
-        "3"
-      ],
-      "P4": [
-        "3"
-      ]
-    },
-    "NetP10_8": {
-      "P16": [
-        "16"
-      ],
-      "P10": [
-        "8"
-      ],
-      "P4": [
-        "8"
-      ]
-    },
-    "NetP10_9": {
-      "P16": [
-        "18"
-      ],
-      "P10": [
-        "9"
-      ],
-      "P4": [
-        "9"
-      ]
-    },
-    "NetP10_10": {
-      "P16": [
-        "20"
-      ],
-      "P10": [
-        "10"
-      ],
-      "P4": [
-        "10"
-      ]
-    },
-    "NetP12_1": {
-      "P17": [
-        "2"
-      ],
-      "P12": [
-        "1"
-      ],
-      "P6": [
-        "1"
-      ]
-    },
-    "NetP12_2": {
-      "P17": [
-        "4"
-      ],
-      "P12": [
-        "2"
-      ],
-      "P6": [
-        "2"
-      ]
-    },
-    "NetP12_4": {
-      "P17": [
-        "8"
-      ],
-      "P12": [
-        "4"
-      ],
-      "P6": [
-        "4"
-      ]
-    },
-    "NetP12_5": {
-      "P17": [
-        "10"
-      ],
-      "P12": [
-        "5"
-      ],
-      "P6": [
-        "5"
-      ]
-    },
-    "NetP12_6": {
-      "P17": [
-        "12"
-      ],
-      "P12": [
-        "6"
-      ],
-      "P6": [
-        "6"
-      ]
-    },
     "NetP12_7": {
       "P17": [
         "14"
@@ -2773,17 +2750,9 @@
       ],
       "P6": [
         "7"
-      ]
-    },
-    "NetP12_3": {
-      "P17": [
-        "6"
       ],
-      "P12": [
-        "3"
-      ],
-      "P6": [
-        "3"
+      "R43": [
+        "1"
       ]
     },
     "NetP12_8": {
@@ -2795,6 +2764,9 @@
       ],
       "P6": [
         "8"
+      ],
+      "R45": [
+        "1"
       ]
     },
     "VDBG": {
@@ -2825,17 +2797,6 @@
         "2"
       ]
     },
-    "NetD61_2": {
-      "D61": [
-        "2"
-      ],
-      "TP10": [
-        "1"
-      ],
-      "J2": [
-        "2"
-      ]
-    },
     "NetC63_1": {
       "D61": [
         "4"
@@ -2857,17 +2818,6 @@
       ],
       "C63": [
         "1"
-      ]
-    },
-    "NetD61_3": {
-      "D61": [
-        "3"
-      ],
-      "TP9": [
-        "1"
-      ],
-      "J2": [
-        "3"
       ]
     },
     "NetFB63_1": {
@@ -2892,62 +2842,81 @@
     "NetP19_2": {
       "P19": [
         "2"
+      ],
+      "R11": [
+        "2"
       ]
     },
     "NetP19_4": {
       "P19": [
         "4"
+      ],
+      "R12": [
+        "2"
       ]
     },
     "NetP19_10": {
       "P19": [
         "10"
+      ],
+      "R15": [
+        "2"
       ]
     },
     "NetP19_6": {
       "P19": [
         "6"
-      ]
-    },
-    "NetP25_12": {
-      "P25": [
-        "12"
-      ]
-    },
-    "NetP25_14": {
-      "P25": [
-        "14"
-      ]
-    },
-    "NetP25_16": {
-      "P25": [
-        "16"
-      ]
-    },
-    "NetP25_18": {
-      "P25": [
-        "18"
-      ]
-    },
-    "NetP25_20": {
-      "P25": [
-        "20"
-      ]
-    },
-    "NetJ5_2": {
-      "J5": [
+      ],
+      "R14": [
         "2"
-      ],
-      "TP17": [
-        "1"
       ]
     },
-    "NetJ5_4": {
-      "J5": [
-        "4"
+    "NetP24_7": {
+      "P24": [
+        "7"
       ],
-      "TP18": [
-        "1"
+      "SB23": [
+        "2"
+      ]
+    },
+    "NetP24_9": {
+      "P24": [
+        "9"
+      ],
+      "SB21": [
+        "2"
+      ]
+    },
+    "NetP24_10": {
+      "P24": [
+        "10"
+      ],
+      "SB22": [
+        "2"
+      ]
+    },
+    "NetP24_11": {
+      "P24": [
+        "11"
+      ],
+      "SB24": [
+        "2"
+      ]
+    },
+    "NetP24_12": {
+      "P24": [
+        "12"
+      ],
+      "SB25": [
+        "2"
+      ]
+    },
+    "NetP24_13": {
+      "P24": [
+        "13"
+      ],
+      "SB20": [
+        "2"
       ]
     },
     "NetC66_2": {
@@ -2984,28 +2953,6 @@
         "2"
       ],
       "TP15": [
-        "1"
-      ]
-    },
-    "NetD60_2": {
-      "J3": [
-        "2"
-      ],
-      "D60": [
-        "2"
-      ],
-      "TP13": [
-        "1"
-      ]
-    },
-    "NetD60_3": {
-      "J3": [
-        "3"
-      ],
-      "D60": [
-        "3"
-      ],
-      "TP14": [
         "1"
       ]
     },
@@ -3089,6 +3036,12 @@
       ],
       "P20": [
         "3"
+      ],
+      "R20": [
+        "1"
+      ],
+      "Q3": [
+        "1"
       ]
     },
     "NetP20_4": {
@@ -3097,6 +3050,9 @@
       ],
       "P20": [
         "4"
+      ],
+      "R16": [
+        "2"
       ]
     },
     "NetP20_5": {
@@ -3105,6 +3061,9 @@
       ],
       "P20": [
         "5"
+      ],
+      "R17": [
+        "2"
       ]
     },
     "NetP20_6": {
@@ -3113,6 +3072,9 @@
       ],
       "P20": [
         "6"
+      ],
+      "R18": [
+        "2"
       ]
     },
     "NetP20_7": {
@@ -3121,6 +3083,9 @@
       ],
       "P20": [
         "7"
+      ],
+      "R19": [
+        "2"
       ]
     },
     "NetP20_8": {
@@ -3692,31 +3657,29 @@
   },
   "components": {
     "Fid1": {
+      "pins": {},
       "mpn": "N.A.",
       "description": "Fiducial Mark",
-      "pins": {},
       "comment": "Fiducial mark",
       "value": "N.A."
     },
     "Fid2": {
+      "pins": {},
       "mpn": "N.A.",
       "description": "Fiducial Mark",
-      "pins": {},
       "comment": "Fiducial mark",
       "value": "N.A."
     },
     "C23": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±0.1pF",
       "pins": {
         "1": "ANT",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±0.1pF",
       "value": "1.2pF"
     },
     "J1": {
-      "mpn": "MM8130-2600",
-      "description": "Coaxial Connector with Switch",
       "pins": {
         "1": {
           "name": "IN",
@@ -3731,11 +3694,11 @@
           "net": "ANT"
         }
       },
+      "mpn": "MM8130-2600",
+      "description": "Coaxial Connector with Switch",
       "value": "MM8130-2600"
     },
     "U1": {
-      "mpn": "nRF52840-QIAAF0",
-      "description": "Multi-protocol Bluetooth Low Energy, IEEE 802.15.4, ANT and 2.4GHz proprietary system-on-chip",
       "pins": {
         "74": {
           "name": "GND",
@@ -4034,11 +3997,11 @@
           "net": "NetC13_1"
         }
       },
+      "mpn": "nRF52840-QIAAF0",
+      "description": "Multi-protocol Bluetooth Low Energy, IEEE 802.15.4, ANT and 2.4GHz proprietary system-on-chip",
       "value": "nRF52840-QIAA"
     },
     "X1": {
-      "mpn": "MP12308",
-      "description": "XTAL SMD 2016, 32MHz, Cl=8pF, Tol: ±10ppm, Stab: ±15ppm, -30°C ~ 85°C, ESR: 50ohm max",
       "pins": {
         "1": {
           "name": "inp",
@@ -4057,218 +4020,218 @@
           "net": ""
         }
       },
+      "mpn": "MP12308",
+      "description": "XTAL SMD 2016, 32MHz, Cl=8pF, Tol: ±10ppm, Stab: ±15ppm, -30°C ~ 85°C, ESR: 50ohm max",
       "value": "32MHz"
     },
     "C1": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±2%",
       "pins": {
         "1": "XC1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±2%",
       "value": "12pF"
     },
     "C2": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±2%",
       "pins": {
         "1": "XC2",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±2%",
       "value": "12pF"
     },
     "C11": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±5%",
       "pins": {
         "1": "DEC3",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±5%",
       "value": "100pF"
     },
     "C5": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "DEC1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "100nF"
     },
     "C20": {
-      "mpn": "CL10B475KQ8NQNC",
-      "description": "Capacitor, X7R, ±10%, 6.3V",
       "pins": {
         "1": "NetC20_1",
         "2": "GND"
       },
+      "mpn": "CL10B475KQ8NQNC",
+      "description": "Capacitor, X7R, ±10%, 6.3V",
       "value": "4.7µF"
     },
     "L2": {
-      "mpn": "MLZ1608M100WTD25",
-      "description": "Inductor, 250mA, ±20%, 1.05ohm. -55°C ~ 125°C",
       "pins": {
         "1": "NetL2_1",
         "2": "NetL2_2"
       },
+      "mpn": "MLZ1608M100WTD25",
+      "description": "Inductor, 250mA, ±20%, 1.05ohm. -55°C ~ 125°C",
       "value": "10µH"
     },
     "C15": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "GND",
         "2": "DEC4_6"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "1.0µF"
     },
     "C3": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±5%",
       "pins": {
         "1": "GND",
         "2": "NetC3_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±5%",
       "value": "0.8pF"
     },
     "C10": {
-      "mpn": "N.A.",
       "pins": {
         "1": "GND",
         "2": "DEC4_6"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "C18": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±2%",
       "pins": {
         "1": "GND",
         "2": "NetC18_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±2%",
       "value": "12pF"
     },
     "C17": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±2%",
       "pins": {
         "1": "GND",
         "2": "NetC17_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±2%",
       "value": "12pF"
     },
     "L4": {
-      "mpn": "MLZ1608M100WTD25",
-      "description": "Inductor, 250mA, ±20%, 1.05ohm. -55°C ~ 125°C",
       "pins": {
         "1": "VDD_nRF",
         "2": "NetL4_2"
       },
+      "mpn": "MLZ1608M100WTD25",
+      "description": "Inductor, 250mA, ±20%, 1.05ohm. -55°C ~ 125°C",
       "value": "10µH"
     },
     "C7": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "VDD_nRF",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "100nF"
     },
     "C21": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7S, ±10%, 10V",
       "pins": {
         "1": "VBUS_nRF",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7S, ±10%, 10V",
       "value": "4.7µF"
     },
     "C8": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "VDD_nRF",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "100nF"
     },
     "C9": {
-      "mpn": "N.A.",
       "pins": {
         "1": "NetC9_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "C12": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "VDD_nRF",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "100nF"
     },
     "C13": {
-      "mpn": "N.A.",
       "pins": {
         "1": "NetC13_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "C19": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7S, ±10%, 10V",
       "pins": {
         "1": "VDD_HV",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7S, ±10%, 10V",
       "value": "4.7µF"
     },
     "C4": {
-      "mpn": "N.A.",
-      "description": "Capacitor, C0G, ±0.05pF, 50V",
       "pins": {
         "1": "GND",
         "2": "RF"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, C0G, ±0.05pF, 50V",
       "value": "0.5pF"
     },
     "C14": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "VDD_nRF",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "1.0µF"
     },
     "C6": {
-      "mpn": "CL10B475KQ8NQNC",
-      "description": "Capacitor, X7R, ±10%, 6.3V",
       "pins": {
         "1": "VDD_nRF",
         "2": "GND"
       },
+      "mpn": "CL10B475KQ8NQNC",
+      "description": "Capacitor, X7R, ±10%, 6.3V",
       "value": "4.7µF"
     },
     "C16": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%, 25V",
       "pins": {
         "1": "DEC4_6",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%, 25V",
       "value": "47nF"
     },
     "SB3": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4279,11 +4242,11 @@
           "net": "P0.01"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB4": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4294,11 +4257,11 @@
           "net": "P0.00"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB1": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4309,11 +4272,11 @@
           "net": "P0.01/XL2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB2": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4324,11 +4287,11 @@
           "net": "P0.00/XL1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "X2": {
-      "mpn": "NX3215SA-32.768K-STD-MUA-9",
-      "description": "XTAL SMD 3215, 32.768kHz, 9pF, ±20ppm",
       "pins": {
         "1": {
           "name": "inp",
@@ -4339,20 +4302,20 @@
           "net": "NetC18_2"
         }
       },
+      "mpn": "NX3215SA-32.768K-STD-MUA-9",
+      "description": "XTAL SMD 3215, 32.768kHz, 9pF, ±20ppm",
       "value": "32.768kHz"
     },
     "C22": {
-      "mpn": "N.A.",
       "pins": {
         "1": "RF",
         "2": "GND"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "SB23": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4360,14 +4323,14 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB23_2"
+          "net": "NetP24_7"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB15": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4378,11 +4341,11 @@
           "net": "NetSB15_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB11": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4393,11 +4356,11 @@
           "net": "NetSB11_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB12": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4408,11 +4371,11 @@
           "net": "NetSB12_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB13": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4423,11 +4386,11 @@
           "net": "NetSB13_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB14": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4438,11 +4401,11 @@
           "net": "NetSB14_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB10": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4453,47 +4416,47 @@
           "net": "NetSB10_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "R1": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±5%, 0.05W",
       "pins": {
         "1": "SDA",
         "2": "P0.26"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±5%, 0.05W",
       "value": "0R"
     },
     "R2": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±5%, 0.05W",
       "pins": {
         "1": "SCL",
         "2": "P0.27"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±5%, 0.05W",
       "value": "0R"
     },
     "C51": {
-      "mpn": "N.A.",
       "pins": {
         "1": "GND",
         "2": "P0.26"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "C52": {
-      "mpn": "N.A.",
       "pins": {
         "1": "GND",
         "2": "P0.27"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "SB21": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4501,14 +4464,14 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB21_2"
+          "net": "NetP24_9"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB22": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4516,14 +4479,14 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB22_2"
+          "net": "NetP24_10"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB24": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4531,14 +4494,14 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB24_2"
+          "net": "NetP24_11"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB20": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4546,14 +4509,14 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB20_2"
+          "net": "NetP24_13"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB25": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -4561,144 +4524,144 @@
         },
         "2": {
           "name": "1",
-          "net": "NetSB25_2"
+          "net": "NetP24_12"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "R43": {
-      "mpn": "N.A.",
       "pins": {
-        "1": "NetR43_1",
+        "1": "NetP12_7",
         "2": "P0.09/NFC1"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "R45": {
-      "mpn": "N.A.",
       "pins": {
-        "1": "NetR45_1",
+        "1": "NetP12_8",
         "2": "P0.10/NFC2"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "L3": {
-      "mpn": "LQG15HS15NJ02D",
-      "description": "Inductor, 450mA, ±5%,  0.32ohm",
       "pins": {
         "1": "DEC4_6",
         "2": "NetL2_1"
       },
+      "mpn": "LQG15HS15NJ02D",
+      "description": "Inductor, 450mA, ±5%,  0.32ohm",
       "value": "15nH"
     },
     "L1": {
-      "mpn": "LQG15HS4N7B02D",
-      "description": "Inductor, 700mA, ±0.1nH, 160mR LQG",
       "pins": {
         "1": "NetC3_2",
         "2": "RF"
       },
+      "mpn": "LQG15HS4N7B02D",
+      "description": "Inductor, 700mA, ±0.1nH, 160mR LQG",
       "value": "4.7nH"
     },
     "R10": {
-      "mpn": "N.A.",
       "pins": {
         "1": "VCOM_CTS",
         "2": "GND"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "R16": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD1_IO",
-        "2": "NetR16_2"
+        "2": "NetP20_4"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R20": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
-        "1": "NetQ3_1",
+        "1": "NetP20_3",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R17": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD1_CLK",
-        "2": "NetR17_2"
+        "2": "NetP20_5"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R18": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD1_SWO",
-        "2": "NetR18_2"
+        "2": "NetP20_6"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R19": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD1_RESET",
-        "2": "NetR19_2"
+        "2": "NetP20_7"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R11": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD0_IO",
-        "2": "NetR11_2"
+        "2": "NetP19_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R12": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD0_CLK",
-        "2": "NetR12_2"
+        "2": "NetP19_4"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R14": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD0_SWO",
-        "2": "NetR14_2"
+        "2": "NetP19_6"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "R15": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SWD0_RESET",
-        "2": "NetR15_2"
+        "2": "NetP19_10"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150R"
     },
     "Q3": {
-      "mpn": "RV2C010UNT2L",
-      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "pins": {
         "1": {
           "name": "G",
-          "net": "NetQ3_1"
+          "net": "NetP20_3"
         },
         "2": {
           "name": "S",
@@ -4709,92 +4672,92 @@
           "net": "SWD1_SEL"
         }
       },
+      "mpn": "RV2C010UNT2L",
+      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "value": "RV2C010UNT2L"
     },
     "C30": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%, 10V",
       "pins": {
         "1": "NetC29_2",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%, 10V",
       "value": "2.2nF"
     },
     "C39": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "NetC39_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C31": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C32": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C37": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7S, ±10%, 10V",
       "pins": {
         "1": "NetC37_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7S, ±10%, 10V",
       "value": "4.7µF"
     },
     "C38": {
-      "mpn": "CL10B475KQ8NQNC",
-      "description": "Capacitor, X7R, ±10%, 6.3V",
       "pins": {
         "1": "NetC38_1",
         "2": "GND"
       },
+      "mpn": "CL10B475KQ8NQNC",
+      "description": "Capacitor, X7R, ±10%, 6.3V",
       "value": "4.7µF"
     },
     "C33": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C34": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C24": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "U2": {
-      "mpn": "nRF5340-QKAAD0",
-      "description": "Multi-protocol Bluetooth Low Energy, IEEE 802.15.4, ANT and 2.4GHz proprietary system-on-chip",
       "pins": {
         "104": {
           "name": "VSS_PAD",
@@ -4909,56 +4872,56 @@
         "AC31": "IMCU_RESET",
         "AL29": "IMCU_LED"
       },
+      "mpn": "nRF5340-QKAAD0",
+      "description": "Multi-protocol Bluetooth Low Energy, IEEE 802.15.4, ANT and 2.4GHz proprietary system-on-chip",
       "value": "nRF5340-QKAA"
     },
     "C25": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C26": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C27": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "R13": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VBUS_IMCU",
         "2": "NetC37_1"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "2R2"
     },
     "R9": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetR9_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "49.9R"
     },
     "X3": {
-      "mpn": "MP12308",
-      "description": "XTAL SMD 2016, 32MHz, Cl=8pF, Tol: ±10ppm, Stab: ±15ppm, -30°C ~ 85°C, ESR: 50ohm max",
       "pins": {
         "1": {
           "name": "inp",
@@ -4977,11 +4940,11 @@
           "net": ""
         }
       },
+      "mpn": "MP12308",
+      "description": "XTAL SMD 2016, 32MHz, Cl=8pF, Tol: ±10ppm, Stab: ±15ppm, -30°C ~ 85°C, ESR: 50ohm max",
       "value": "32MHz"
     },
     "J4": {
-      "mpn": "TC2050-IDC-NLFP",
-      "description": "CBL PLUG-OF-NAILS 10-PIN",
       "pins": {
         "1": "VDD_IMCU",
         "2": "IMCU_SWDIO",
@@ -4994,52 +4957,52 @@
         "9": "",
         "10": "IMCU_RESET"
       },
+      "mpn": "TC2050-IDC-NLFP",
+      "description": "CBL PLUG-OF-NAILS 10-PIN",
       "value": "TC2050-IDC"
     },
     "R8": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "IMCU_RESET",
         "2": "VDD_IMCU"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "100k"
     },
     "TP50": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "IMCU_RESET"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "TP49": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "IMCU_SWDIO"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "TP51": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "IMCU_SWDCLK"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "TP48": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "VDD_IMCU"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "LED5": {
-      "mpn": "VS 25C7M5",
-      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "pins": {
         "1": {
           "name": "C",
@@ -5050,20 +5013,20 @@
           "net": "NetLED5_2"
         }
       },
+      "mpn": "VS 25C7M5",
+      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "value": "L0603G"
     },
     "R7": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetLED5_2",
         "2": "VBUS_IMCU"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "560R"
     },
     "Q2": {
-      "mpn": "RV2C010UNT2L",
-      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "pins": {
         "1": {
           "name": "G",
@@ -5078,88 +5041,88 @@
           "net": "NetLED5_1"
         }
       },
+      "mpn": "RV2C010UNT2L",
+      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "value": "RV2C010UNT2L"
     },
     "C28": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 6.3V",
       "pins": {
         "1": "VDD_IMCU",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 6.3V",
       "value": "1.0µF"
     },
     "C29": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 6.3V",
       "pins": {
         "1": "GND",
         "2": "NetC29_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 6.3V",
       "value": "1.0µF"
     },
     "C35": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 6.3V",
       "pins": {
         "1": "GND",
         "2": "VDD_IMCU"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 6.3V",
       "value": "1.0µF"
     },
     "C36": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 6.3V",
       "pins": {
         "1": "GND",
         "2": "NetC36_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 6.3V",
       "value": "1.0µF"
     },
     "C40": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 6.3V",
       "pins": {
         "1": "GND",
         "2": "NetC40_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 6.3V",
       "value": "1.0µF"
     },
     "TP3": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VCOM_RTS"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP2": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VCOM_RxD"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP4": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VCOM_TxD"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP1": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VCOM_CTS"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "SB51": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5170,11 +5133,11 @@
           "net": "NetSB51_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB53": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5185,11 +5148,11 @@
           "net": "NetSB53_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB50": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5200,11 +5163,11 @@
           "net": "NetSB50_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB52": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5215,11 +5178,11 @@
           "net": "NetSB52_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "U6": {
-      "mpn": "FSA2466UMX",
-      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "pins": {
         "1": {
           "name": "NC1",
@@ -5286,20 +5249,20 @@
           "net": "NetSB54_2"
         }
       },
+      "mpn": "FSA2466UMX",
+      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "value": "FSA2466UMX"
     },
     "C45": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "U5": {
-      "mpn": "FSA2466UMX",
-      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "pins": {
         "1": {
           "name": "NC1",
@@ -5366,11 +5329,11 @@
           "net": "VCOM_RTS"
         }
       },
+      "mpn": "FSA2466UMX",
+      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "value": "FSA2466UMX"
     },
     "U7": {
-      "mpn": "FSA2466UMX",
-      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "pins": {
         "1": {
           "name": "NC1",
@@ -5437,29 +5400,29 @@
           "net": "BOOT/RESET"
         }
       },
+      "mpn": "FSA2466UMX",
+      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "value": "FSA2466UMX"
     },
     "C42": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C48": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "U8": {
-      "mpn": "FSA2466UMX",
-      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "pins": {
         "1": {
           "name": "NC1",
@@ -5526,20 +5489,20 @@
           "net": "CTS"
         }
       },
+      "mpn": "FSA2466UMX",
+      "description": "Data / Audio Low-Voltage Dual DPDT Analog Switch",
       "value": "FSA2466UMX"
     },
     "C50": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "SW7": {
-      "mpn": "CJS-1200TA",
-      "description": "SMD slide Switch (ON-ON)",
       "pins": {
         "1": {
           "name": "N.C",
@@ -5554,29 +5517,29 @@
           "net": "VDD"
         }
       },
+      "mpn": "CJS-1200TA",
+      "description": "SMD slide Switch (ON-ON)",
       "value": "Switch"
     },
     "R48": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetLED2_2",
         "2": "VDD_PER"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "220R"
     },
     "R47": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetLED1_2",
         "2": "VDD_PER"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "220R"
     },
     "SB6": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5587,20 +5550,20 @@
           "net": "NetLED2_1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "R50": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetLED3_2",
         "2": "VDD_PER"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "220R"
     },
     "SB7": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5611,20 +5574,20 @@
           "net": "NetLED3_1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "R51": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetLED4_2",
         "2": "VDD_PER"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "220R"
     },
     "SB8": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5635,11 +5598,11 @@
           "net": "NetLED4_1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB5": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5650,11 +5613,11 @@
           "net": "NetLED1_1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "LED1": {
-      "mpn": "VS 25C7M5",
-      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "pins": {
         "1": {
           "name": "C",
@@ -5665,11 +5628,11 @@
           "net": "NetLED1_2"
         }
       },
+      "mpn": "VS 25C7M5",
+      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "value": "L0603G"
     },
     "LED2": {
-      "mpn": "VS 25C7M5",
-      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "pins": {
         "1": {
           "name": "C",
@@ -5680,11 +5643,11 @@
           "net": "NetLED2_2"
         }
       },
+      "mpn": "VS 25C7M5",
+      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "value": "L0603G"
     },
     "LED3": {
-      "mpn": "VS 25C7M5",
-      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "pins": {
         "1": {
           "name": "C",
@@ -5695,11 +5658,11 @@
           "net": "NetLED3_2"
         }
       },
+      "mpn": "VS 25C7M5",
+      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "value": "L0603G"
     },
     "LED4": {
-      "mpn": "VS 25C7M5",
-      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "pins": {
         "1": {
           "name": "C",
@@ -5710,11 +5673,11 @@
           "net": "NetLED4_2"
         }
       },
+      "mpn": "VS 25C7M5",
+      "description": "LED, Green, 0603, 573nm, Vf=2.0V, 24mcd, - 40 to +85°C",
       "value": "L0603G"
     },
     "SW5": {
-      "mpn": "TS604VM1-025BR-R",
-      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "pins": {
         "1": {
           "name": "N.O",
@@ -5725,11 +5688,11 @@
           "net": "BOOT/RESET"
         }
       },
+      "mpn": "TS604VM1-025BR-R",
+      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "value": "PB SW"
     },
     "SW6": {
-      "mpn": "MKH-22D14-G2-B",
-      "description": "Slide Switch DPDT",
       "pins": {
         "1": {
           "name": "N.O-1",
@@ -5756,11 +5719,11 @@
           "net": "VDD"
         }
       },
+      "mpn": "MKH-22D14-G2-B",
+      "description": "Slide Switch DPDT",
       "value": "MKH-22D14-G2-B"
     },
     "SB9": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5771,11 +5734,11 @@
           "net": "VDD_PER"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "U4": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -5794,29 +5757,29 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "R41": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD",
         "2": "NetQ40_5"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R40": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VBUS",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "150k"
     },
     "SB31": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5827,11 +5790,11 @@
           "net": "USB_DETECT"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB46": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5842,11 +5805,11 @@
           "net": "NetSB46_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB45": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5857,11 +5820,11 @@
           "net": "P0.18/RESET"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB42": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5872,11 +5835,11 @@
           "net": "P0.18/RESET"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB43": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5887,11 +5850,11 @@
           "net": "NetSB43_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB44": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -5902,23 +5865,23 @@
           "net": "P0.18/RESET"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "U3": {
-      "mpn": "MX25R6435FZNIL0",
-      "description": "Ultra low power, 64M-bit, serial multi I/O flash memory",
       "pins": {
         "1": {
           "name": "C\\S\\",
-          "net": ""
+          "net": "NetSB13_2"
         },
         "2": {
           "name": "SIO1/SO",
-          "net": ""
+          "net": "NetSB14_2"
         },
         "3": {
           "name": "SIO2/W\\P\\",
-          "net": ""
+          "net": "NetSB15_2"
         },
         "4": {
           "name": "GND",
@@ -5926,15 +5889,15 @@
         },
         "5": {
           "name": "SIO0/SI",
-          "net": ""
+          "net": "NetSB12_2"
         },
         "6": {
           "name": "SCLK",
-          "net": ""
+          "net": "NetSB11_2"
         },
         "7": {
           "name": "SIO3/R\\E\\S\\E\\T\\",
-          "net": ""
+          "net": "NetSB10_2"
         },
         "8": {
           "name": "VCC",
@@ -5945,56 +5908,56 @@
           "net": "GND"
         }
       },
+      "mpn": "MX25R6435FZNIL0",
+      "description": "Ultra low power, 64M-bit, serial multi I/O flash memory",
       "value": "MX25R6435F"
     },
     "C49": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC49_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "R46": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±5%, 0.063W",
       "pins": {
         "1": "NFC2",
         "2": "P0.10/NFC2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±5%, 0.063W",
       "value": "0R"
     },
     "R44": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±5%, 0.063W",
       "pins": {
         "1": "NFC1",
         "2": "P0.09/NFC1"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±5%, 0.063W",
       "value": "0R"
     },
     "C46": {
-      "mpn": "N.A.",
-      "description": "Capacitor, C0G, ±5%, 50V",
       "pins": {
         "1": "NFC1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, C0G, ±5%, 50V",
       "value": "300pF"
     },
     "C47": {
-      "mpn": "N.A.",
-      "description": "Capacitor, C0G, ±5%, 50V",
       "pins": {
         "1": "GND",
         "2": "NFC2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, C0G, ±5%, 50V",
       "value": "300pF"
     },
     "SW1": {
-      "mpn": "TS604VM1-025BR-R",
-      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "pins": {
         "1": {
           "name": "N.O",
@@ -6005,11 +5968,11 @@
           "net": "BUTTON1"
         }
       },
+      "mpn": "TS604VM1-025BR-R",
+      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "value": "PB SW"
     },
     "SW2": {
-      "mpn": "TS604VM1-025BR-R",
-      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "pins": {
         "1": {
           "name": "N.O",
@@ -6020,11 +5983,11 @@
           "net": "BUTTON2"
         }
       },
+      "mpn": "TS604VM1-025BR-R",
+      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "value": "PB SW"
     },
     "SW3": {
-      "mpn": "TS604VM1-025BR-R",
-      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "pins": {
         "1": {
           "name": "N.O",
@@ -6035,11 +5998,11 @@
           "net": "P0.24"
         }
       },
+      "mpn": "TS604VM1-025BR-R",
+      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "value": "PB SW"
     },
     "SW4": {
-      "mpn": "TS604VM1-025BR-R",
-      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "pins": {
         "1": {
           "name": "N.O",
@@ -6050,11 +6013,11 @@
           "net": "P0.25"
         }
       },
+      "mpn": "TS604VM1-025BR-R",
+      "description": "Tactile Switch, SPNO, SMD, 160gf, 6.2x6.3x2.5mm",
       "value": "PB SW"
     },
     "U19": {
-      "mpn": "TS27L2IPT",
-      "description": "Precision very low power CMOS dual operational amplifier",
       "pins": {
         "5": {
           "name": "IN2+",
@@ -6069,48 +6032,48 @@
           "net": "NetP28_3"
         }
       },
+      "mpn": "TS27L2IPT",
+      "description": "Precision very low power CMOS dual operational amplifier",
       "value": "TS27L2IPT"
     },
     "P28": {
-      "mpn": "N.A.",
-      "description": "Pin List 1x3, 2.54mm (100mil)",
       "pins": {
         "1": "NetP28_1",
         "2": "NetP28_2",
         "3": "NetP28_3"
       },
+      "mpn": "N.A.",
+      "description": "Pin List 1x3, 2.54mm (100mil)",
       "value": "Pin List 1x3"
     },
     "R26": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "USB_DETECT",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "47k"
     },
     "R52": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD",
         "2": "NetR52_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "4k7"
     },
     "R53": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD",
         "2": "NetR53_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "4k7"
     },
     "SB17": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6121,11 +6084,11 @@
           "net": "NetC49_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB16": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6136,11 +6099,11 @@
           "net": "NetC49_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB18": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6151,70 +6114,70 @@
           "net": "NetC49_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "R54": {
-      "mpn": "N.A.",
       "pins": {
         "1": "BOOT/RESET",
         "2": "VDD"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "TP22": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "nRF_ONLY"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "R3": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "nRF_ONLY",
         "2": "NetR3_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10k"
     },
     "TP23": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "TRACE_SW"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "R4": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "TRACE_SW",
         "2": "NetR4_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10k"
     },
     "TP21": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "BUTTON2"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP20": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "BUTTON1"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "Q40": {
-      "mpn": "PMCPB5530X,115",
-      "description": "Mosfet Array N and P-Channel 20V 4A (Ta), 3.4A (Ta) 490mW Surface Mount 6-HUSON-EP (2x2)",
       "pins": {
         "1": "GND",
         "2": "VBUS",
@@ -6232,35 +6195,35 @@
         },
         "6": "NetQ40_5"
       },
+      "mpn": "PMCPB5530X,115",
+      "description": "Mosfet Array N and P-Channel 20V 4A (Ta), 3.4A (Ta) 490mW Surface Mount 6-HUSON-EP (2x2)",
       "value": "PMCPB5530"
     },
     "TP5": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "SWD3_IO"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP6": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "SWD3_CLK"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP7": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "SWD3_RESET"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "SB54": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6271,11 +6234,11 @@
           "net": "NetSB54_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB55": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6286,11 +6249,11 @@
           "net": "NetSB55_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB57": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6301,11 +6264,11 @@
           "net": "NetSB57_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB56": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6316,19 +6279,19 @@
           "net": "NetSB56_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "TP8": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "SWD3_SWO"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "SW11": {
-      "mpn": "CJS-1200TA",
-      "description": "SMD slide Switch (ON-ON)",
       "pins": {
         "1": {
           "name": "N.C",
@@ -6343,11 +6306,11 @@
           "net": "GND"
         }
       },
+      "mpn": "CJS-1200TA",
+      "description": "SMD slide Switch (ON-ON)",
       "value": "Switch"
     },
     "P7": {
-      "mpn": "1125-1108S0M116CR04",
-      "description": "Pin List 1x8, 2.54mm (100mil), SMD",
       "pins": {
         "1": "VIO",
         "2": "VIO",
@@ -6358,93 +6321,93 @@
         "7": "GND",
         "8": "VIN"
       },
+      "mpn": "1125-1108S0M116CR04",
+      "description": "Pin List 1x8, 2.54mm (100mil), SMD",
       "value": "Pin List 1x8"
     },
     "P11": {
-      "mpn": "2171-203MS0CUNR3",
-      "description": "Socket 2x3, 2.54mm (100mil), SMD",
       "pins": {
-        "1": "NetP10_5",
+        "1": "P1.14",
         "2": "V5V",
-        "3": "NetP10_6",
-        "4": "NetP10_4",
+        "3": "P1.15",
+        "4": "P1.13",
         "5": "RESET_PIN",
         "6": "NetP11_6"
       },
+      "mpn": "2171-203MS0CUNR3",
+      "description": "Socket 2x3, 2.54mm (100mil), SMD",
       "value": "Socket 2x3"
     },
     "P14": {
-      "mpn": "N.A.",
-      "description": "Pin Header 2x6, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
-        "2": "NetP14_2",
+        "2": "P0.03/AIN1",
         "3": "GND",
-        "4": "NetP14_4",
+        "4": "P0.04/AIN2",
         "5": "GND",
-        "6": "NetP14_6",
+        "6": "P0.28/AIN4",
         "7": "GND",
-        "8": "NetP14_8",
+        "8": "P0.29/AIN5",
         "9": "GND",
-        "10": "NetP14_10",
+        "10": "P0.30/AIN6",
         "11": "GND",
-        "12": "NetP14_12"
+        "12": "P0.31/AIN7"
       },
+      "mpn": "N.A.",
+      "description": "Pin Header 2x6, 2.54mm (100mil)",
       "value": "Pin Header 2x6"
     },
     "P15": {
-      "mpn": "N.A.",
-      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
-        "2": "NetP15_2",
+        "2": "P1.01",
         "3": "GND",
-        "4": "NetP15_4",
+        "4": "P1.02",
         "5": "GND",
-        "6": "NetP15_6",
+        "6": "P1.03",
         "7": "GND",
-        "8": "NetP15_8",
+        "8": "P1.04",
         "9": "GND",
-        "10": "NetP15_10",
+        "10": "P1.05",
         "11": "GND",
-        "12": "NetP15_12",
+        "12": "P1.06",
         "13": "GND",
-        "14": "NetP15_14",
+        "14": "P1.07",
         "15": "GND",
-        "16": "NetP15_16"
+        "16": "P1.08"
       },
+      "mpn": "N.A.",
+      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "value": "Pin Header 2x8"
     },
     "P16": {
-      "mpn": "N.A.",
-      "description": "Pin Header 2x10, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
-        "2": "NetP10_1",
+        "2": "P1.10",
         "3": "GND",
-        "4": "NetP10_2",
+        "4": "P1.11",
         "5": "GND",
-        "6": "NetP10_3",
+        "6": "P1.12",
         "7": "GND",
-        "8": "NetP10_4",
+        "8": "P1.13",
         "9": "GND",
-        "10": "NetP10_5",
+        "10": "P1.14",
         "11": "GND",
-        "12": "NetP10_6",
+        "12": "P1.15",
         "13": "GND",
         "14": "GND",
         "15": "GND",
-        "16": "NetP10_8",
+        "16": "P0.02/AIN0",
         "17": "GND",
-        "18": "NetP10_9",
+        "18": "SDA",
         "19": "GND",
-        "20": "NetP10_10"
+        "20": "SCL"
       },
+      "mpn": "N.A.",
+      "description": "Pin Header 2x10, 2.54mm (100mil)",
       "value": "Pin Header 2x10"
     },
     "P13": {
-      "mpn": "N.A.",
-      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
         "2": "GND",
@@ -6463,43 +6426,43 @@
         "15": "GND",
         "16": "VIN"
       },
+      "mpn": "N.A.",
+      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "value": "Pin Header 2x8"
     },
     "P17": {
-      "mpn": "N.A.",
-      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
-        "2": "NetP12_1",
+        "2": "P0.00",
         "3": "GND",
-        "4": "NetP12_2",
+        "4": "P0.01",
         "5": "GND",
-        "6": "NetP12_3",
+        "6": "P0.05/AIN3",
         "7": "GND",
-        "8": "NetP12_4",
+        "8": "P0.06",
         "9": "GND",
-        "10": "NetP12_5",
+        "10": "P0.07",
         "11": "GND",
-        "12": "NetP12_6",
+        "12": "P0.08",
         "13": "GND",
         "14": "NetP12_7",
         "15": "GND",
         "16": "NetP12_8"
       },
+      "mpn": "N.A.",
+      "description": "Pin Header 2x8, 2.54mm (100mil)",
       "value": "Pin Header 2x8"
     },
     "C67": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%, 10V",
       "pins": {
         "1": "GND",
         "2": "NetC67_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%, 10V",
       "value": "4.7nF"
     },
     "D61": {
-      "mpn": "PRTR5V0U2X",
-      "description": "Ultra low capacitance double rail-to-rail ESD protection diode",
       "pins": {
         "1": {
           "name": "GND",
@@ -6507,72 +6470,72 @@
         },
         "2": {
           "name": "IO1",
-          "net": "NetD61_2"
+          "net": "IMCU_N"
         },
         "3": {
           "name": "IO2",
-          "net": "NetD61_3"
+          "net": "IMCU_P"
         },
         "4": {
           "name": "VCC",
           "net": "NetC63_1"
         }
       },
+      "mpn": "PRTR5V0U2X",
+      "description": "Ultra low capacitance double rail-to-rail ESD protection diode",
       "value": "PRTR5V0U2X"
     },
     "TP12": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "GND"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "C64": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±20%",
       "pins": {
         "1": "GND",
         "2": "NetC63_1"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±20%",
       "value": "10µF"
     },
     "TP11": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "NetC63_1"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "C65": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC63_1"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "TP9": {
+      "pins": {
+        "1": "IMCU_P"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetD61_3"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP10": {
+      "pins": {
+        "1": "IMCU_N"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetD61_2"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "SB32": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6583,11 +6546,11 @@
           "net": "NetP11_6"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB33": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -6598,28 +6561,28 @@
           "net": "SHIELD_DETECT"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "R68": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "SHIELD_DETECT",
         "2": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "TP19": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "SHIELD_DETECT"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "J2": {
-      "mpn": "AJU55-BS2111-L",
-      "description": "MicroUSB-B-SMT",
       "pins": {
         "1": {
           "name": "VBUS",
@@ -6627,11 +6590,11 @@
         },
         "2": {
           "name": "D-",
-          "net": "NetD61_2"
+          "net": "IMCU_N"
         },
         "3": {
           "name": "D+",
-          "net": "NetD61_3"
+          "net": "IMCU_P"
         },
         "4": {
           "name": "ID",
@@ -6646,24 +6609,24 @@
           "net": "NetC67_2"
         }
       },
+      "mpn": "AJU55-BS2111-L",
+      "description": "MicroUSB-B-SMT",
       "value": "MicroUSB-B"
     },
     "P5": {
-      "mpn": "1125-1203S0M116CR03",
-      "description": "Pin Header 2x3, 2.54mm (100mil) SMD",
       "pins": {
-        "1": "NetP10_5",
+        "1": "P1.14",
         "2": "V5V",
-        "3": "NetP10_6",
-        "4": "NetP10_4",
+        "3": "P1.15",
+        "4": "P1.13",
         "5": "RESET_PIN",
         "6": "NetP11_6"
       },
+      "mpn": "1125-1203S0M116CR03",
+      "description": "Pin Header 2x3, 2.54mm (100mil) SMD",
       "value": "Pin Hdr 2x3"
     },
     "P18": {
-      "mpn": "3132-10MS0BK00R5",
-      "description": "Pin Header 2x5, 1.27mm (50mil), SMD, Keying Shroud",
       "pins": {
         "1": "VDBG",
         "2": "SWDIO",
@@ -6676,11 +6639,11 @@
         "9": "GND",
         "10": "P0.18/RESET"
       },
+      "mpn": "3132-10MS0BK00R5",
+      "description": "Pin Header 2x5, 1.27mm (50mil), SMD, Keying Shroud",
       "value": "Pin Header 2x5, 1.27mm"
     },
     "P19": {
-      "mpn": "3132-10MS0BK00R5",
-      "description": "Pin Header 2x5, 1.27mm (50mil), SMD, Keying Shroud",
       "pins": {
         "1": "NetP19_1",
         "2": "NetP19_2",
@@ -6693,36 +6656,36 @@
         "9": "",
         "10": "NetP19_10"
       },
+      "mpn": "3132-10MS0BK00R5",
+      "description": "Pin Header 2x5, 1.27mm (50mil), SMD, Keying Shroud",
       "value": "Pin Header 2x5, 1.27mm"
     },
     "P24": {
-      "mpn": "2171-209MS0CUNR3",
-      "description": "Socket 2x9, 2.54mm (100mil), SMD",
       "pins": {
-        "1": "",
-        "2": "",
-        "3": "",
-        "4": "",
-        "5": "",
-        "6": "",
-        "7": "",
-        "8": "",
-        "9": "",
-        "10": "",
-        "11": "",
-        "12": "",
-        "13": "",
-        "14": "",
-        "15": "",
-        "16": "",
-        "17": "",
+        "1": "P0.11",
+        "2": "P0.12",
+        "3": "P0.13",
+        "4": "P0.14",
+        "5": "P0.15",
+        "6": "P0.16",
+        "7": "NetP24_7",
+        "8": "P0.18/RESET",
+        "9": "NetP24_9",
+        "10": "NetP24_10",
+        "11": "NetP24_11",
+        "12": "NetP24_12",
+        "13": "NetP24_13",
+        "14": "P0.24",
+        "15": "P0.25",
+        "16": "P1.00",
+        "17": "P1.09",
         "18": "GND"
       },
+      "mpn": "2171-209MS0CUNR3",
+      "description": "Socket 2x9, 2.54mm (100mil), SMD",
       "value": "Socket 2x9"
     },
     "P25": {
-      "mpn": "3132-20MS0BK00R1",
-      "description": "Pin Header 2x10, 1.27mm (50mil), SMD, Keying Shroud",
       "pins": {
         "1": "VDBG",
         "2": "SWDIO",
@@ -6735,42 +6698,42 @@
         "9": "GND",
         "10": "P0.18/RESET",
         "11": "",
-        "12": "NetP25_12",
+        "12": "P0.07",
         "13": "",
-        "14": "NetP25_14",
+        "14": "P1.00",
         "15": "GND",
-        "16": "NetP25_16",
+        "16": "P0.12",
         "17": "GND",
-        "18": "NetP25_18",
+        "18": "P0.11",
         "19": "GND",
-        "20": "NetP25_20"
+        "20": "P1.09"
       },
+      "mpn": "3132-20MS0BK00R1",
+      "description": "Pin Header 2x10, 1.27mm (50mil), SMD, Keying Shroud",
       "value": "Pin Header 2x10, 1.27mm"
     },
     "J5": {
-      "mpn": "5141-05RZDNWR03",
-      "description": "0.5mm FPC, 5P,Right Angle SMT,Double Contact,H=1.2mm,White, Tin plated",
       "pins": {
         "1": "",
-        "2": "NetJ5_2",
+        "2": "NFC1",
         "3": "",
-        "4": "NetJ5_4",
+        "4": "NFC2",
         "5": ""
       },
+      "mpn": "5141-05RZDNWR03",
+      "description": "0.5mm FPC, 5P,Right Angle SMT,Double Contact,H=1.2mm,White, Tin plated",
       "value": "FPC 0.5mm RA SMD"
     },
     "C66": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%, 10V",
       "pins": {
         "1": "GND",
         "2": "NetC66_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%, 10V",
       "value": "4.7nF"
     },
     "J3": {
-      "mpn": "AJU55-BS2111-L",
-      "description": "MicroUSB-B-SMT",
       "pins": {
         "1": {
           "name": "VBUS",
@@ -6778,11 +6741,11 @@
         },
         "2": {
           "name": "D-",
-          "net": "NetD60_2"
+          "net": "D_N"
         },
         "3": {
           "name": "D+",
-          "net": "NetD60_3"
+          "net": "D_P"
         },
         "4": {
           "name": "ID",
@@ -6797,29 +6760,29 @@
           "net": "NetC66_2"
         }
       },
+      "mpn": "AJU55-BS2111-L",
+      "description": "MicroUSB-B-SMT",
       "value": "MicroUSB-B"
     },
     "J6": {
-      "mpn": "SM02B-SRSS-TB(LF)(SN)",
-      "description": "1.0mm pitch connector side entry SMD",
       "pins": {
         "1": "GND",
         "2": "VLi-Ion"
       },
+      "mpn": "SM02B-SRSS-TB(LF)(SN)",
+      "description": "1.0mm pitch connector side entry SMD",
       "value": "HDR-2, 1mm"
     },
     "P27": {
-      "mpn": "N.A.",
-      "description": "Pin List 1x2, 2.54mm (100mil)",
       "pins": {
         "1": "GND",
         "2": "VLi-Ion"
       },
+      "mpn": "N.A.",
+      "description": "Pin List 1x2, 2.54mm (100mil)",
       "value": "Pin List 1x2"
     },
     "P26": {
-      "mpn": "2171-113MS0CUNR1",
-      "description": "Socket 1x13, 2.54mm (100mil), SMD",
       "pins": {
         "1": "VDD_nRF",
         "2": "VDD_nRF'",
@@ -6835,11 +6798,11 @@
         "12": "VIO_REF",
         "13": "NetP20_13"
       },
+      "mpn": "2171-113MS0CUNR1",
+      "description": "Socket 1x13, 2.54mm (100mil), SMD",
       "value": "Socket 1x13"
     },
     "D60": {
-      "mpn": "PRTR5V0U2X",
-      "description": "Ultra low capacitance double rail-to-rail ESD protection diode",
       "pins": {
         "1": {
           "name": "GND",
@@ -6847,170 +6810,170 @@
         },
         "2": {
           "name": "IO1",
-          "net": "NetD60_2"
+          "net": "D_N"
         },
         "3": {
           "name": "IO2",
-          "net": "NetD60_3"
+          "net": "D_P"
         },
         "4": {
           "name": "VCC",
           "net": "NetC60_2"
         }
       },
+      "mpn": "PRTR5V0U2X",
+      "description": "Ultra low capacitance double rail-to-rail ESD protection diode",
       "value": "PRTR5V0U2X"
     },
     "C61": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±20%",
       "pins": {
         "1": "GND",
         "2": "NetC60_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±20%",
       "value": "10µF"
     },
     "C62": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC60_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "FB64": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetC66_2",
         "2": "GND"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "FB60": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetC60_2",
         "2": "VBUS_nRF'"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "C60": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC60_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "10nF"
     },
     "FB62": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetFB62_1",
         "2": "GND"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "FB63": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetFB63_1",
         "2": "GND"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "FB61": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetC63_1",
         "2": "VBUS"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "C63": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "NetC63_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "10nF"
     },
     "FB65": {
-      "mpn": "BLM15AG121SN1D",
-      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "pins": {
         "1": "NetC67_2",
         "2": "GND"
       },
+      "mpn": "BLM15AG121SN1D",
+      "description": "Ferrite Bead, 120 Ohm @ 100MHz, 500mA, 250 mOhm Max",
       "value": "120R/0.55A"
     },
     "TP13": {
+      "pins": {
+        "1": "D_N"
+      },
       "mpn": "N.A.",
       "description": "1.5mm circular SMD testpad",
-      "pins": {
-        "1": "NetD60_2"
-      },
       "value": "Ø1.5mm,SMD"
     },
     "TP14": {
+      "pins": {
+        "1": "D_P"
+      },
       "mpn": "N.A.",
       "description": "1.5mm circular SMD testpad",
-      "pins": {
-        "1": "NetD60_3"
-      },
       "value": "Ø1.5mm,SMD"
     },
     "TP18": {
+      "pins": {
+        "1": "NFC2"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetJ5_4"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP17": {
+      "pins": {
+        "1": "NFC1"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetJ5_2"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP31": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VLi-Ion"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "C69": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VBUS"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C68": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VBUS_nRF'"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "SB47": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7021,27 +6984,27 @@
           "net": "NetP19_1"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "TP16": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "NetFB62_1"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "TP15": {
-      "mpn": "N.A.",
-      "description": "1.5mm circular SMD testpad",
       "pins": {
         "1": "NetC60_2"
       },
+      "mpn": "N.A.",
+      "description": "1.5mm circular SMD testpad",
       "value": "Ø1.5mm,SMD"
     },
     "SB60": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7052,11 +7015,11 @@
           "net": "VDD_nRF'"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "SB59": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7067,86 +7030,86 @@
           "net": "VDD"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "TP42": {
+      "pins": {
+        "1": "P0.03/AIN1"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_2"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP43": {
+      "pins": {
+        "1": "P0.04/AIN2"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_4"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP44": {
+      "pins": {
+        "1": "P0.28/AIN4"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_6"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP45": {
+      "pins": {
+        "1": "P0.29/AIN5"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_8"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP46": {
+      "pins": {
+        "1": "P0.30/AIN6"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_10"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "TP47": {
+      "pins": {
+        "1": "P0.31/AIN7"
+      },
       "mpn": "N.A.",
       "description": "1.0mm circular SMD testpad",
-      "pins": {
-        "1": "NetP14_12"
-      },
       "value": "Ø1.0mm,SMD"
     },
     "R63": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "GND",
         "2": "NetC67_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R62": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "GND",
         "2": "NetC66_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R69": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "GND",
         "2": "NetP20_13"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "866R"
     },
     "SB19": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7157,11 +7120,11 @@
           "net": "VIO_REF"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "P1": {
-      "mpn": "2171-108MS0CUNR3",
-      "description": "Socket 1x8, 2.54mm (100mil), SMD",
       "pins": {
         "1": "VIO",
         "2": "VIO",
@@ -7172,131 +7135,131 @@
         "7": "GND",
         "8": "VIN"
       },
+      "mpn": "2171-108MS0CUNR3",
+      "description": "Socket 1x8, 2.54mm (100mil), SMD",
       "value": "Socket 1x8"
     },
     "P2": {
+      "pins": {
+        "1": "P0.03/AIN1",
+        "2": "P0.04/AIN2",
+        "3": "P0.28/AIN4",
+        "4": "P0.29/AIN5",
+        "5": "P0.30/AIN6",
+        "6": "P0.31/AIN7"
+      },
       "mpn": "2171-106MS0CUNR3",
       "description": "Socket 1x6, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP14_2",
-        "2": "NetP14_4",
-        "3": "NetP14_6",
-        "4": "NetP14_8",
-        "5": "NetP14_10",
-        "6": "NetP14_12"
-      },
       "value": "Socket 1x6"
     },
     "P8": {
+      "pins": {
+        "1": "P0.03/AIN1",
+        "2": "P0.04/AIN2",
+        "3": "P0.28/AIN4",
+        "4": "P0.29/AIN5",
+        "5": "P0.30/AIN6",
+        "6": "P0.31/AIN7"
+      },
       "mpn": "1125-1106S0M116R2",
       "description": "Pin List 1x6, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP14_2",
-        "2": "NetP14_4",
-        "3": "NetP14_6",
-        "4": "NetP14_8",
-        "5": "NetP14_10",
-        "6": "NetP14_12"
-      },
       "value": "Pin List 1x6"
     },
     "P9": {
+      "pins": {
+        "1": "P1.01",
+        "2": "P1.02",
+        "3": "P1.03",
+        "4": "P1.04",
+        "5": "P1.05",
+        "6": "P1.06",
+        "7": "P1.07",
+        "8": "P1.08"
+      },
       "mpn": "1125-1108S0M116CR04",
       "description": "Pin List 1x8, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP15_2",
-        "2": "NetP15_4",
-        "3": "NetP15_6",
-        "4": "NetP15_8",
-        "5": "NetP15_10",
-        "6": "NetP15_12",
-        "7": "NetP15_14",
-        "8": "NetP15_16"
-      },
       "value": "Pin List 1x8"
     },
     "P3": {
+      "pins": {
+        "1": "P1.01",
+        "2": "P1.02",
+        "3": "P1.03",
+        "4": "P1.04",
+        "5": "P1.05",
+        "6": "P1.06",
+        "7": "P1.07",
+        "8": "P1.08"
+      },
       "mpn": "2171-108MS0CUNR3",
       "description": "Socket 1x8, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP15_2",
-        "2": "NetP15_4",
-        "3": "NetP15_6",
-        "4": "NetP15_8",
-        "5": "NetP15_10",
-        "6": "NetP15_12",
-        "7": "NetP15_14",
-        "8": "NetP15_16"
-      },
       "value": "Socket 1x8"
     },
     "P10": {
+      "pins": {
+        "1": "P1.10",
+        "2": "P1.11",
+        "3": "P1.12",
+        "4": "P1.13",
+        "5": "P1.14",
+        "6": "P1.15",
+        "7": "GND",
+        "8": "P0.02/AIN0",
+        "9": "SDA",
+        "10": "SCL"
+      },
       "mpn": "1125-1110S0M116R2",
       "description": "Pin List 1x10, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP10_1",
-        "2": "NetP10_2",
-        "3": "NetP10_3",
-        "4": "NetP10_4",
-        "5": "NetP10_5",
-        "6": "NetP10_6",
-        "7": "GND",
-        "8": "NetP10_8",
-        "9": "NetP10_9",
-        "10": "NetP10_10"
-      },
       "value": "Pin List 1x10"
     },
     "P4": {
+      "pins": {
+        "1": "P1.10",
+        "2": "P1.11",
+        "3": "P1.12",
+        "4": "P1.13",
+        "5": "P1.14",
+        "6": "P1.15",
+        "7": "GND",
+        "8": "P0.02/AIN0",
+        "9": "SDA",
+        "10": "SCL"
+      },
       "mpn": "2171-110MS0CUNR3",
       "description": "Socket 1x10, 2.54mm (100mil), SMD",
-      "pins": {
-        "1": "NetP10_1",
-        "2": "NetP10_2",
-        "3": "NetP10_3",
-        "4": "NetP10_4",
-        "5": "NetP10_5",
-        "6": "NetP10_6",
-        "7": "GND",
-        "8": "NetP10_8",
-        "9": "NetP10_9",
-        "10": "NetP10_10"
-      },
       "value": "Socket 1x10"
     },
     "P12": {
-      "mpn": "1125-1108S0M116CR04",
-      "description": "Pin List 1x8, 2.54mm (100mil), SMD",
       "pins": {
-        "1": "NetP12_1",
-        "2": "NetP12_2",
-        "3": "NetP12_3",
-        "4": "NetP12_4",
-        "5": "NetP12_5",
-        "6": "NetP12_6",
+        "1": "P0.00",
+        "2": "P0.01",
+        "3": "P0.05/AIN3",
+        "4": "P0.06",
+        "5": "P0.07",
+        "6": "P0.08",
         "7": "NetP12_7",
         "8": "NetP12_8"
       },
+      "mpn": "1125-1108S0M116CR04",
+      "description": "Pin List 1x8, 2.54mm (100mil), SMD",
       "value": "Pin List 1x8"
     },
     "P6": {
-      "mpn": "2171-108MS0CUNR3",
-      "description": "Socket 1x8, 2.54mm (100mil), SMD",
       "pins": {
-        "1": "NetP12_1",
-        "2": "NetP12_2",
-        "3": "NetP12_3",
-        "4": "NetP12_4",
-        "5": "NetP12_5",
-        "6": "NetP12_6",
+        "1": "P0.00",
+        "2": "P0.01",
+        "3": "P0.05/AIN3",
+        "4": "P0.06",
+        "5": "P0.07",
+        "6": "P0.08",
         "7": "NetP12_7",
         "8": "NetP12_8"
       },
+      "mpn": "2171-108MS0CUNR3",
+      "description": "Socket 1x8, 2.54mm (100mil), SMD",
       "value": "Socket 1x8"
     },
     "P20": {
-      "mpn": "1125-1113S0M116CR04",
-      "description": "Pin List 1x13, 2.54mm (100mil), SMD",
       "pins": {
         "1": "VDD_nRF",
         "2": "VDD_nRF'",
@@ -7312,11 +7275,11 @@
         "12": "VIO_REF",
         "13": "NetP20_13"
       },
+      "mpn": "1125-1113S0M116CR04",
+      "description": "Pin List 1x13, 2.54mm (100mil), SMD",
       "value": "Pin List 1x13"
     },
     "SB34": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7327,11 +7290,11 @@
           "net": "VREG"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SB36": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7342,35 +7305,35 @@
           "net": "VEXT"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "TP30": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VSENSE_SW_OUT"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP40": {
-      "mpn": "N.A.",
-      "description": "Testpoint, through hole",
       "pins": {
         "1": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Testpoint, through hole",
       "value": "TP"
     },
     "TP41": {
-      "mpn": "N.A.",
-      "description": "Testpoint, through hole",
       "pins": {
         "1": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Testpoint, through hole",
       "value": "TP"
     },
     "SW8": {
-      "mpn": "MKH-22D14-G2-B",
-      "description": "Slide Switch DPDT",
       "pins": {
         "1": {
           "name": "N.O-1",
@@ -7397,20 +7360,20 @@
           "net": "VBOOST_SRC"
         }
       },
+      "mpn": "MKH-22D14-G2-B",
+      "description": "Slide Switch DPDT",
       "value": "MKH-22D14-G2-B"
     },
     "P21": {
-      "mpn": "1125B-1102S0Z135CR06",
-      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "pins": {
         "1": "GND",
         "2": "NetP21_2"
       },
+      "mpn": "1125B-1102S0Z135CR06",
+      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "value": "Pin List 1x2, Angled"
     },
     "Q81": {
-      "mpn": "TSM250N02DCQ RFG",
-      "description": "Dual N Ch MOFET, 5.8A, 55mOhm max, 620mW",
       "pins": {
         "1": "GND",
         "2": "VREG_EN",
@@ -7428,20 +7391,20 @@
         },
         "6": "VREG_EN_INV"
       },
+      "mpn": "TSM250N02DCQ RFG",
+      "description": "Dual N Ch MOFET, 5.8A, 55mOhm max, 620mW",
       "value": "TSM250N02DCQ RFG"
     },
     "R86": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VSUPPLY",
         "2": "VREG_EN_INV"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "U15": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7460,11 +7423,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "U14": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7483,11 +7446,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "U13": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7506,11 +7469,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "SB38": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7521,20 +7484,20 @@
           "net": "VDD"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "C85": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "V5V"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "U16": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7553,20 +7516,20 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "R88": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD_nRF_SENSE",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10M"
     },
     "U17": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7585,11 +7548,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "Q82": {
-      "mpn": "RV2C010UNT2L",
-      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "pins": {
         "1": {
           "name": "G",
@@ -7604,29 +7567,29 @@
           "net": "VSUPPLY_EN"
         }
       },
+      "mpn": "RV2C010UNT2L",
+      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "value": "RV2C010UNT2L"
     },
     "R87": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VSUPPLY",
         "2": "VSUPPLY_EN"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R89": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VSUPPLY",
         "2": "VEXT_EN_INV"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "D81": {
-      "mpn": "NSR0620P2T5G",
-      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "pins": {
         "1": {
           "name": "C",
@@ -7637,11 +7600,11 @@
           "net": "VBUS_nRF'"
         }
       },
+      "mpn": "NSR0620P2T5G",
+      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "value": "NSR0620P2T5G"
     },
     "D80": {
-      "mpn": "NSR0620P2T5G",
-      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "pins": {
         "1": {
           "name": "C",
@@ -7652,11 +7615,11 @@
           "net": "VBUS"
         }
       },
+      "mpn": "NSR0620P2T5G",
+      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "value": "NSR0620P2T5G"
     },
     "D82": {
-      "mpn": "NSR0620P2T5G",
-      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "pins": {
         "1": {
           "name": "C",
@@ -7667,74 +7630,74 @@
           "net": "VLi-Ion"
         }
       },
+      "mpn": "NSR0620P2T5G",
+      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "value": "NSR0620P2T5G"
     },
     "C80": {
-      "mpn": "CL10A106MA8NRNC",
-      "description": "Capacitor, X5R, ±20%, 25V",
       "pins": {
         "1": "GND",
         "2": "VBOOST_SRC"
       },
+      "mpn": "CL10A106MA8NRNC",
+      "description": "Capacitor, X5R, ±20%, 25V",
       "value": "10µF"
     },
     "C82": {
-      "mpn": "CL10A106MA8NRNC",
-      "description": "Capacitor, X5R, ±20%, 25V",
       "pins": {
         "1": "GND",
         "2": "V5V"
       },
+      "mpn": "CL10A106MA8NRNC",
+      "description": "Capacitor, X5R, ±20%, 25V",
       "value": "10µF"
     },
     "R84": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "GND",
         "2": "NetC87_1"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "120k"
     },
     "R82": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetC87_1",
         "2": "VREG"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "330k"
     },
     "L81": {
-      "mpn": "NR3015T4R7M",
-      "description": "Ferrite Inductor, Shielded, 1,04A, 144mOhm",
       "pins": {
         "1": "NetL81_1",
         "2": "VREG"
       },
+      "mpn": "NR3015T4R7M",
+      "description": "Ferrite Inductor, Shielded, 1,04A, 144mOhm",
       "value": "4.7µH"
     },
     "C88": {
-      "mpn": "CL10A106MA8NRNC",
-      "description": "Capacitor, X5R, ±20%, 25V",
       "pins": {
         "1": "GND",
         "2": "VREG"
       },
+      "mpn": "CL10A106MA8NRNC",
+      "description": "Capacitor, X5R, ±20%, 25V",
       "value": "10µF"
     },
     "C86": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%, 16V",
       "pins": {
         "1": "GND",
         "2": "NetC86_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%, 16V",
       "value": "4.7µF"
     },
     "U11": {
-      "mpn": "XC9236D08CER-G",
-      "description": "600mA Driver Transistor Built-In, Synchronous Step-Down DC/DC Converters",
       "pins": {
         "1": {
           "name": "LX",
@@ -7765,20 +7728,20 @@
           "net": ""
         }
       },
+      "mpn": "XC9236D08CER-G",
+      "description": "600mA Driver Transistor Built-In, Synchronous Step-Down DC/DC Converters",
       "value": "XC9236"
     },
     "C87": {
-      "mpn": "N.A.",
-      "description": "Capacitor, NP0, ±5%, 25V",
       "pins": {
         "1": "NetC87_1",
         "2": "VREG"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, NP0, ±5%, 25V",
       "value": "150pF"
     },
     "D83": {
-      "mpn": "NSR0620P2T5G",
-      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "pins": {
         "1": {
           "name": "C",
@@ -7789,11 +7752,11 @@
           "net": "VIN3-5V"
         }
       },
+      "mpn": "NSR0620P2T5G",
+      "description": "20V schottky barrier diode, Vf 350 mV @ 100 mA, Ir 2.0 µA @ 10 V, If 500 mA",
       "value": "NSR0620P2T5G"
     },
     "Q80": {
-      "mpn": "FCX690BTA",
-      "description": "45V NPN high gain power transistor",
       "pins": {
         "1": {
           "name": "B",
@@ -7808,11 +7771,11 @@
           "net": "NetQ80_3"
         }
       },
+      "mpn": "FCX690BTA",
+      "description": "45V NPN high gain power transistor",
       "value": "FCX690BTA"
     },
     "SB37": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7823,11 +7786,11 @@
           "net": "VDD"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "U18": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7846,56 +7809,56 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "R83": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "V5V",
         "2": "VREG_EN"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "820k"
     },
     "R85": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VREG_EN",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "470k"
     },
     "C89": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VSUPPLY"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C90": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VSUPPLY"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "C83": {
-      "mpn": "CL10A106MA8NRNC",
-      "description": "Capacitor, X5R, ±20%, 25V",
       "pins": {
         "1": "GND",
         "2": "V5V"
       },
+      "mpn": "CL10A106MA8NRNC",
+      "description": "Capacitor, X5R, ±20%, 25V",
       "value": "10µF"
     },
     "SB39": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7906,11 +7869,11 @@
           "net": "VSUPPLY"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "SW10": {
-      "mpn": "CAS-220TA",
-      "description": "Slide Switch DPDT J Hook",
       "pins": {
         "1": {
           "name": "N.O-1",
@@ -7937,11 +7900,11 @@
           "net": "VDD"
         }
       },
+      "mpn": "CAS-220TA",
+      "description": "Slide Switch DPDT J Hook",
       "value": "CAS-220TA"
     },
     "SB48": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -7952,11 +7915,11 @@
           "net": "VBUS"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "U24": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -7975,11 +7938,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "U25": {
-      "mpn": "74LVC1G08GW",
-      "description": "Single 2-Input AND Gate",
       "pins": {
         "1": {
           "name": "A",
@@ -8002,11 +7965,11 @@
           "net": "VSUPPLY"
         }
       },
+      "mpn": "74LVC1G08GW",
+      "description": "Single 2-Input AND Gate",
       "value": "74LVC1G08"
     },
     "U21": {
-      "mpn": "74LVC1G11GW",
-      "description": "Single 3-input AND gate",
       "pins": {
         "1": {
           "name": "A",
@@ -8033,11 +7996,11 @@
           "net": "VEXT_EN_INV"
         }
       },
+      "mpn": "74LVC1G11GW",
+      "description": "Single 3-input AND gate",
       "value": "74LVC1G11"
     },
     "U20": {
-      "mpn": "74LVC1G08GW",
-      "description": "Single 2-Input AND Gate",
       "pins": {
         "1": {
           "name": "A",
@@ -8060,29 +8023,29 @@
           "net": "VSUPPLY"
         }
       },
+      "mpn": "74LVC1G08GW",
+      "description": "Single 2-Input AND Gate",
       "value": "74LVC1G08"
     },
     "C93": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VSUPPLY"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "R92": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VEXT",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10M"
     },
     "D84": {
-      "mpn": "LS14",
-      "description": "Diode Schottky Vf=0.45, Vr=40V, If=1A, Ir=1µA",
       "pins": {
         "1": {
           "name": "C",
@@ -8093,11 +8056,11 @@
           "net": "V5V"
         }
       },
+      "mpn": "LS14",
+      "description": "Diode Schottky Vf=0.45, Vr=40V, If=1A, Ir=1µA",
       "value": "LS14"
     },
     "Q83": {
-      "mpn": "RV2C010UNT2L",
-      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "pins": {
         "1": {
           "name": "G",
@@ -8112,101 +8075,101 @@
           "net": "NetQ83_3"
         }
       },
+      "mpn": "RV2C010UNT2L",
+      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "value": "RV2C010UNT2L"
     },
     "R93": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "V5V",
         "2": "NetQ83_3"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1k"
     },
     "R94": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetQ83_1",
         "2": "GND"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10M"
     },
     "TP27": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "NetP21_2"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP26": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VBAT"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP33": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VDD_nRF_SENSE"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP34": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "NetQ80_3"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP32": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VBOOST_SRC'"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP35": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VDD_IMCU"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP28": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VBOOST_SRC"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP36": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "V5V"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP29": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VSUPPLY"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "SB58": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -8217,38 +8180,38 @@
           "net": "NetSB58_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "R96": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VSUPPLY",
         "2": "NetQ84_5"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "1M0"
     },
     "R95": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VBAT",
         "2": "NetR95_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "100k"
     },
     "C94": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X5R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VSUPPLY"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X5R, ±10%",
       "value": "100nF"
     },
     "U26": {
-      "mpn": "74LVC1G11GW",
-      "description": "Single 3-input AND gate",
       "pins": {
         "1": {
           "name": "A",
@@ -8275,11 +8238,11 @@
           "net": "VEXT_EN_INV"
         }
       },
+      "mpn": "74LVC1G11GW",
+      "description": "Single 3-input AND gate",
       "value": "74LVC1G11"
     },
     "SW9": {
-      "mpn": "JS203011JCQN",
-      "description": "Slide Switch DP3T 300mA 6V",
       "pins": {
         "1": {
           "name": "N.O",
@@ -8314,20 +8277,20 @@
           "net": "NetR97_2"
         }
       },
+      "mpn": "JS203011JCQN",
+      "description": "Slide Switch DP3T 300mA 6V",
       "value": "JS203011JCQN"
     },
     "R90": {
-      "mpn": "N.A.",
       "pins": {
         "1": "VDD_nRF'",
         "2": "VDD_nRF"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "SB40": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -8338,29 +8301,29 @@
           "net": "VDD_nRF'"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "P22": {
-      "mpn": "1125B-1102S0Z135CR06",
-      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "pins": {
         "1": "VDD_nRF",
         "2": "VDD_nRF'"
       },
+      "mpn": "1125B-1102S0Z135CR06",
+      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "value": "Pin List 1x2, Angled"
     },
     "R91": {
-      "mpn": "N.A.",
       "pins": {
         "1": "VDD_HV'",
         "2": "VDD_HV"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     },
     "SB41": {
-      "mpn": "N.A.",
-      "description": "Shorted Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -8371,29 +8334,29 @@
           "net": "VDD_HV'"
         }
       },
+      "mpn": "N.A.",
+      "description": "Shorted Solderbridge",
       "value": "Solderbridge"
     },
     "P23": {
-      "mpn": "1125B-1102S0Z135CR06",
-      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "pins": {
         "1": "VDD_HV",
         "2": "VDD_HV'"
       },
+      "mpn": "1125B-1102S0Z135CR06",
+      "description": "Pin List 1x2, 2.54mm (100mil), Right Angled, SMD",
       "value": "Pin List 1x2, Angled"
     },
     "C92": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC92_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "1.0µF"
     },
     "SB81": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -8404,20 +8367,20 @@
           "net": "NetC92_2"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "C91": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "GND",
         "2": "VBUS_nRF'"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "1.0µF"
     },
     "SB80": {
-      "mpn": "N.A.",
-      "description": "Solderbridge",
       "pins": {
         "1": {
           "name": "0",
@@ -8428,87 +8391,87 @@
           "net": "VBUS_nRF'"
         }
       },
+      "mpn": "N.A.",
+      "description": "Solderbridge",
       "value": "Solderbridge"
     },
     "TP38": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "NetR98_1"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP24": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VDD_nRF"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP25": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VDD_HV"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP37": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "VDD"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "TP39": {
-      "mpn": "N.A.",
-      "description": "1.0mm circular SMD testpad",
       "pins": {
         "1": "GND"
       },
+      "mpn": "N.A.",
+      "description": "1.0mm circular SMD testpad",
       "value": "Ø1.0mm,SMD"
     },
     "R97": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VBUS_nRF'",
         "2": "NetR97_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "4R7"
     },
     "R98": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetR98_1",
         "2": "VBUS_nRF"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "4R7"
     },
     "Bat1": {
-      "mpn": "L-KLS5-CR2032-23-B1",
-      "description": "Bat Holder CR2032 SMD",
       "pins": {
         "1": "VBAT",
         "2": "GND"
       },
+      "mpn": "L-KLS5-CR2032-23-B1",
+      "description": "Bat Holder CR2032 SMD",
       "value": "Bat Holder CR2032"
     },
     "R99": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD_nRF_SENSE",
         "2": "VIO_REF"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10k"
     },
     "Q84": {
-      "mpn": "PMCPB5530X,115",
-      "description": "Mosfet Array N and P-Channel 20V 4A (Ta), 3.4A (Ta) 490mW Surface Mount 6-HUSON-EP (2x2)",
       "pins": {
         "1": "GND",
         "2": "NetQ84_2",
@@ -8526,11 +8489,11 @@
         },
         "6": "NetQ84_5"
       },
+      "mpn": "PMCPB5530X,115",
+      "description": "Mosfet Array N and P-Channel 20V 4A (Ta), 3.4A (Ta) 490mW Surface Mount 6-HUSON-EP (2x2)",
       "value": "PMCPB5530"
     },
     "Q1": {
-      "mpn": "RV2C010UNT2L",
-      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "pins": {
         "1": {
           "name": "G",
@@ -8545,38 +8508,38 @@
           "net": "NetQ1_3"
         }
       },
+      "mpn": "RV2C010UNT2L",
+      "description": "N-Channel MOSFET, 20V, 1A, 470mOhm, 400mW",
       "value": "RV2C010UNT2L"
     },
     "R6": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "NetQ1_3",
         "2": "VDD_nRF_SENSE"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "47k"
     },
     "C53": {
-      "mpn": "N.A.",
-      "description": "Capacitor, X7R, ±10%",
       "pins": {
         "1": "GND",
         "2": "NetC53_2"
       },
+      "mpn": "N.A.",
+      "description": "Capacitor, X7R, ±10%",
       "value": "10nF"
     },
     "R5": {
-      "mpn": "N.A.",
-      "description": "Resistor, ±1%, 0.05W",
       "pins": {
         "1": "VDD_nRF_SENSE",
         "2": "NetC53_2"
       },
+      "mpn": "N.A.",
+      "description": "Resistor, ±1%, 0.05W",
       "value": "10M"
     },
     "U9": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -8595,11 +8558,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "U10": {
-      "mpn": "TCK106AG,LF",
-      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "pins": {
         "A2": {
           "name": "VIN",
@@ -8618,11 +8581,11 @@
           "net": "GND"
         }
       },
+      "mpn": "TCK106AG,LF",
+      "description": "1.0 A Load Switch IC with Slew Rate Control Driver in Ultra Small Package",
       "value": "TCK106AG"
     },
     "U12": {
-      "mpn": "XC9148A50CER-G",
-      "description": "1.4A Driver Transistor Built-In, Multi Functional Step-Up DC/DC Converter",
       "pins": {
         "1": {
           "name": "BAT",
@@ -8653,23 +8616,25 @@
           "net": "GND"
         }
       },
+      "mpn": "XC9148A50CER-G",
+      "description": "1.4A Driver Transistor Built-In, Multi Functional Step-Up DC/DC Converter",
       "value": "XC9148"
     },
     "L80": {
-      "mpn": "VLS3012HBX-4R7M-N",
-      "description": "4.7µH Shielded Wirewound Inductor 2.23A 201 mOhm Max Nonstandard",
       "pins": {
         "1": "VBOOST_SRC",
         "2": "NetL80_2"
       },
+      "mpn": "VLS3012HBX-4R7M-N",
+      "description": "4.7µH Shielded Wirewound Inductor 2.23A 201 mOhm Max Nonstandard",
       "value": "4.7µH"
     },
     "C96": {
-      "mpn": "N.A.",
       "pins": {
         "1": "GND",
         "2": "V5V"
       },
+      "mpn": "N.A.",
       "value": "N.C.",
       "dns": true
     }

--- a/test/golden/altium/q23-harness.json
+++ b/test/golden/altium/q23-harness.json
@@ -39,7 +39,8 @@
       "REAR_LOOM_CONN": [
         "2",
         "44",
-        "50"
+        "50",
+        "23"
       ],
       "REAR_WHEEL_BULK": [
         "1",
@@ -52,6 +53,24 @@
         "3",
         "6",
         "9"
+      ],
+      "ECU_CONN_B": [
+        "26"
+      ],
+      "INLET_MANI_PRESSURE_CONN": [
+        "1"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "3"
+      ],
+      "APPS_CONN2": [
+        "1"
+      ],
+      "FRONT_BR_PRES?": [
+        "1"
+      ],
+      "REAR_BR_PRES?": [
+        "1"
       ]
     },
     "BSPD_FAULT_n": {
@@ -76,6 +95,9 @@
       ],
       "REAR_LOOM_CONN": [
         "27"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "5"
       ]
     },
     "PDM_GND": {
@@ -90,6 +112,12 @@
       ],
       "LAMBDA_SEN_CONN": [
         "1"
+      ],
+      "PDM_CONN_A": [
+        "28"
+      ],
+      "PDM_CONN_B": [
+        "22"
       ],
       "BRAKE_OT_CONN": [
         "2"
@@ -106,72 +134,20 @@
       ],
       "UNDERLEGS_BULKHEAD_CONN": [
         "2"
-      ]
-    },
-    "DRIVER_SWITCH_1": {
-      "STEERING_QUICK_CONN": [
+      ],
+      "IGNITION_CONN": [
+        "4"
+      ],
+      "FUEL_PUMP_CONN": [
+        "3",
+        "4"
+      ],
+      "INJECTOR_CONN": [
+        "4",
         "5"
       ],
-      "STEERING_BULKHEAD_CONN": [
-        "5"
-      ],
-      "ECU_CONN_D": [
-        "2"
-      ]
-    },
-    "DRIVER_SWITCH_2": {
-      "STEERING_QUICK_CONN": [
-        "6"
-      ],
-      "STEERING_BULKHEAD_CONN": [
-        "6"
-      ],
-      "ECU_CONN_D": [
-        "8"
-      ]
-    },
-    "DRIVER_SWITCH_3": {
-      "STEERING_QUICK_CONN": [
-        "7"
-      ],
-      "STEERING_BULKHEAD_CONN": [
-        "7"
-      ],
-      "ECU_CONN_D": [
-        "9"
-      ]
-    },
-    "DRIVER_SWITCH_4": {
-      "STEERING_QUICK_CONN": [
-        "8"
-      ],
-      "STEERING_BULKHEAD_CONN": [
-        "8"
-      ],
-      "ECU_CONN_D": [
-        "10"
-      ]
-    },
-    "KILL_SWITCH_IN": {
-      "KILL_SWITCH_CONN": [
+      "BRAKE_LIGHT_CONN": [
         "1"
-      ],
-      "DASH_BULKHEAD_CONN": [
-        "9"
-      ],
-      "PDM_CONN_A": [
-        "19"
-      ]
-    },
-    "GND": {
-      "KILL_SWITCH_CONN": [
-        "2"
-      ],
-      "KNOCK_CONN": [
-        "3"
-      ],
-      "TRANSPONDER_CONN": [
-        "2"
       ]
     },
     "FL_DAMPER_POT": {
@@ -242,6 +218,50 @@
         "5",
         "8",
         "11"
+      ],
+      "KILL_SWITCH_CONN": [
+        "2"
+      ],
+      "DATA_LOGGER_CONN": [
+        "7"
+      ],
+      "ECU_CONN_A": [
+        "24",
+        "25",
+        "32"
+      ],
+      "ECU_CONN_C": [
+        "10",
+        "11"
+      ],
+      "KNOCK_CONN": [
+        "3"
+      ],
+      "ENGINE_SPEED_CONN": [
+        "3"
+      ],
+      "ENGINE_CAM_SEN_CONN": [
+        "3"
+      ],
+      "INLET_MANI_PRESSURE_CONN": [
+        "3"
+      ],
+      "GEAR_SHIFT_ACT_CONN": [
+        "2",
+        "4"
+      ],
+      "TURBO_CONN": [
+        "2",
+        "4"
+      ],
+      "APPS_CONN2": [
+        "3"
+      ],
+      "FRONT_BR_PRES?": [
+        "3"
+      ],
+      "REAR_BR_PRES?": [
+        "3"
       ]
     },
     "FR_DAMPER_POT": {
@@ -279,11 +299,11 @@
       "LAMBDA_SEN_CONN": [
         "3"
       ],
-      "PDM_CAN_CONN": [
-        "1"
-      ],
       "REAR_LOOM_CONN": [
         "20"
+      ],
+      "PDM_CAN_CONN": [
+        "1"
       ]
     },
     "CAN_N": {
@@ -305,11 +325,55 @@
       "LAMBDA_SEN_CONN": [
         "2"
       ],
-      "PDM_CAN_CONN": [
-        "2"
-      ],
       "REAR_LOOM_CONN": [
         "22"
+      ],
+      "PDM_CAN_CONN": [
+        "2"
+      ]
+    },
+    "DRIVER_SWITCH_1": {
+      "STEERING_QUICK_CONN": [
+        "5"
+      ],
+      "STEERING_BULKHEAD_CONN": [
+        "5"
+      ],
+      "ECU_CONN_D": [
+        "2"
+      ]
+    },
+    "DRIVER_SWITCH_2": {
+      "STEERING_QUICK_CONN": [
+        "6"
+      ],
+      "STEERING_BULKHEAD_CONN": [
+        "6"
+      ],
+      "ECU_CONN_D": [
+        "8"
+      ]
+    },
+    "DRIVER_SWITCH_3": {
+      "STEERING_QUICK_CONN": [
+        "7"
+      ],
+      "STEERING_BULKHEAD_CONN": [
+        "7"
+      ],
+      "ECU_CONN_D": [
+        "9"
+      ]
+    },
+    "DRIVER_SWITCH_4": {
+      "STEERING_QUICK_CONN": [
+        "8"
+      ],
+      "STEERING_BULKHEAD_CONN": [
+        "8"
+      ],
+      "ECU_CONN_D": [
+        "10"
       ]
     },
     "PDM_CAN_GND": {
@@ -318,12 +382,17 @@
       ],
       "DASH_BULKHEAD_CONN": [
         "7"
+      ]
+    },
+    "KILL_SWITCH_IN": {
+      "KILL_SWITCH_CONN": [
+        "1"
+      ],
+      "DASH_BULKHEAD_CONN": [
+        "9"
       ],
       "PDM_CONN_A": [
-        "28"
-      ],
-      "PDM_CONN_B": [
-        "22"
+        "19"
       ]
     },
     "IGNITION_SWITCH_IN": {
@@ -359,20 +428,6 @@
       ],
       "UNDERLEGS_BULKHEAD_CONN": [
         "4"
-      ]
-    },
-    "VBATT-": {
-      "DATA_LOGGER_CONN": [
-        "7"
-      ],
-      "ECU_CONN_A": [
-        "24",
-        "25",
-        "32"
-      ],
-      "ECU_CONN_C": [
-        "10",
-        "11"
       ]
     },
     "DATA_LOGGER_VBATT": {
@@ -440,263 +495,6 @@
         "4"
       ]
     },
-    "INLET_AIR_TEMP": {
-      "ECU_CONN_D": [
-        "3"
-      ],
-      "REAR_LOOM_CONN": [
-        "5"
-      ]
-    },
-    "SEN_0V_A": {
-      "ECU_CONN_D": [
-        "15"
-      ],
-      "REAR_LOOM_CONN": [
-        "7"
-      ]
-    },
-    "COOLANT_TEMP": {
-      "ECU_CONN_A": [
-        "1"
-      ],
-      "REAR_LOOM_CONN": [
-        "9"
-      ]
-    },
-    "SEN_0V_C1": {
-      "ECU_CONN_A": [
-        "26"
-      ],
-      "REAR_LOOM_CONN": [
-        "11"
-      ]
-    },
-    "SEN_5V_B": {
-      "ECU_CONN_C": [
-        "9"
-      ],
-      "REAR_LOOM_CONN": [
-        "13"
-      ]
-    },
-    "SEN_0V_B": {
-      "ECU_CONN_D": [
-        "16"
-      ],
-      "REAR_LOOM_CONN": [
-        "17"
-      ]
-    },
-    "GEAR_SHIFT_ACTUATOR_PRESSURE": {
-      "ECU_CONN_C": [
-        "14"
-      ],
-      "REAR_LOOM_CONN": [
-        "15"
-      ]
-    },
-    "SEN_5V_A2": {
-      "ECU_CONN_C": [
-        "2"
-      ],
-      "PEDALBOX_BULKHEAD_CONN": [
-        "4"
-      ]
-    },
-    "SEN_0V_A1": {
-      "ECU_CONN_A": [
-        "34"
-      ],
-      "PEDALBOX_BULKHEAD_CONN": [
-        "6"
-      ]
-    },
-    "APPS_VOLTAGE1": {
-      "ECU_CONN_C": [
-        "15"
-      ],
-      "PEDALBOX_BULKHEAD_CONN": [
-        "5"
-      ]
-    },
-    "SEN_5V_C1": {
-      "ECU_CONN_A": [
-        "10"
-      ],
-      "REAR_LOOM_CONN": [
-        "31"
-      ]
-    },
-    "SEN_0V_B1": {
-      "ECU_CONN_A": [
-        "33"
-      ],
-      "REAR_LOOM_CONN": [
-        "35"
-      ]
-    },
-    "FUEL_COMP_VOLTAGE": {
-      "ECU_CONN_D": [
-        "11"
-      ],
-      "REAR_LOOM_CONN": [
-        "33"
-      ]
-    },
-    "CYLINDER_KNOCK": {
-      "ECU_CONN_D": [
-        "7"
-      ],
-      "REAR_LOOM_CONN": [
-        "1"
-      ]
-    },
-    "SEN_5V_C2": {
-      "ECU_CONN_A": [
-        "18"
-      ],
-      "REAR_LOOM_CONN": [
-        "43"
-      ]
-    },
-    "ENGINE_SPEED_IN": {
-      "ECU_CONN_D": [
-        "1"
-      ],
-      "REAR_LOOM_CONN": [
-        "45"
-      ]
-    },
-    "SEN_5V_B2": {
-      "ECU_CONN_A": [
-        "19"
-      ],
-      "REAR_LOOM_CONN": [
-        "37"
-      ]
-    },
-    "ENGINE_SYNC_CAM_IN": {
-      "ECU_CONN_D": [
-        "14"
-      ],
-      "REAR_LOOM_CONN": [
-        "39"
-      ]
-    },
-    "SEN_5V_A1": {
-      "ECU_CONN_B": [
-        "26"
-      ],
-      "REAR_LOOM_CONN": [
-        "23"
-      ]
-    },
-    "INLET_MAN_PRESS_SEN": {
-      "ECU_CONN_D": [
-        "22"
-      ],
-      "REAR_LOOM_CONN": [
-        "46"
-      ]
-    },
-    "TB_MOTOR+": {
-      "ECU_CONN_C": [
-        "1"
-      ],
-      "REAR_LOOM_CONN": [
-        "25"
-      ]
-    },
-    "TB_MOTOR-": {
-      "ECU_CONN_C": [
-        "18"
-      ],
-      "REAR_LOOM_CONN": [
-        "19"
-      ]
-    },
-    "TPS_TRACKING_VOLTAGE": {
-      "ECU_CONN_C": [
-        "17"
-      ],
-      "REAR_LOOM_CONN": [
-        "29"
-      ]
-    },
-    "SEN_0V_C2": {
-      "ECU_CONN_A": [
-        "27"
-      ],
-      "REAR_LOOM_CONN": [
-        "21"
-      ]
-    },
-    "GEAR_SHIFT_UP_CTRL": {
-      "ECU_CONN_C": [
-        "32"
-      ],
-      "REAR_LOOM_CONN": [
-        "36"
-      ]
-    },
-    "GEAR_SHIFT_DOWN_CTRL": {
-      "ECU_CONN_C": [
-        "33"
-      ],
-      "REAR_LOOM_CONN": [
-        "40"
-      ]
-    },
-    "TURBO_ACT_BYP": {
-      "ECU_CONN_C": [
-        "34"
-      ],
-      "REAR_LOOM_CONN": [
-        "28"
-      ]
-    },
-    "BOOST_ACT_OUT": {
-      "ECU_CONN_B": [
-        "21"
-      ],
-      "REAR_LOOM_CONN": [
-        "32"
-      ]
-    },
-    "APPS_VOLTAGE2": {
-      "ECU_CONN_B": [
-        "16"
-      ],
-      "PEDALBOX_BULKHEAD_CONN": [
-        "2"
-      ]
-    },
-    "GEAR_POS_SIG": {
-      "ECU_CONN_D": [
-        "21"
-      ],
-      "GEAR_POS_CONN": [
-        "2"
-      ],
-      "PDM_CONN_B": [
-        "24"
-      ],
-      "REAR_LOOM_CONN": [
-        "4"
-      ]
-    },
-    "FUEL_PRES_SEN": {
-      "ECU_CONN_C": [
-        "25"
-      ],
-      "FUEL_PRES_CONN": [
-        "2"
-      ],
-      "REAR_LOOM_CONN": [
-        "16"
-      ]
-    },
     "OIL_PRESSURE_SWITCH": {
       "ECU_CONN_A": [
         "2"
@@ -706,6 +504,72 @@
       ],
       "REAR_LOOM_CONN": [
         "3"
+      ]
+    },
+    "COOLANT_TEMP": {
+      "ECU_CONN_A": [
+        "1"
+      ],
+      "REAR_LOOM_CONN": [
+        "9"
+      ],
+      "COOLANT_TEMP_CONN": [
+        "1"
+      ]
+    },
+    "SEN_5V_C1": {
+      "ECU_CONN_A": [
+        "10"
+      ],
+      "REAR_LOOM_CONN": [
+        "31"
+      ],
+      "FUEL_COMP_SEN_CONN": [
+        "1"
+      ]
+    },
+    "SEN_5V_C2": {
+      "ECU_CONN_A": [
+        "18"
+      ],
+      "REAR_LOOM_CONN": [
+        "43"
+      ],
+      "ENGINE_SPEED_CONN": [
+        "1"
+      ]
+    },
+    "SEN_5V_B2": {
+      "ECU_CONN_A": [
+        "19"
+      ],
+      "REAR_LOOM_CONN": [
+        "37"
+      ],
+      "ENGINE_CAM_SEN_CONN": [
+        "1"
+      ]
+    },
+    "SEN_0V_C1": {
+      "ECU_CONN_A": [
+        "26"
+      ],
+      "REAR_LOOM_CONN": [
+        "11"
+      ],
+      "COOLANT_TEMP_CONN": [
+        "2"
+      ]
+    },
+    "SEN_0V_C2": {
+      "ECU_CONN_A": [
+        "27"
+      ],
+      "REAR_LOOM_CONN": [
+        "21"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "2"
       ]
     },
     "ECU_CAN2_P": {
@@ -722,6 +586,28 @@
       ],
       "ECU_CAN_CONNECTOR": [
         "2"
+      ]
+    },
+    "SEN_0V_B1": {
+      "ECU_CONN_A": [
+        "33"
+      ],
+      "REAR_LOOM_CONN": [
+        "35"
+      ],
+      "FUEL_COMP_SEN_CONN": [
+        "3"
+      ]
+    },
+    "SEN_0V_A1": {
+      "ECU_CONN_A": [
+        "34"
+      ],
+      "PEDALBOX_BULKHEAD_CONN": [
+        "6"
+      ],
+      "APPS_CONN1": [
+        "3"
       ]
     },
     "WHEEL_SPEED_FL": {
@@ -762,6 +648,9 @@
       ],
       "PEDALBOX_BULKHEAD_CONN": [
         "11"
+      ],
+      "FRONT_BR_PRES?": [
+        "2"
       ]
     },
     "REAR_BR_PRES": {
@@ -770,6 +659,9 @@
       ],
       "PEDALBOX_BULKHEAD_CONN": [
         "14"
+      ],
+      "REAR_BR_PRES?": [
+        "2"
       ]
     },
     "ECU_VBATT": {
@@ -789,6 +681,17 @@
         "13"
       ]
     },
+    "APPS_VOLTAGE2": {
+      "ECU_CONN_B": [
+        "16"
+      ],
+      "PEDALBOX_BULKHEAD_CONN": [
+        "2"
+      ],
+      "APPS_CONN2": [
+        "2"
+      ]
+    },
     "NetECU_CONN_B_17": {
       "ECU_CONN_B": [
         "17"
@@ -799,12 +702,103 @@
         "18"
       ]
     },
+    "BOOST_ACT_OUT": {
+      "ECU_CONN_B": [
+        "21"
+      ],
+      "REAR_LOOM_CONN": [
+        "32"
+      ],
+      "TURBO_CONN": [
+        "3"
+      ]
+    },
+    "SEN_5V_A2": {
+      "ECU_CONN_C": [
+        "2"
+      ],
+      "PEDALBOX_BULKHEAD_CONN": [
+        "4"
+      ],
+      "APPS_CONN1": [
+        "1"
+      ]
+    },
+    "TB_MOTOR+": {
+      "ECU_CONN_C": [
+        "1"
+      ],
+      "REAR_LOOM_CONN": [
+        "25"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "4"
+      ]
+    },
     "IGNITION_CTRL_OUT": {
       "ECU_CONN_C": [
         "4"
       ],
       "REAR_LOOM_CONN": [
         "15"
+      ],
+      "IGNITION_CONN": [
+        "3"
+      ]
+    },
+    "SEN_5V_B": {
+      "ECU_CONN_C": [
+        "9"
+      ],
+      "REAR_LOOM_CONN": [
+        "13"
+      ],
+      "GEAR_SHIFT_ACT_PRESSURE_CONN": [
+        "1"
+      ]
+    },
+    "GEAR_SHIFT_ACTUATOR_PRESSURE": {
+      "ECU_CONN_C": [
+        "14"
+      ],
+      "REAR_LOOM_CONN": [
+        "15"
+      ],
+      "GEAR_SHIFT_ACT_PRESSURE_CONN": [
+        "2"
+      ]
+    },
+    "APPS_VOLTAGE1": {
+      "ECU_CONN_C": [
+        "15"
+      ],
+      "PEDALBOX_BULKHEAD_CONN": [
+        "5"
+      ],
+      "APPS_CONN1": [
+        "2"
+      ]
+    },
+    "TPS_TRACKING_VOLTAGE": {
+      "ECU_CONN_C": [
+        "17"
+      ],
+      "REAR_LOOM_CONN": [
+        "29"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "6"
+      ]
+    },
+    "TB_MOTOR-": {
+      "ECU_CONN_C": [
+        "18"
+      ],
+      "REAR_LOOM_CONN": [
+        "19"
+      ],
+      "THROTTLE_BODY_CONN": [
+        "1"
       ]
     },
     "INJECTOR_CTRL_OUT": {
@@ -813,11 +807,160 @@
       ],
       "REAR_LOOM_CONN": [
         "5"
+      ],
+      "INJECTOR_CONN": [
+        "3"
+      ]
+    },
+    "FUEL_PRES_SEN": {
+      "ECU_CONN_C": [
+        "25"
+      ],
+      "FUEL_PRES_CONN": [
+        "2"
+      ],
+      "REAR_LOOM_CONN": [
+        "16"
+      ]
+    },
+    "GEAR_SHIFT_UP_CTRL": {
+      "ECU_CONN_C": [
+        "32"
+      ],
+      "REAR_LOOM_CONN": [
+        "36"
+      ],
+      "GEAR_SHIFT_ACT_CONN": [
+        "1"
+      ]
+    },
+    "GEAR_SHIFT_DOWN_CTRL": {
+      "ECU_CONN_C": [
+        "33"
+      ],
+      "REAR_LOOM_CONN": [
+        "40"
+      ],
+      "GEAR_SHIFT_ACT_CONN": [
+        "3"
+      ]
+    },
+    "TURBO_ACT_BYP": {
+      "ECU_CONN_C": [
+        "34"
+      ],
+      "REAR_LOOM_CONN": [
+        "28"
+      ],
+      "TURBO_CONN": [
+        "1"
+      ]
+    },
+    "ENGINE_SPEED_IN": {
+      "ECU_CONN_D": [
+        "1"
+      ],
+      "REAR_LOOM_CONN": [
+        "45"
+      ],
+      "ENGINE_SPEED_CONN": [
+        "2"
+      ]
+    },
+    "INLET_AIR_TEMP": {
+      "ECU_CONN_D": [
+        "3"
+      ],
+      "REAR_LOOM_CONN": [
+        "5"
+      ],
+      "INLET_TEMP_CONN": [
+        "1"
+      ]
+    },
+    "CYLINDER_KNOCK": {
+      "ECU_CONN_D": [
+        "7"
+      ],
+      "REAR_LOOM_CONN": [
+        "1"
+      ],
+      "KNOCK_CONN": [
+        "2"
+      ]
+    },
+    "FUEL_COMP_VOLTAGE": {
+      "ECU_CONN_D": [
+        "11"
+      ],
+      "REAR_LOOM_CONN": [
+        "33"
+      ],
+      "FUEL_COMP_SEN_CONN": [
+        "2"
+      ]
+    },
+    "ENGINE_SYNC_CAM_IN": {
+      "ECU_CONN_D": [
+        "14"
+      ],
+      "REAR_LOOM_CONN": [
+        "39"
+      ],
+      "ENGINE_CAM_SEN_CONN": [
+        "2"
+      ]
+    },
+    "SEN_0V_A": {
+      "ECU_CONN_D": [
+        "15"
+      ],
+      "REAR_LOOM_CONN": [
+        "7"
+      ],
+      "INLET_TEMP_CONN": [
+        "2"
+      ]
+    },
+    "SEN_0V_B": {
+      "ECU_CONN_D": [
+        "16"
+      ],
+      "REAR_LOOM_CONN": [
+        "17"
+      ],
+      "GEAR_SHIFT_ACT_PRESSURE_CONN": [
+        "3"
       ]
     },
     "SEN_6V3": {
       "ECU_CONN_D": [
         "19"
+      ]
+    },
+    "GEAR_POS_SIG": {
+      "ECU_CONN_D": [
+        "21"
+      ],
+      "GEAR_POS_CONN": [
+        "2"
+      ],
+      "PDM_CONN_B": [
+        "24"
+      ],
+      "REAR_LOOM_CONN": [
+        "4"
+      ]
+    },
+    "INLET_MAN_PRESS_SEN": {
+      "ECU_CONN_D": [
+        "22"
+      ],
+      "REAR_LOOM_CONN": [
+        "46"
+      ],
+      "INLET_MANI_PRESSURE_CONN": [
+        "2"
       ]
     },
     "ECU_ETH_TX_P": {
@@ -850,112 +993,6 @@
       ],
       "ECU_ETH_CONN": [
         "4"
-      ]
-    },
-    "ANALOG_1K_PULLUP_IN": {
-      "INLET_TEMP_CONN": [
-        "1"
-      ]
-    },
-    "SEN_0V": {
-      "INLET_TEMP_CONN": [
-        "2"
-      ],
-      "APPS_CONN1": [
-        "3"
-      ]
-    },
-    "SEN_5V": {
-      "INLET_MANI_PRESSURE_CONN": [
-        "1"
-      ],
-      "APPS_CONN1": [
-        "1"
-      ]
-    },
-    "SIGNAL": {
-      "INLET_MANI_PRESSURE_CONN": [
-        "2"
-      ]
-    },
-    "SIGNAL_CTRL": {
-      "KNOCK_CONN": [
-        "2"
-      ]
-    },
-    "SHIFT_UP_CTRL": {
-      "GEAR_SHIFT_ACT_CONN": [
-        "1"
-      ]
-    },
-    "SHIFT_DOWN_CTRL": {
-      "GEAR_SHIFT_ACT_CONN": [
-        "3"
-      ]
-    },
-    "SHIFT_UP_CTRL_GND": {
-      "GEAR_SHIFT_ACT_CONN": [
-        "2"
-      ]
-    },
-    "SHIFT_DOWN_CTRL_GND": {
-      "GEAR_SHIFT_ACT_CONN": [
-        "4"
-      ]
-    },
-    "POWER1": {
-      "INJECTOR_CONN": [
-        "1"
-      ]
-    },
-    "CTRL": {
-      "INJECTOR_CONN": [
-        "3"
-      ]
-    },
-    "GND1": {
-      "INJECTOR_CONN": [
-        "4"
-      ]
-    },
-    "GND2": {
-      "INJECTOR_CONN": [
-        "5"
-      ]
-    },
-    "POWER2": {
-      "INJECTOR_CONN": [
-        "2"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_1": {
-      "THROTTLE_BODY_CONN": [
-        "1"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_2": {
-      "THROTTLE_BODY_CONN": [
-        "2"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_3": {
-      "THROTTLE_BODY_CONN": [
-        "3"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_4": {
-      "THROTTLE_BODY_CONN": [
-        "4"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_5": {
-      "THROTTLE_BODY_CONN": [
-        "5"
-      ]
-    },
-    "NetTHROTTLE_BODY_CONN_6": {
-      "THROTTLE_BODY_CONN": [
-        "6"
       ]
     },
     "NetRL_DAMP_CONN_1": {
@@ -1031,36 +1068,6 @@
         "3"
       ]
     },
-    "NetTURBO_CONN_1": {
-      "TURBO_CONN": [
-        "1"
-      ]
-    },
-    "NetTURBO_CONN_2": {
-      "TURBO_CONN": [
-        "2"
-      ]
-    },
-    "NetTURBO_CONN_3": {
-      "TURBO_CONN": [
-        "3"
-      ]
-    },
-    "NetTURBO_CONN_4": {
-      "TURBO_CONN": [
-        "4"
-      ]
-    },
-    "NetBRAKE_LIGHT_CONN_1": {
-      "BRAKE_LIGHT_CONN": [
-        "1"
-      ]
-    },
-    "NetBRAKE_LIGHT_CONN_2": {
-      "BRAKE_LIGHT_CONN": [
-        "2"
-      ]
-    },
     "FAN_POWER": {
       "FAN_CONN": [
         "2"
@@ -1092,6 +1099,10 @@
       "REAR_LOOM_CONN": [
         "11",
         "13"
+      ],
+      "IGNITION_CONN": [
+        "1",
+        "2"
       ]
     },
     "FUEL_PUMP_POWER": {
@@ -1102,6 +1113,10 @@
       "REAR_LOOM_CONN": [
         "21",
         "23"
+      ],
+      "FUEL_PUMP_CONN": [
+        "1",
+        "2"
       ]
     },
     "FUEL_INJECTOR_POWER": {
@@ -1110,6 +1125,10 @@
       ],
       "REAR_LOOM_CONN": [
         "1"
+      ],
+      "INJECTOR_CONN": [
+        "1",
+        "2"
       ]
     },
     "TRANSPONDER_POWER": {
@@ -1131,6 +1150,9 @@
       ],
       "REAR_WHEEL_BULK": [
         "13"
+      ],
+      "BRAKE_LIGHT_CONN": [
+        "2"
       ]
     },
     "THROTTLE_BODY_POTI+": {
@@ -1188,49 +1210,12 @@
         "2"
       ]
     },
-    "APPS2_VOLTAGE": {
-      "APPS_CONN2": [
-        "2"
-      ]
-    },
-    "APPS1_VOLTAGE": {
-      "APPS_CONN1": [
-        "2"
-      ]
-    },
-    "NetFRONT_BR_PRES?_1": {
-      "FRONT_BR_PRES?": [
-        "1"
-      ]
-    },
-    "NetFRONT_BR_PRES?_2": {
-      "FRONT_BR_PRES?": [
-        "2"
-      ]
-    },
-    "NetFRONT_BR_PRES?_3": {
-      "FRONT_BR_PRES?": [
-        "3"
-      ]
-    },
-    "NetREAR_BR_PRES?_1": {
-      "REAR_BR_PRES?": [
-        "1"
-      ]
-    },
-    "NetREAR_BR_PRES?_2": {
-      "REAR_BR_PRES?": [
-        "2"
-      ]
-    },
-    "NetREAR_BR_PRES?_3": {
-      "REAR_BR_PRES?": [
-        "3"
-      ]
-    },
     "IGNITION_SEN_0V": {
       "REAR_LOOM_CONN": [
         "29"
+      ],
+      "IGNITION_CONN": [
+        "5"
       ]
     },
     "VIN": {
@@ -1244,9 +1229,14 @@
         "2"
       ]
     },
-    "PWR": {
+    "NetTRANSPONDER_CONN_1": {
       "TRANSPONDER_CONN": [
         "1"
+      ]
+    },
+    "NetTRANSPONDER_CONN_2": {
+      "TRANSPONDER_CONN": [
+        "2"
       ]
     },
     "NetWHEEL_SPEED_FL_CONN_1": {
@@ -1339,7 +1329,7 @@
     "KILL_SWITCH_CONN": {
       "pins": {
         "1": "KILL_SWITCH_IN",
-        "2": "GND"
+        "2": "SIG_GND"
       },
       "description": "Header, 2-Pin",
       "comment": "Header 2"
@@ -1384,7 +1374,7 @@
         "4": "",
         "5": "",
         "6": "",
-        "7": "VBATT-",
+        "7": "SIG_GND",
         "8": "DATA_LOGGER_VBATT",
         "9": "",
         "10": "",
@@ -1521,15 +1511,15 @@
         "21": "",
         "22": "",
         "23": "",
-        "24": "VBATT-",
-        "25": "VBATT-",
+        "24": "SIG_GND",
+        "25": "SIG_GND",
         "26": "SEN_0V_C1",
         "27": "SEN_0V_C2",
         "28": "",
         "29": "",
         "30": "ECU_CAN2_P",
         "31": "ECU_CAN2_N",
-        "32": "VBATT-",
+        "32": "SIG_GND",
         "33": "SEN_0V_B1",
         "34": "SEN_0V_A1"
       },
@@ -1563,7 +1553,7 @@
         "23": "",
         "24": "",
         "25": "",
-        "26": "SEN_5V_A1",
+        "26": "VCC5V",
         "27": "",
         "28": "",
         "29": "",
@@ -1587,8 +1577,8 @@
         "7": "",
         "8": "",
         "9": "SEN_5V_B",
-        "10": "VBATT-",
-        "11": "VBATT-",
+        "10": "SIG_GND",
+        "11": "SIG_GND",
         "12": "",
         "13": "",
         "14": "GEAR_SHIFT_ACTUATOR_PRESSURE",
@@ -1684,73 +1674,73 @@
     },
     "INLET_TEMP_CONN": {
       "pins": {
-        "1": "ANALOG_1K_PULLUP_IN",
-        "2": "SEN_0V"
+        "1": "INLET_AIR_TEMP",
+        "2": "SEN_0V_A"
       },
       "description": "Header, 2-Pin",
       "comment": "Header 2"
     },
     "COOLANT_TEMP_CONN": {
       "pins": {
-        "1": "",
-        "2": ""
+        "1": "COOLANT_TEMP",
+        "2": "SEN_0V_C1"
       },
       "description": "Header, 2-Pin",
       "comment": "Header 2"
     },
     "GEAR_SHIFT_ACT_PRESSURE_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": ""
+        "1": "SEN_5V_B",
+        "2": "GEAR_SHIFT_ACTUATOR_PRESSURE",
+        "3": "SEN_0V_B"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "ENGINE_SPEED_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": ""
+        "1": "SEN_5V_C2",
+        "2": "ENGINE_SPEED_IN",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "ENGINE_CAM_SEN_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": ""
+        "1": "SEN_5V_B2",
+        "2": "ENGINE_SYNC_CAM_IN",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "INLET_MANI_PRESSURE_CONN": {
       "pins": {
-        "1": "SEN_5V",
-        "2": "SIGNAL",
-        "3": ""
+        "1": "VCC5V",
+        "2": "INLET_MAN_PRESS_SEN",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "FUEL_COMP_SEN_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": ""
+        "1": "SEN_5V_C1",
+        "2": "FUEL_COMP_VOLTAGE",
+        "3": "SEN_0V_B1"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "THROTTLE_BODY_CONN": {
       "pins": {
-        "1": "NetTHROTTLE_BODY_CONN_1",
-        "2": "NetTHROTTLE_BODY_CONN_2",
-        "3": "NetTHROTTLE_BODY_CONN_3",
-        "4": "NetTHROTTLE_BODY_CONN_4",
-        "5": "NetTHROTTLE_BODY_CONN_5",
-        "6": "NetTHROTTLE_BODY_CONN_6"
+        "1": "TB_MOTOR-",
+        "2": "SEN_0V_C2",
+        "3": "VCC5V",
+        "4": "TB_MOTOR+",
+        "5": "TPS_VOLTAGE",
+        "6": "TPS_TRACKING_VOLTAGE"
       },
       "description": "Header, 6-Pin",
       "comment": "Header 6"
@@ -1802,21 +1792,21 @@
     },
     "GEAR_SHIFT_ACT_CONN": {
       "pins": {
-        "1": "SHIFT_UP_CTRL",
-        "2": "SHIFT_UP_CTRL_GND",
-        "3": "SHIFT_DOWN_CTRL",
-        "4": "SHIFT_DOWN_CTRL_GND"
+        "1": "GEAR_SHIFT_UP_CTRL",
+        "2": "SIG_GND",
+        "3": "GEAR_SHIFT_DOWN_CTRL",
+        "4": "SIG_GND"
       },
       "description": "Header, 4-Pin",
       "comment": "Header 4"
     },
     "IGNITION_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": "",
-        "4": "",
-        "5": "",
+        "1": "IGNITION_COIL_POWER",
+        "2": "IGNITION_COIL_POWER",
+        "3": "IGNITION_CTRL_OUT",
+        "4": "PDM_GND",
+        "5": "IGNITION_SEN_0V",
         "6": ""
       },
       "description": "Header, 6-Pin",
@@ -1824,31 +1814,31 @@
     },
     "TURBO_CONN": {
       "pins": {
-        "1": "NetTURBO_CONN_1",
-        "2": "NetTURBO_CONN_2",
-        "3": "NetTURBO_CONN_3",
-        "4": "NetTURBO_CONN_4"
+        "1": "TURBO_ACT_BYP",
+        "2": "SIG_GND",
+        "3": "BOOST_ACT_OUT",
+        "4": "SIG_GND"
       },
       "description": "Header, 4-Pin",
       "comment": "Header 4"
     },
     "FUEL_PUMP_CONN": {
       "pins": {
-        "1": "",
-        "2": "",
-        "3": "",
-        "4": ""
+        "1": "FUEL_PUMP_POWER",
+        "2": "FUEL_PUMP_POWER",
+        "3": "PDM_GND",
+        "4": "PDM_GND"
       },
       "description": "Header, 4-Pin",
       "comment": "Header 4"
     },
     "INJECTOR_CONN": {
       "pins": {
-        "1": "POWER1",
-        "2": "POWER2",
-        "3": "CTRL",
-        "4": "GND1",
-        "5": "GND2",
+        "1": "FUEL_INJECTOR_POWER",
+        "2": "FUEL_INJECTOR_POWER",
+        "3": "INJECTOR_CTRL_OUT",
+        "4": "PDM_GND",
+        "5": "PDM_GND",
         "6": ""
       },
       "description": "Header, 6-Pin",
@@ -1856,8 +1846,8 @@
     },
     "BRAKE_LIGHT_CONN": {
       "pins": {
-        "1": "NetBRAKE_LIGHT_CONN_1",
-        "2": "NetBRAKE_LIGHT_CONN_2"
+        "1": "PDM_GND",
+        "2": "BRAKE_LIGHT"
       },
       "description": "Header, 2-Pin",
       "comment": "Header 2"
@@ -1865,8 +1855,8 @@
     "KNOCK_CONN": {
       "pins": {
         "1": "",
-        "2": "SIGNAL_CTRL",
-        "3": "GND"
+        "2": "CYLINDER_KNOCK",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
@@ -1952,7 +1942,7 @@
         "25": "",
         "26": "",
         "27": "IGNITION_SWITCH_IN",
-        "28": "PDM_CAN_GND",
+        "28": "PDM_GND",
         "29": "",
         "30": "",
         "31": "",
@@ -1986,7 +1976,7 @@
         "19": "",
         "20": "BSPD_FAULT_n",
         "21": "BRAKE_OT_n",
-        "22": "PDM_CAN_GND",
+        "22": "PDM_GND",
         "23": "",
         "24": "GEAR_POS_SIG",
         "25": "PDM_CAN_N",
@@ -2046,9 +2036,9 @@
     },
     "APPS_CONN1": {
       "pins": {
-        "1": "SEN_5V",
-        "2": "APPS1_VOLTAGE",
-        "3": "SEN_0V"
+        "1": "SEN_5V_A2",
+        "2": "APPS_VOLTAGE1",
+        "3": "SEN_0V_A1"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
@@ -2070,27 +2060,27 @@
     },
     "APPS_CONN2": {
       "pins": {
-        "1": "",
-        "2": "APPS2_VOLTAGE",
-        "3": ""
+        "1": "VCC5V",
+        "2": "APPS_VOLTAGE2",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "FRONT_BR_PRES?": {
       "pins": {
-        "1": "NetFRONT_BR_PRES?_1",
-        "2": "NetFRONT_BR_PRES?_2",
-        "3": "NetFRONT_BR_PRES?_3"
+        "1": "VCC5V",
+        "2": "FRONT_BR_PRES",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
     },
     "REAR_BR_PRES?": {
       "pins": {
-        "1": "NetREAR_BR_PRES?_1",
-        "2": "NetREAR_BR_PRES?_2",
-        "3": "NetREAR_BR_PRES?_3"
+        "1": "VCC5V",
+        "2": "REAR_BR_PRES",
+        "3": "SIG_GND"
       },
       "description": "Header, 3-Pin",
       "comment": "Header 3"
@@ -2113,17 +2103,17 @@
         "14": "SIG_GND",
         "15": "IGNITION_CTRL_OUT",
         "16": "FUEL_PRES_SEN",
-        "17": "PDM_GND",
+        "17": "SEN_0V_B",
         "18": "PDM_GND",
-        "19": "PDM_GND",
+        "19": "TB_MOTOR-",
         "20": "CAN_P",
         "21": "FUEL_PUMP_POWER",
         "22": "CAN_N",
         "23": "FUEL_PUMP_POWER",
         "24": "LAMBDA_LTC_POWER",
-        "25": "PDM_GND",
+        "25": "TB_MOTOR+",
         "26": "",
-        "27": "PDM_GND",
+        "27": "TPS_VOLTAGE",
         "28": "TURBO_ACT_BYP",
         "29": "IGNITION_SEN_0V",
         "30": "SIG_GND",
@@ -2175,8 +2165,8 @@
     },
     "TRANSPONDER_CONN": {
       "pins": {
-        "1": "PWR",
-        "2": "GND"
+        "1": "NetTRANSPONDER_CONN_1",
+        "2": "NetTRANSPONDER_CONN_2"
       },
       "description": "Header, 2-Pin",
       "comment": "Header 2"


### PR DESCRIPTION
Fixes #115.

## Summary

A net whose label differs either side of a signal harness was reported as two
unconnected nets. The harness was only ever bridging nets by accident: a harness
entry named the net it touched, so two ends agreed only when the entry name and
both wire labels happened to coincide.

Altium is explicit that this is the wrong model — the harness type and its
entries are ["names of the containers that carry the nets, not the names of the
nets themselves"](https://www.altium.com/documentation/altium-designer/schematic/buses-signal-harnesses).
So connectivity now comes from the bundle:

- **A bundle is identified by what its connector's outgoing connection reaches** —
  a harness-typed port (whose name is global), a signal harness line (everything
  meeting it is one bundle), or nothing, in which case it is local to its sheet.
- **Entries of one bundle sharing a name are one net**, however the wires reaching
  them are labelled, within a sheet and across sheets.
- **A bundle goes by a different name at each end** (`TRANSPONDER_POWER_UL` in,
  `TRANSPONDER_POWER` out). The parent sheet shows they are one, by a harness line
  between the two sheet entries naming them; those names are folded together
  project-wide.
- **Harness entries no longer name nets.** A member name is unique only inside its
  bundle — `qfsae/pcb` draws one `3WIRE_PSG_SENSOR` per sensor, each with an entry
  called `SIGNAL`. The one exception Altium documents is honoured: a net label on
  the harness line names the harness, and its nets become `<label>.<entry>`.

Three supporting defects surfaced on the way, each fixed and covered:

- **Half of all harness entries were never placed.** Which edge entries sit on is
  written two ways — `HarnessConnectorSide=1` on the connector (left) or `Side=1`
  on each entry (right) — and only the first was read. 62 of 115 connectors in the
  fixture corpus use the second form. `DistanceFromTop` is also fixed-point
  (`DistanceFromTop_Frac1`), which placed half-step entries 5 units off. The rules
  now put 364 of 365 entries in `qfsae/pcb` and `pulp-bio/HELIOS-R` exactly on the
  end of a wire.
- **Unplaced entries collapsed onto the origin**, where they all appeared to touch.
  They are now skipped.
- **Two nets of the same name on one sheet overwrote each other** in `convertNets`,
  silently dropping the first one's pins. They are merged.

`OwnerIndex` in the `Additional` stream numbers that stream's own records, so it is
rebased when the two record lists are joined; harness entries now nest under their
connector rather than under an unrelated `FileHeader` record.

## Effect on the fixtures

Measured per pin, before against after:

| Design | Pins | Changed | Shape of the change |
|---|---|---|---|
| `qfsae/pcb` | 364 | 77 | sensor pins that were dangling or falsely on a global `GND`/`SIGNAL` now land on the ECU net they belong to |
| `pulp-bio/HELIOS-R` | 392 | 90 | `J4`/`J5` pins that were isolated per channel now join through the internal harnesses |
| `nRF52840-DK pca10056` | 1120 | 161 | header pins joined to the MCU balls they break out, e.g. `P10.5` to `U1.B15` on `P1.14` |
| `aberrant_sound_module` | 429 | 41 | all `(none) -> net`: pins restored by the same-name merge |

`HELIOS-R` already contained the reported case: `channel.SchDoc` labels one side of
its `PGND_Domain` harness `_OP_O` while the other side reaches entry `OP_OUT`, so
`J4.5` and `J5.8` were two nets. They are now one.

No pin loses a connection in any fixture. The remaining renames are nets that
merged and kept the name carried by more pins.

## Changelog

**Fixed**

- Altium: nets are traced through a signal harness by the bundle the harness
  carries, so a net keeps its identity when the wires either side of the harness
  are labelled differently, on one sheet or across sheets.
- Altium: harness entries drawn on the right-hand edge of a connector are now
  placed, roughly doubling the harness entries that take part in connectivity, and
  entries at a fractional `DistanceFromTop` are placed exactly.
- Altium: a harness entry no longer names the net it touches. Entry names are only
  unique within their own harness, so this had been merging unrelated nets. A net
  label placed on the signal harness line still names the nets it carries, as
  `<label>.<entry>`.
- Altium: two nets sharing a name on one sheet are merged instead of the second
  replacing the first and dropping its pins.

## Test plan

- [x] `npm run type-check`, `npm run lint`, `npm test` (732 passed)
- [x] Golden output regenerated for the four designs whose netlist changed, each
      diff inspected pin by pin
- [x] New unit tests: entry placement on both edges and at fractional distances,
      bundle identity through a line and through ports, harness-line naming,
      sheet-entry bundle links, and the issue's own topology end to end