### PR TITLE
build: let compile:all run off macOS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ npm run lint         # ESLint
 npm run lint:fix     # ESLint with auto-fix
 npm test             # Run tests with Vitest
 npm run test:watch   # Run tests in watch mode
-npm run compile:all  # Build all platform binaries
+npm run compile:all  # Build the five per-arch binaries (any host)
+npm run compile:darwin-universal  # Add the lipo'd macOS universal binary (macOS only)
 ```
 
 ### Binary Compilation
@@ -39,6 +40,12 @@ bun build src/index.ts --compile --minify --target=bun-<platform> --outfile=bin/
 ```
 
 Platforms: `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `windows-x64`
+
+Bun cross-compiles every one of those targets from any host, so `compile:all` builds the
+five per-arch binaries anywhere. The macOS universal binary is a separate step,
+`compile:darwin-universal`, because `lipo` exists only on macOS; keeping it out of
+`compile:all` is what lets a Linux host build the per-arch artifacts. `release.yml` runs
+on macOS and produces both.
 
 macOS binaries require code signing with `entitlements.plist` (for Bun JIT) and Apple notarization.
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compile:linux-x64": "bun build --compile --minify --target=bun-linux-x64 --define BUILD_VERSION=\"\\\"$(node -p 'require(\"./package.json\").version')\\\"\" src/index.ts --outfile bin/universal-netlist-linux-x64",
     "compile:windows-x64": "bun build --compile --minify --target=bun-windows-x64 --define BUILD_VERSION=\"\\\"$(node -p 'require(\"./package.json\").version')\\\"\" src/index.ts --outfile bin/universal-netlist-windows-x64.exe",
     "compile:darwin-universal": "npm run compile:darwin-arm64 && npm run compile:darwin-x64 && lipo -create bin/universal-netlist-darwin-arm64 bin/universal-netlist-darwin-x64 -output bin/universal-netlist-darwin-universal",
-    "compile:all": "npm run compile:darwin-arm64 && npm run compile:darwin-x64 && npm run compile:linux-arm64 && npm run compile:linux-x64 && npm run compile:windows-x64 && lipo -create bin/universal-netlist-darwin-arm64 bin/universal-netlist-darwin-x64 -output bin/universal-netlist-darwin-universal",
+    "compile:all": "npm run compile:darwin-arm64 && npm run compile:darwin-x64 && npm run compile:linux-arm64 && npm run compile:linux-x64 && npm run compile:windows-x64",
     "prepublishOnly": "npm run type-check && npm run lint && npm test && npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

`compile:all` ended with a `lipo` invocation to produce the macOS universal binary. `lipo` ships only with macOS, so the whole script required a macOS host — even though Bun cross-compiles `bun-darwin-arm64`, `bun-darwin-x64`, `bun-linux-*` and `bun-windows-x64` from anywhere. For anyone who needs only the per-arch artifacts, the universal-binary step was the sole thing forcing a macOS runner.

## Changes

- `compile:all` builds the five per-arch targets and stops. Runs on any host.
- `compile:darwin-universal` keeps the `lipo` step and stays opt-in. It already compiled both halves itself, so it is unchanged.
- CLAUDE.md/AGENTS.md says which of the two runs where.

`release.yml` runs on `macos-latest` and does its own `lipo` step, so the published artifact set is unchanged.

## Related Issues

Closes #134

## Testing

- [x] `npm run compile:all` produces all five per-arch binaries and leaves `bin/universal-netlist-darwin-universal` untouched (no `lipo` invoked)
- [x] `npm run compile:darwin-universal` still produces the fat binary: `lipo -info` reports `x86_64 arm64`, and it runs (`universal-netlist v1.5.2`)
- [x] `file bin/universal-netlist-linux-x64` → `ELF 64-bit LSB executable, x86-64`, i.e. the cross-compiled targets are real
- [x] `npm test` unaffected (no source change)

The `package.json` edit is confined to the `scripts` block; version and CHANGELOG are untouched, per the release policy in AGENTS.md.

## Changelog

`npm run compile:all` now builds the five per-arch binaries on any host; the macOS universal binary moved to its own `npm run compile:darwin-universal`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)