### PR TITLE
feat: annotate every tool and publish a privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,113 @@
+# Privacy Policy
+
+**Effective date:** 12 August 2026
+
+Universal Netlist MCP Server ("the server") is a local program. It runs on your
+own machine, reads design files from your own disk, and answers questions about
+them through the MCP client you connect it to.
+
+The author operates no service, no account system, and no backend. Nothing you
+query is sent to the author.
+
+## What the server collects
+
+**Nothing.** The server has no telemetry of its own, no account, no API key, no
+licence check, and no usage reporting. It stores no data about you.
+
+## What the server reads
+
+The server reads the EDA design files you point it at, and the directories you
+ask it to search:
+
+- Cadence `.DSN` schematics and exported `.dat` netlists
+- Altium `.PrjPcb` projects and `.SchDoc` documents
+- KiCad `.kicad_pro` projects, `.kicad_sch` schematics, and `.net` exports
+
+It reads these from your local filesystem, on demand, when a tool is called. It
+holds their contents in memory for the life of the query. It writes nothing back
+to them.
+
+## Where your design data goes
+
+**To your MCP client, and therefore to that client's model provider.** This is
+the point of the server, and it is the most important thing to understand about
+it.
+
+When you ask your AI assistant about a design, the server returns the relevant
+component, net, and connectivity data to the client you connected, such as
+Claude Desktop, Claude Code, or another MCP client. That client sends it on to
+its model provider as part of your conversation. What that provider does with it
+is governed by their privacy policy and your agreement with them, not by this
+one.
+
+If your schematics are confidential, treat querying them the same way you would
+treat pasting them into that assistant's chat window, because that is what
+happens.
+
+## Network connections the server makes
+
+The server makes no network connection in order to read a design. It parses
+every supported format locally. Two connections can occur, and neither carries
+design data:
+
+**1. Update check (standalone binary only).** On startup the compiled binary
+requests
+`https://api.github.com/repos/IntelligentElectron/universal-netlist/releases/latest`
+to see whether a newer release exists, and downloads it if so. GitHub receives
+what any HTTP request reveals: your IP address and a `User-Agent` naming the
+program and its version. No design data, filename, or path is sent. Installs via
+npm and runs from source do not check for updates.
+
+**2. OpenTelemetry (off by default).** The server can emit traces, metrics, and
+logs about tool calls. This is disabled unless you set an `OTEL_*` endpoint, and
+when you enable it the data goes **to the endpoint you configure**, which is
+your own observability backend. It is never sent to the author. What it contains:
+
+- Tool names, durations, and success or failure
+- `enduser.id`, your host operating system account name
+- Tool arguments, **only** if you additionally set `OTEL_CAPTURE_TOOL_ARGS`.
+  These include the file paths and search patterns you passed.
+
+Setting `OTEL_SDK_DISABLED=1` forces it off even when an endpoint is configured.
+
+## Writing to your disk
+
+One tool writes: `export_cadence_netlist` runs Cadence's own exporter on Windows
+and creates a netlist directory beside your schematic, replacing an earlier
+export of the same design. Every other tool is read-only. Tools are annotated so
+your client can tell the difference and ask before running the one that writes.
+
+## Third parties
+
+The author shares nothing, because the author receives nothing. The third
+parties that can receive data are the ones you choose and connect:
+
+| Party | What they receive | When |
+|---|---|---|
+| Your MCP client and its model provider | The design data returned by your queries | Whenever you query a design |
+| GitHub | IP address and User-Agent of an update check | Binary startup |
+| Your own OTLP backend | Tool call telemetry | Only if you configure `OTEL_*` |
+
+## Retention
+
+The server retains nothing. It keeps parsed design data in memory only while
+serving your request, and that memory is released when the process exits.
+Anything retained is retained by your MCP client, your model provider, or your
+telemetry backend, under their own policies.
+
+## Children
+
+The server is a professional engineering tool and is not directed at children.
+
+## Changes
+
+Material changes to this policy will be recorded in `CHANGELOG.md` and in this
+file's effective date. The current version always lives at
+<https://github.com/IntelligentElectron/universal-netlist/blob/main/PRIVACY.md>.
+
+## Contact
+
+Questions about this policy, or a privacy concern:
+
+- Open an issue: <https://github.com/IntelligentElectron/universal-netlist/issues>
+- Email: valentino.zegna@gmail.com

--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ See [docs/](docs/README.md) for API documentation and response schemas.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 
+## Privacy Policy
+
+The server runs on your machine and collects nothing. It reads the design files
+you point it at, holds them in memory for the life of a query, and sends nothing
+to the author, who operates no service and no backend.
+
+Your design data does reach your MCP client and that client's model provider,
+because that is how you get an answer. Treat querying a confidential schematic
+the way you would treat pasting it into that assistant's chat window.
+
+The only network calls the server makes are an update check against the GitHub
+releases API, on the standalone binary alone, and OpenTelemetry, which is off
+unless you point `OTEL_*` at your own backend. Neither carries design data.
+
+See [PRIVACY.md](PRIVACY.md) for the full policy, including what telemetry
+contains when you enable it and which tool writes to disk.
+
 ---
 
 ## About

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,10 @@
   },
   "homepage": "https://github.com/IntelligentElectron/universal-netlist",
   "documentation": "https://github.com/IntelligentElectron/universal-netlist/tree/main/docs",
+  "support": "https://github.com/IntelligentElectron/universal-netlist/issues",
+  "privacy_policies": [
+    "https://github.com/IntelligentElectron/universal-netlist/blob/main/PRIVACY.md"
+  ],
   "keywords": [
     "netlist",
     "circuit",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "files": [
     "dist",
     "README.md",
+    "PRIVACY.md",
     "LICENSE",
     "NOTICE",
     "CHANGELOG.md"

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "./server.js";
+
+/**
+ * Tool metadata as the Connectors Directory requires it.
+ *
+ * Every tool must carry a title and say whether it can write, because those
+ * annotations decide what a client can run without asking the user first. A
+ * submission with a tool missing either one is rejected, and the failure is
+ * invisible from the source alone, so these assertions go through a real
+ * client and read the tool list off the wire.
+ */
+
+/** The one tool that writes: it runs Cadence's exporter and lands files on disk. */
+const WRITING_TOOLS = ["export_cadence_netlist"];
+
+type ListedTool = {
+  name: string;
+  title?: string;
+  description?: string;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+};
+
+let tools: ListedTool[];
+
+beforeAll(async () => {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0.0.0" });
+  await Promise.all([client.connect(clientTransport), createServer().connect(serverTransport)]);
+  tools = (await client.listTools()).tools as ListedTool[];
+});
+
+describe("tool annotations", () => {
+  it("registers every tool with a title", () => {
+    const untitled = tools.filter((t) => !t.title?.trim()).map((t) => t.name);
+    expect(untitled).toEqual([]);
+  });
+
+  it("registers every tool with a read-only hint", () => {
+    const unannotated = tools
+      .filter((t) => typeof t.annotations?.readOnlyHint !== "boolean")
+      .map((t) => t.name);
+    expect(unannotated).toEqual([]);
+  });
+
+  it("marks exactly the writing tools as not read-only", () => {
+    const writers = tools.filter((t) => t.annotations?.readOnlyHint === false).map((t) => t.name);
+    expect(writers.sort()).toEqual([...WRITING_TOOLS].sort());
+  });
+
+  it("marks every writing tool destructive, and no read-only tool", () => {
+    for (const tool of tools) {
+      const readOnly = tool.annotations?.readOnlyHint;
+      expect(tool.annotations?.destructiveHint, tool.name).toBe(!readOnly);
+    }
+  });
+
+  it("reports every tool as closed-world, since all of them read local files", () => {
+    for (const tool of tools) {
+      expect(tool.annotations?.openWorldHint, tool.name).toBe(false);
+    }
+  });
+
+  it("keeps tool names within the 64-character directory limit", () => {
+    const overlong = tools.filter((t) => t.name.length > 64).map((t) => t.name);
+    expect(overlong).toEqual([]);
+  });
+
+  it("gives every tool a description", () => {
+    const undescribed = tools.filter((t) => !t.description?.trim()).map((t) => t.name);
+    expect(undescribed).toEqual([]);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,34 @@ const formatResult = (result: unknown): { content: { type: "text"; text: string 
 // =============================================================================
 
 /**
+ * Tool annotations.
+ *
+ * Every tool declares whether it can write, so a client can decide what needs
+ * the user's confirmation. Read-only tools may run without one; a tool that
+ * touches the disk always prompts.
+ *
+ * `openWorldHint` is false throughout: every tool operates on the design files
+ * already on this machine, not on an open-ended set of external entities.
+ */
+const READ_ONLY = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+/**
+ * `export_cadence_netlist` runs Cadence's own exporter, which writes a netlist
+ * directory beside the schematic and overwrites an earlier export in place.
+ */
+const WRITES_TO_DISK = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: false,
+  openWorldHint: false,
+} as const;
+
+/**
  * Create and configure the MCP server.
  */
 export const createServer = (): McpServer => {
@@ -79,7 +107,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_designs",
     {
+      title: "List designs",
       description: LIST_DESIGNS_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         path: z.string().optional().describe("Path to directory to search for designs"),
         pattern: z.string().optional().describe("Regex pattern to filter design names"),
@@ -115,7 +145,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_components",
     {
+      title: "List components",
       description: LIST_COMPONENTS_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file, as returned by list_designs"),
         type: z.string().describe("Component prefix: U, C, R, L, etc."),
@@ -138,7 +170,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "list_nets",
     {
+      title: "List nets",
       description: LIST_NETS_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file"),
       },
@@ -155,7 +189,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_nets",
     {
+      title: "Search nets",
       description: SEARCH_NETS_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         pattern: z.string().describe("Regex pattern"),
         design: z.string().describe("Path to design file"),
@@ -173,7 +209,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_refdes",
     {
+      title: "Search components by refdes",
       description: SEARCH_COMPONENTS_BY_REFDES_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         pattern: z.string().describe("Regex pattern for refdes"),
         design: z.string().describe("Path to design file"),
@@ -192,7 +230,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_mpn",
     {
+      title: "Search components by MPN",
       description: SEARCH_COMPONENTS_BY_MPN_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         pattern: z.string().describe("Regex pattern for MPN"),
         design: z.string().describe("Path to design file"),
@@ -211,7 +251,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "search_components_by_description",
     {
+      title: "Search components by description",
       description: SEARCH_COMPONENTS_BY_DESCRIPTION_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         pattern: z.string().describe("Regex pattern for description"),
         design: z.string().describe("Path to design file"),
@@ -230,7 +272,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_xnet_by_net_name",
     {
+      title: "Trace XNET from a net",
       description: QUERY_XNET_BY_NET_NAME_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file"),
         net_name: z.string().describe("Exact net name"),
@@ -256,7 +300,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_xnet_by_pin_name",
     {
+      title: "Trace XNET from a pin",
       description: QUERY_XNET_BY_PIN_NAME_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file"),
         pin_name: z.string().describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
@@ -279,7 +325,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "query_component",
     {
+      title: "Get component details",
       description: QUERY_COMPONENT_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file"),
         refdes: z.string().describe("Component reference designator"),
@@ -297,7 +345,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "run_erc",
     {
+      title: "Run electrical rule checks",
       description: RUN_ERC_DESCRIPTION,
+      annotations: READ_ONLY,
       inputSchema: {
         design: z.string().describe("Path to design file"),
         include_dns: z
@@ -328,7 +378,9 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "export_cadence_netlist",
     {
+      title: "Export Cadence netlist",
       description: EXPORT_CADENCE_NETLIST_DESCRIPTION,
+      annotations: WRITES_TO_DISK,
       inputSchema: {
         design: z.string().describe("Path to .DSN schematic file"),
       },


### PR DESCRIPTION
Makes universal-netlist submittable to the Claude Connectors Directory. Today it is not: two of the directory's requirements are unmet, and one of them is an automatic rejection.

## What was blocking submission

**No tool annotations.** Every `registerTool` call passed only `description` and `inputSchema`. The rule is unconditional — *"Every tool must include a title and the applicable hint"* — and the submission portal flags tools that lack them before you can submit.

**No privacy policy.** Local connectors must carry a "Privacy Policy" section in `README.md` and a `privacy_policies` array in `manifest.json`. Per the docs, *"Missing or incomplete privacy policies result in immediate rejection."*

## Annotations

| Tools | `readOnlyHint` | `destructiveHint` | Effect in Claude |
|---|---|---|---|
| The 11 query tools + `run_erc` | `true` | `false` | May run without per-call confirmation |
| `export_cadence_netlist` | `false` | `true` | Always prompts |

`openWorldHint` is `false` on all twelve: they read design files already on the machine rather than an open-ended set of external entities. That field is not required by Anthropic but is required by OpenAI's portal, so it costs nothing to be accurate now.

The read/write split was already clean — one writer, eleven readers — which is what the directory's "separate read and write tools" rule asks for.

## The test asserts it over the wire

`src/server.test.ts` connects a real `Client` over `InMemoryTransport` and reads the tool list off the protocol, rather than inspecting the source. A tool registered without a title or hint fails the build.

I mutation-tested it rather than trusting a green run: removing `list_nets`'s title and mis-marking `export_cadence_netlist` as read-only both failed, naming the offending tool.

```
× registers every tool with a title
  → expected [ 'list_nets' ] to deeply equal []
× marks exactly the writing tools as not read-only
  → expected [] to deeply equal [ 'export_cadence_netlist' ]
```

It also encodes the 64-character tool-name limit, so that rule cannot be broken silently either.

## Privacy policy

`PRIVACY.md` is written from the code, not from assumption. The substantive disclosure is that **design data reaches your MCP client and that client's model provider** — the policy says plainly that querying a confidential schematic is equivalent to pasting it into that assistant's chat window.

The two network calls are documented precisely: the update check against `api.github.com/repos/.../releases/latest`, which happens only for the compiled binary (not npm installs, not source runs) and carries no design data; and OpenTelemetry, off unless `OTEL_*` is set, going to the user's own backend, with `tool.args` captured only behind the additional `OTEL_CAPTURE_TOOL_ARGS` flag.

**Please read this one properly before merging.** It is a public commitment about data handling and it carries your name and email.

## Validation

- `mcpb validate manifest.json` → *"Manifest schema validation passes!"*
- `npm run type-check` → clean
- `npm run lint` → clean
- `npm test` → 740 passed, 10 skipped
- I checked `privacy_policies` and `support` against the real v0.3 MCPB schema before adding them; that schema sets `additionalProperties: false`, so an invented field name would have failed.

## Not in this PR

`claude plugin validate` needs a `.claude-plugin/plugin.json`, which is the *plugin* route rather than the MCPB one. Making this repo a plugin as well is a real design decision — a plugin declares how to launch its MCP server, and the obvious `npx` form would reintroduce the Node dependency the native installer exists to avoid. Worth deciding deliberately rather than folding in here.

## Changelog

Every tool now declares a title and whether it can write, so clients can run the read-only tools without prompting and always confirm the one that writes to disk. The server ships a privacy policy covering what it reads, what it retains, and the two network calls it can make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)