### PR TITLE
docs: one submodule, so name it in the singular

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This project is maintained by:
 
 - `src/` - Main source code
 - `src/parsers/` - Format-specific parsers (Cadence, Altium, KiCad)
-- `test/fixtures/` - Test fixture designs (git submodules)
+- `test/fixtures/` - Test fixture designs (git submodule)
 - `test/golden/` - Golden reference outputs for regression testing
 - `docs/` - API documentation
 


### PR DESCRIPTION
Follow-up to #122, which rewrote CONTRIBUTING's "Test Fixtures" section to describe the single `test/fixtures` submodule but left the project-structure list four lines above it saying "git submodules", plural. The two now agree.

Caught by the review bot on #122 ([thread](https://github.com/IntelligentElectron/universal-netlist/pull/122#discussion_r3768709973)); it arrived after that PR had entered the merge queue, which locks the branch, hence the separate PR.

## Changelog

None. Contributor documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)