### PR TITLE
docs: carry a release through instead of parking it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -89,8 +89,17 @@ what is missing instead of merging it.
 
 ## Releases
 
-Tagging is the one step that is NOT automatic: the tag push publishes to npm and cuts a
-public GitHub Release, so it is the maintainer's call. Ask before tagging; merge freely.
+The tag push publishes to npm and cuts a public GitHub Release, and it cannot be taken
+back cleanly, so it needs the user to have actually asked for a release.
+
+Once they have, it is asked and answered: tag it. "Release 1.5.2", "ship it", or "take
+this all the way" is the green light, and a second confirmation afterwards only parks
+finished work. `scripts/tag-release.sh --yes` skips the interactive prompt, which a
+non-interactive session cannot answer anyway; the script still refuses a wrong state,
+which is the check that actually protects the release.
+
+Absent that ask, do not infer one. Cut the release PR, merge it, say that the tag is the
+remaining step, and stop there.
 
 1. Ensure `main` is clean and all checks pass
 2. Ensure `CHANGELOG.md` covers every change in the release. Feature PRs do not edit it

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -104,7 +104,9 @@ remaining step, and stop there.
 1. Ensure `main` is clean and all checks pass
 2. Ensure `CHANGELOG.md` covers every change in the release. Feature PRs do not edit it
    (see CLAUDE.md), so collect their `## Changelog` sections into the version section first
-3. Create and push the tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. Create and push the tag with `scripts/tag-release.sh` (add `--yes` when the session
+   cannot answer its prompt). Never tag by hand: `git tag` skips every state check, and
+   tagging the wrong commit is the mistake the script exists to prevent
 4. Monitor CI: `gh run list` and `gh run view`
 
 ## Pre-commit Hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,20 @@ Two things fail for want of a socket rather than because anything is wrong:
 
 ### Releasing
 
-The maintainer owns `CHANGELOG.md` and the version bump. Feature PRs carry code and
-tests only; they must NOT edit `CHANGELOG.md` or `package.json`.
+`CHANGELOG.md` and the version bump belong to the release PR, never to a feature PR.
+Feature PRs carry code and tests only; they must NOT edit `CHANGELOG.md` or
+`package.json`.
 
 Both files append at the top, so a bump in every feature PR makes each concurrent PR
 conflict with the last, and a contributor cannot know whether their change is a patch or
 a minor. Instead a PR describes its user-visible effect in a `## Changelog` section of the
-PR body, and the maintainer collects those into one release PR.
+PR body, and those get collected into one release PR.
+
+Cutting that release PR is ordinary work: an agent asked to release, or asked to carry
+something through to a release, writes the changelog section and bumps the version
+without checking back first. The version number is the one judgment call worth stating
+out loud — say which bump you chose and why, so a disagreement surfaces before the tag
+rather than after it.
 
 1. Cut a release PR from `main` after the fixes for the release have merged:
    - Update `CHANGELOG.md` with a new version section, written from the merged PRs' own


### PR DESCRIPTION
## Summary

Two instructions in this repo told an agent to stop at points where stopping only delayed work the user had already asked for. This session hit both: after being told to take universal-netlist all the way to a directory submission, I cut the release PR only after asking, then merged it and stopped again to ask permission to tag — permission that "ok to release 1.5.2" had already given.

- **`CLAUDE.md`** said *"The maintainer owns `CHANGELOG.md` and the version bump"*, which reads as "do not cut a release PR." The rule exists to stop concurrent feature PRs conflicting on two append-at-the-top files, and that part is unchanged: feature PRs still never touch `CHANGELOG.md` or `package.json`. What changes is that cutting the release PR is now ordinary work, with the version number named as the one judgment worth stating out loud so a disagreement surfaces before the tag rather than after it.
- **`.claude/skills/release/SKILL.md`** said *"Ask before tagging; merge freely"* with no qualification, so an agent asked to ship would do everything and then park. Tagging still requires that the user actually asked for a release — it no longer requires asking twice. It also now records that `tag-release.sh --yes` is the right invocation from a non-interactive session, since the interactive prompt cannot be answered there and the script's state checks are the real protection.

The `## Merging` section already said not to leave finished work waiting for permission. These two edits bring the release path in line with it.

## Test plan

- [x] Documentation only — no code, no tests affected
- [x] `git diff` reviewed; conflict-avoidance rationale for feature PRs preserved verbatim
- [x] Grepped both files for remaining stop-rules; only match left is an unrelated line about queued PRs waiting on a check

## Changelog

None. Contributor and agent documentation only.