### PR TITLE
ci: let a review that needed no inline comments pass the guard

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -129,15 +129,23 @@ jobs:
               --jq '[.comments[] | select(.author.login == "claude") | .body]')
             count=$(printf '%s' "$bodies" | jq 'length')
             unticked=$(printf '%s' "$bodies" | jq -r '.[]' | grep -cE '^- \[ \]' || true)
+            # The action rewrites its tracking comment in place and stamps it
+            # with its own run time when it is done, so this marker says the run
+            # reached the end rather than dying partway.
+            finished=$(printf '%s' "$bodies" | jq -r '.[]' | grep -cE '^\*\*Claude finished' || true)
 
             if [ "$count" -eq 0 ]; then
               reason="The review posted no comment at all."
             elif [ "$unticked" -gt 0 ]; then
               reason="The review exited with $unticked unfinished todo item(s), so it did not complete."
-            elif [ "$count" -lt 2 ]; then
-              reason="The review left a progress comment but never posted a summary."
+            elif [ "$count" -lt 2 ] && [ "$finished" -eq 0 ]; then
+              # A review with findings posts its summary separately from the
+              # tracking comment, so two comments is the usual shape. One is
+              # equally valid when the PR needed no inline comments at all, and
+              # requiring two failed exactly the PRs that were clean.
+              reason="The review left a progress comment but never finished."
             else
-              echo "Review completed: $count comments, no unticked todos."
+              echo "Review completed: $count comment(s), no unticked todos."
               exit 0
             fi
 


### PR DESCRIPTION
## Summary

The review guard required two comments from `claude`, a progress one and a
separate summary. The action rewrites its single tracking comment in place, and
only posts a second when it has inline findings to summarise. So a PR clean
enough to draw no inline comments ends with exactly one comment, holding a fully
ticked checklist and a verdict, and failed a check it had in fact passed.

That is what happened to #119, the v1.5.1 release PR: the review ran, ticked
every box, said "Verdict: LGTM", and the guard reported "left a progress comment
but never posted a summary". The rule punished precisely the PRs with nothing
wrong with them.

Completion is now read from the marker the action stamps on its comment when the
run ends, rather than inferred from how many comments it happened to write. Two
comments still passes, unchanged.

Checked against the four states the guard has to tell apart:

| Comments | Verdict |
|---|---|
| none | fails, review never ran |
| one, unticked todos | fails, review abandoned |
| one, still running | fails, review never finished |
| one, finished (#119's shape) | passes |
| two (the previous shape) | passes |

## Test plan

- [x] Guard logic exercised against all five cases above
- [ ] This PR edits `claude-code-review.yml`, so the action self-skips for
      workflow validation and the guard exits 0 with a notice. Review by hand.