### PR TITLE
docs: bring the project's own description up to date

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,6 +35,7 @@ What actually happened.
 - [ ] Cadence CIS (.dsn)
 - [ ] Cadence HDL (.cpm)
 - [ ] Altium Designer (.PrjPcb)
+- [ ] KiCad (.kicad_pro)
 
 ## Additional Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MCP server for querying EDA netlists and tracing circuit connectivity. Supports Cadence (CIS, HDL) and Altium Designer formats.
+MCP server for querying EDA netlists and tracing circuit connectivity. Supports Cadence (CIS, HDL), Altium Designer, and KiCad formats.
 
 ## Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,22 +52,17 @@ This project is maintained by:
 ### Project Structure
 
 - `src/` - Main source code
-- `src/parsers/` - Format-specific parsers (Cadence, Altium)
+- `src/parsers/` - Format-specific parsers (Cadence, Altium, KiCad)
 - `test/fixtures/` - Test fixture designs (git submodules)
 - `test/golden/` - Golden reference outputs for regression testing
 - `docs/` - API documentation
 
 ### Test Fixtures
 
-Test fixtures are stored as git submodules pointing to open-source hardware projects:
-
-| Fixture | Source |
-|---------|--------|
-| `test/fixtures/altium/LimeSDR-USB` | [myriadrf/LimeSDR-USB](https://github.com/myriadrf/LimeSDR-USB) |
-| `test/fixtures/altium/Altium-STM32-PCB` | [akhilaprabodha/Altium-STM32-PCB](https://github.com/akhilaprabodha/Altium-STM32-PCB) |
-| `test/fixtures/cadence/BeagleBone-Black` | [beagleboard/beaglebone-black](https://github.com/beagleboard/beaglebone-black) |
-
-The `nRF52840-Development-Kit` fixture is included inline as it's a minimal test case.
+`test/fixtures` is a git submodule of
+[IntelligentElectron/test-fixtures](https://github.com/IntelligentElectron/test-fixtures),
+a curated corpus of open-source hardware designs covering Altium, Cadence, and KiCad.
+Its `NOTICE.md` records the upstream source, license, and copyright of every fixture.
 
 ## Development Workflow
 

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024-2025 Valentino Zegna
+   Copyright 2024-2026 Valentino Zegna
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Universal Netlist MCP Server
-Copyright 2024-2025 Valentino Zegna
+Copyright 2024-2026 Valentino Zegna
 
 This product includes software developed by Valentino Zegna.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The **Universal Netlist MCP Server** gives AI agents the tools to understand and analyze your electrical schematics, for powerful and comprehensive design reviews through natural conversations.
 
-It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. Note that the commercial EDAs (Cadence and Altium) require your own license to unleash the full capabilities of this MCP server; KiCad is free and open-source.
+It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. It reads your design files directly: Cadence `.DSN` and Altium `.SchDoc` schematics are parsed natively on macOS, Linux, and Windows, with no EDA installation and no EDA license required. KiCad projects are read from a committed `.net` export where one is present, and otherwise through the free `kicad-cli`.
 
 ## Supported Formats
 
 | Format | Input Files | Description |
 |--------|------------|-------------|
-| Cadence (CIS / HDL) | `.dat` netlist files | Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) from Cadence Capture CIS or HDL designs |
+| Cadence (CIS / HDL) | `.DSN` schematic, or `.dat` netlist files | The `.DSN` binary schematic is parsed natively. Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) are preferred where they sit beside the design |
 | Altium Designer | `.SchDoc` | Altium schematic documents (discovered via `.PrjPcb` project files) |
 | KiCad | `.kicad_pro` (or root `.kicad_sch`) | Reads a resolved `kicadsexpr` netlist export: a committed `.net` beside the project if present, otherwise generated on demand via `kicad-cli` (requires KiCad installed; set `KICAD_CLI_PATH` for a non-standard location) |
 

--- a/docs/schemas/universal-netlist.md
+++ b/docs/schemas/universal-netlist.md
@@ -1,6 +1,6 @@
 # Universal Netlist Schema
 
-This document defines the **Universal Netlist Schema** - the core data model that represents netlists from any supported EDA format (Cadence CIS, Cadence HDL, Altium Designer). All parsers convert format-specific data into this unified representation.
+This document defines the **Universal Netlist Schema** - the core data model that represents netlists from any supported EDA format (Cadence CIS, Cadence HDL, Altium Designer, KiCad). All parsers convert format-specific data into this unified representation.
 
 ## Overview
 
@@ -223,12 +223,20 @@ Represents a pin-to-net connection. Uses a string for simple pins, or an object 
 - Component properties come from `pstxprt.dat`
 - Net connections come from `pstxnet.dat`
 - Pin names extracted from `pstchip.dat`
+- Without `.dat` files, all three come from the `.DSN` binary schematic directly
 
 ### Altium Designer
 
 - Component properties parsed from `.SchDoc` XML
 - Net connections derived from wire/junction analysis
 - Pin names come from component library definitions
+
+### KiCad
+
+- Component properties come from each `comp` record's `value`, `description`, and MPN-style fields
+- Net connections come from the `nets` section of the resolved `kicadsexpr` export
+- Pin names come from the `node` entries' `pinfunction`
+- Nets declared inside a hierarchical sheet carry the sheet path in their name (e.g. `/Peripherals/D0`)
 
 ## Design Decisions
 

--- a/docs/tools/list_nets.md
+++ b/docs/tools/list_nets.md
@@ -70,7 +70,7 @@ Response:
 **Error (unsupported format):**
 ```json
 {
-  "error": "Unsupported design file format '.kicad_pcb'. Supported: .dsn, .cpm (Cadence), .PrjPcb (Altium)"
+  "error": "Unsupported design file format '.kicad_pcb'. Supported: .dsn, .cpm (Cadence), .PrjPcb, .SchDoc (Altium), .kicad_pro, .kicad_sch (KiCad)"
 }
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display_name": "Universal Netlist",
   "version": "0.0.3",
   "description": "Query EDA netlists and trace circuit connectivity for schematic design reviews",
-  "long_description": "The Universal Netlist MCP Server gives AI agents the power to understand and analyze your electrical schematics. Query components, trace signal paths through XNETs, and perform comprehensive design reviews through natural conversations.\n\nSupports Cadence (CIS, HDL) and Altium Designer formats.",
+  "long_description": "The Universal Netlist MCP Server gives AI agents the power to understand and analyze your electrical schematics. Query components, trace signal paths through XNETs, run electrical rule checks, and perform comprehensive design reviews through natural conversations.\n\nSupports Cadence (CIS, HDL), Altium Designer, and KiCad formats. Design files are read directly, with no EDA installation and no EDA license required.",
   "author": {
     "name": "IntelligentElectron",
     "url": "https://github.com/IntelligentElectron"
@@ -26,6 +26,7 @@
     "schematic",
     "Cadence",
     "Altium",
+    "KiCad",
     "electronics",
     "design review"
   ],

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "circuit",
     "cadence",
     "altium",
+    "kicad",
     "eda"
   ],
   "author": "Valentino Zegna <valentino.zegna@gmail.com> (https://github.com/IntelligentElectron)",


### PR DESCRIPTION
KiCad has been a supported format since 1.1.0 and the Cadence `.DSN` parser has read binary schematics directly for longer than that, but the front door still described a two-format server that needed a Cadence or Altium seat to be useful. This is a copy-only pass over the README, docs, and manifests: no code, no behaviour change.

## What was wrong

| Where | Said | Actually |
|---|---|---|
| `README.md` | "the commercial EDAs (Cadence and Altium) require your own license to unleash the full capabilities" | `.DSN` and `.SchDoc` are parsed natively on macOS, Linux, and Windows with no EDA installed. The only Cadence-seat feature is the optional `export_cadence_netlist` |
| `README.md` format table | Cadence input is `.dat` netlist files | `.DSN` is read directly; `.dat` is preferred where it exists |
| `CLAUDE.md`, `manifest.json`, `package.json` keywords, `docs/schemas/universal-netlist.md`, bug-report template | Cadence and Altium | Cadence, Altium, and KiCad since 1.1.0 |
| `docs/tools/list_nets.md` | unsupported-format error lists `.dsn, .cpm, .PrjPcb` | `src/service/load-netlist.ts` also lists `.SchDoc`, `.kicad_pro`, `.kicad_sch` |
| `CONTRIBUTING.md` | three per-design submodules, `nRF52840-Development-Kit` inline | one `test/fixtures` submodule of `IntelligentElectron/test-fixtures` |
| `CONTRIBUTING.md` | parsers are Cadence, Altium | `src/parsers/` also holds `kicad/` |
| `LICENSE`, `NOTICE` | Copyright 2024-2025 | 2026 |

## What was added

- `docs/schemas/universal-netlist.md` gains a KiCad entry under Format-Specific Behavior (where properties, nets, and pin names come from, and the sheet-path prefix on hierarchical nets) and a line for the Cadence `.DSN` fallback
- `manifest.json`'s long description mentions `run_erc`, which shipped in 1.3.0

## Changelog

The README, docs, and extension manifest describe the server as it is today: KiCad joins Cadence and Altium in every format list, Cadence `.DSN` schematics are documented as read natively, and the claim that Cadence and Altium users need their own EDA licence is gone. No EDA installation or licence is required to read a design; the optional `export_cadence_netlist` tool remains Windows plus Cadence SPB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)