### PR TITLE
docs: let the format table carry the format detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **Universal Netlist MCP Server** gives AI agents the tools to understand and analyze your electrical schematics, for powerful and comprehensive design reviews through natural conversations.
 
-It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. It reads your design files directly: Cadence `.DSN` and Altium `.SchDoc` schematics are parsed natively on macOS, Linux, and Windows, with no EDA installation and no EDA license required. KiCad projects are read from a committed `.net` export where one is present, and otherwise through the free `kicad-cli`.
+It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. It reads your design files directly on macOS, Linux, and Windows, with no Cadence or Altium installation and no EDA license required.
 
 ## Supported Formats
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "display_name": "Universal Netlist",
   "version": "0.0.3",
   "description": "Query EDA netlists and trace circuit connectivity for schematic design reviews",
-  "long_description": "The Universal Netlist MCP Server gives AI agents the power to understand and analyze your electrical schematics. Query components, trace signal paths through XNETs, run electrical rule checks, and perform comprehensive design reviews through natural conversations.\n\nSupports Cadence (CIS, HDL), Altium Designer, and KiCad formats. Design files are read directly, with no EDA installation and no EDA license required.",
+  "long_description": "The Universal Netlist MCP Server gives AI agents the power to understand and analyze your electrical schematics. Query components, trace signal paths through XNETs, run electrical rule checks, and perform comprehensive design reviews through natural conversations.\n\nSupports Cadence (CIS, HDL), Altium Designer, and KiCad formats. Design files are read directly, with no Cadence or Altium installation and no EDA license required.",
   "author": {
     "name": "IntelligentElectron",
     "url": "https://github.com/IntelligentElectron"


### PR DESCRIPTION
Follow-up to #122. That PR fixed the README intro's *accuracy* but left it restating every row of the Supported Formats table sitting directly beneath it: `.DSN`, `.SchDoc`, and the KiCad committed-`.net`-otherwise-`kicad-cli` resolution all appeared twice within a screen of each other.

The table is the better home for per-format detail, so the paragraph now carries only what the table doesn't: which EDAs are supported, that more are planned, and the licensing/installation point.

**Before**

> It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. It reads your design files directly: Cadence `.DSN` and Altium `.SchDoc` schematics are parsed natively on macOS, Linux, and Windows, with no EDA installation and no EDA license required. KiCad projects are read from a committed `.net` export where one is present, and otherwise through the free `kicad-cli`.

**After**

> It is compatible with Cadence, Altium, and KiCad, with plans to integrate more EDAs in the future. It reads your design files directly on macOS, Linux, and Windows, with no Cadence or Altium installation and no EDA license required.

One accuracy point came out of the trim: "no EDA installation" was a blanket claim, but a KiCad project with no committed `.net` does invoke `kicad-cli`. Scoping the installation claim to Cadence and Altium makes it true without a caveat; the licence claim holds for all three, KiCad's tooling being free. Same scoping applied to `manifest.json`'s long description, which carried the same sentence.

## Changelog

The README intro no longer repeats the per-format detail already given in the Supported Formats table, and the "no EDA installation" claim is scoped to Cadence and Altium, since KiCad projects without a committed `.net` export use the free `kicad-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)