### PR TITLE
feat: add a build-time flag to disable the self-updater

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,19 @@ no `GITHUB_REF`. The version it bakes in comes from `package.json`, which is the
 source of it; the release workflow validates the tag against `package.json` rather than
 deriving a version from the tag.
 
+The third argument is the build channel, baked in as `BUILD_CHANNEL` (see
+[src/build-flags.ts](src/build-flags.ts)):
+
+- `github` (default): the binary `install.sh` puts in place. It owns its own file, so it
+  self-updates on startup, `--update` replaces it, and `--uninstall` removes it.
+- `packaged`: a binary a package manager owns (Homebrew, nix, a distro package, a
+  vendored copy). Startup self-update is off, and `--update` / `--uninstall` explain that
+  the install is managed elsewhere instead of modifying it. Build one with:
+
+  ```bash
+  scripts/build-binary.sh bun-linux-x64 bin/universal-netlist-linux-x64 packaged
+  ```
+
 Bun cross-compiles every one of those targets from any host, so `compile:all` builds the
 five per-arch binaries anywhere. The macOS universal binary is a separate step,
 `compile:darwin-universal`, because `lipo` exists only on macOS; keeping it out of

--- a/src/build-flags.test.ts
+++ b/src/build-flags.test.ts
@@ -1,0 +1,18 @@
+/**
+ * The build channel defaults to the self-updating GitHub release build, so a
+ * build that passes no `--define BUILD_CHANNEL` (running from source, or any
+ * existing release) behaves exactly as it did before the flag existed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { CHANNEL, SELF_UPDATE_ENABLED } from "./build-flags.js";
+
+describe("build flags", () => {
+  it("defaults to the github channel when BUILD_CHANNEL is not injected", () => {
+    expect(CHANNEL).toBe("github");
+  });
+
+  it("enables self-update on the github channel", () => {
+    expect(SELF_UPDATE_ENABLED).toBe(true);
+  });
+});

--- a/src/build-flags.ts
+++ b/src/build-flags.ts
@@ -1,0 +1,30 @@
+/**
+ * Build-time flags for the compiled binary.
+ *
+ * `BUILD_CHANNEL` is injected at compile time via `--define`, the same
+ * mechanism `BUILD_VERSION` uses; see `scripts/build-binary.sh`.
+ */
+
+// Injected at compile time via --define (for Bun binaries).
+declare const BUILD_CHANNEL: string | undefined;
+
+/**
+ * Who owns the installed binary.
+ *
+ * - `github`: installed by `install.sh` from a GitHub release. It owns its own
+ *   file, so it self-updates and can uninstall itself. This is the default, and
+ *   what every existing install is.
+ * - `packaged`: installed by a package manager (Homebrew, nix, a distro
+ *   package, a vendored copy). The file belongs to that package manager, is
+ *   often root-owned or on a read-only prefix, and replacing it in place would
+ *   desynchronize the manager's view of what is installed and break its
+ *   file-integrity checks. Such a host may also have no outbound network at
+ *   all, so a startup update check is a failed HTTP call every time.
+ *
+ * Build a packaged binary with the third argument of the build script:
+ * `scripts/build-binary.sh bun-linux-x64 <outfile> packaged`.
+ */
+export const CHANNEL = typeof BUILD_CHANNEL !== "undefined" ? BUILD_CHANNEL : "github";
+
+/** Whether this build may replace its own binary. */
+export const SELF_UPDATE_ENABLED = CHANNEL === "github";

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for what the build channel changes about the CLI commands.
+ *
+ * A packaged build (`BUILD_CHANNEL=packaged`) is owned by the package manager
+ * that installed it, so `--update` and `--uninstall` explain that instead of
+ * touching the install, and the help text drops the install.sh line.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+/** Load commands.js as a packaged build. */
+const loadPackagedCommands = async (): Promise<typeof import("./commands.js")> => {
+  vi.doMock("../build-flags.js", () => ({ CHANNEL: "packaged", SELF_UPDATE_ENABLED: false }));
+  vi.resetModules();
+  return import("./commands.js");
+};
+
+const captureStdout = (): { lines: string[]; restore: () => void } => {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  return { lines, restore: () => spy.mockRestore() };
+};
+
+afterEach(() => {
+  vi.doUnmock("../build-flags.js");
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("printHelp", () => {
+  it("prints the install.sh line on the default (github) channel", async () => {
+    const { printHelp } = await import("./commands.js");
+    const out = captureStdout();
+
+    printHelp();
+
+    out.restore();
+    expect(out.lines.join("\n")).toContain("install.sh | bash");
+  });
+
+  it("points at the package manager instead on a packaged build", async () => {
+    const { printHelp } = await loadPackagedCommands();
+    const out = captureStdout();
+
+    printHelp();
+
+    out.restore();
+    const text = out.lines.join("\n");
+    expect(text).not.toContain("install.sh");
+    expect(text).toContain("package manager");
+  });
+});
+
+describe("handleUpdateCommand on a packaged build", () => {
+  it("explains the install is managed elsewhere and performs no network call", async () => {
+    const { handleUpdateCommand } = await loadPackagedCommands();
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const out = captureStdout();
+
+    await handleUpdateCommand();
+
+    out.restore();
+    expect(out.lines.join("\n")).toContain("package manager");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleUninstallCommand on a packaged build", () => {
+  it("removes nothing and never prompts", async () => {
+    const confirmSpy = vi.fn();
+    const removeFromPathSpy = vi.fn();
+    const rmSyncSpy = vi.fn();
+    vi.doMock("./prompts.js", () => ({ confirm: confirmSpy }));
+    vi.doMock("./shell.js", () => ({ removeFromPath: removeFromPathSpy }));
+    vi.doMock("node:fs", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("node:fs")>()),
+      rmSync: rmSyncSpy,
+    }));
+    const { handleUninstallCommand } = await loadPackagedCommands();
+    const out = captureStdout();
+
+    await handleUninstallCommand();
+
+    out.restore();
+    vi.doUnmock("./prompts.js");
+    vi.doUnmock("./shell.js");
+    vi.doUnmock("node:fs");
+
+    expect(out.lines.join("\n")).toContain("package manager");
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(removeFromPathSpy).not.toHaveBeenCalled();
+    expect(rmSyncSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -6,6 +6,7 @@
 import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "../version.js";
+import { SELF_UPDATE_ENABLED } from "../build-flags.js";
 import { exportTelemetry } from "../telemetry/index.js";
 import { parseDesign } from "../parsers/index.js";
 import {
@@ -37,6 +38,12 @@ export const printVersion = (): void => {
  * Print help message.
  */
 export const printHelp = (): void => {
+  // A packaged build was installed by a package manager, so the install line
+  // that applies to it is that manager's, not this repo's install.sh.
+  const installation = SELF_UPDATE_ENABLED
+    ? `  curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/install.sh | bash`
+    : `  Installed and updated by your package manager.`;
+
   console.log(
     `
 ${BINARY_NAME} v${VERSION}
@@ -56,7 +63,7 @@ OPTIONS:
   --verbose            Show per-design field mismatch breakdowns (with --coverage)
 
 INSTALLATION:
-  curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/install.sh | bash
+${installation}
 
 MORE INFO:
   https://github.com/${GITHUB_REPO}
@@ -70,6 +77,14 @@ MORE INFO:
  * For npm installs, directs users to use npm update instead.
  */
 export const handleUpdateCommand = async (): Promise<void> => {
+  // A packaged build's file belongs to the package manager that installed it,
+  // so the update belongs there too.
+  if (!SELF_UPDATE_ENABLED) {
+    console.log(`${BINARY_NAME} v${VERSION} was installed by a package manager.`);
+    console.log("Update it the way you installed it.");
+    return;
+  }
+
   // For npm installs, provide npm-specific update instructions
   if (isNpmInstall()) {
     console.log(`Checking for updates...`);
@@ -131,6 +146,14 @@ export const handleUpdateCommand = async (): Promise<void> => {
  * Removes the binary and PATH entries from shell rc files.
  */
 export const handleUninstallCommand = async (): Promise<void> => {
+  // Deleting a packaged install directory would leave the package manager
+  // believing it is still installed, so leave the files where they are.
+  if (!SELF_UPDATE_ENABLED) {
+    console.log(`${BINARY_NAME} v${VERSION} was installed by a package manager.`);
+    console.log("Remove it the way you installed it.");
+    return;
+  }
+
   const confirmed = await confirm(`This will remove ${BINARY_NAME} from your system. Continue?`);
   if (!confirmed) {
     console.log("Uninstall cancelled");

--- a/src/cli/updater.test.ts
+++ b/src/cli/updater.test.ts
@@ -55,3 +55,29 @@ describe("autoUpdate self-update guard", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("autoUpdate on a packaged build", () => {
+  afterEach(() => {
+    vi.doUnmock("../build-flags.js");
+    vi.resetModules();
+  });
+
+  it("returns false and performs no network call even as the compiled binary", async () => {
+    // Every other guard is satisfied: this is the compiled binary, installed
+    // outside node_modules. Only the build channel stops it.
+    const bin = "/opt/homebrew/bin/universal-netlist";
+    setExecPath(bin);
+    process.argv[1] = bin;
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    vi.doMock("../build-flags.js", () => ({ CHANNEL: "packaged", SELF_UPDATE_ENABLED: false }));
+    vi.resetModules();
+    const { autoUpdate: packagedAutoUpdate } = await import("./updater.js");
+
+    const updated = await packagedAutoUpdate();
+
+    expect(updated).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/updater.ts
+++ b/src/cli/updater.ts
@@ -2,7 +2,8 @@
  * Auto-updater for universal-netlist server.
  *
  * Checks GitHub Releases for newer versions and self-updates on startup.
- * Always runs on startup for compiled binaries. Skipped for npm installs.
+ * Runs on startup for compiled binaries built on the `github` channel.
+ * Skipped for npm installs and for packaged builds (see ../build-flags.ts).
  */
 
 import {
@@ -17,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { spawn } from "node:child_process";
 import { VERSION, GITHUB_REPO, BINARY_NAME } from "../version.js";
+import { SELF_UPDATE_ENABLED } from "../build-flags.js";
 import { getCurrentExecutablePath, isCompiledBinary } from "./executable.js";
 
 /** GitHub release information. */
@@ -341,6 +343,13 @@ export const reexec = (): never => {
  * @returns true if an update was applied and process should restart
  */
 export const autoUpdate = async (): Promise<boolean> => {
+  // A packaged build does not own its own file: the package manager that
+  // installed it does. Replacing it in place would break that manager's view
+  // of what is installed, and often fails outright on a read-only prefix.
+  if (!SELF_UPDATE_ENABLED) {
+    return false;
+  }
+
   // Only the compiled standalone binary self-updates. Running from source
   // (tsx/node) must never download a binary and re-exec into it.
   if (!isCompiledBinary()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   handleCoverageCommand,
 } from "./cli/commands.js";
 import { autoUpdate, reexec } from "./cli/updater.js";
+import { SELF_UPDATE_ENABLED } from "./build-flags.js";
 import { runServer } from "./server.js";
 
 const main = async (): Promise<void> => {
@@ -87,10 +88,12 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Auto-update on startup
-  const updated = await autoUpdate();
-  if (updated) {
-    reexec();
+  // Auto-update on startup. A packaged build never touches its own file.
+  if (SELF_UPDATE_ENABLED) {
+    const updated = await autoUpdate();
+    if (updated) {
+      reexec();
+    }
   }
 
   await runServer();


### PR DESCRIPTION
## Summary

The compiled binary self-updated on every startup: `src/index.ts` called `autoUpdate()` before `runServer()`, hitting the GitHub releases API, downloading the platform asset over itself, and re-execing. That is the right default for a binary installed by `install.sh`, and wrong for one a package manager owns (Homebrew, nix, a distro package, a vendored copy), where the file is expected to be immutable and is often root-owned or on a read-only prefix, self-replacement desynchronizes the package manager's view of what is installed and breaks its file-integrity checks, and a host with no outbound network pays a failed HTTP call on every start.

There was no way to turn it off at build time. Now there is one, and the default is unchanged.

## Changes

- `src/build-flags.ts`: `CHANNEL` from a `BUILD_CHANNEL` `--define` (the same mechanism as `BUILD_VERSION`), defaulting to `github`, and `SELF_UPDATE_ENABLED = CHANNEL === "github"`.
- `src/index.ts` gates the startup update on the flag; `autoUpdate()` gets the matching early return next to the existing `isCompiledBinary()` / `isNpmInstall()` guards, so no caller can route around it.
- `--update` and `--uninstall` become no-ops on a packaged build that say the install is managed externally. `--uninstall` in particular no longer deletes an install directory the package manager still believes it owns.
- `printHelp()` prints the install line that applies to the build: the `curl … install.sh | bash` line on `github`, the package manager on `packaged`.
- `scripts/build-binary.sh` already accepts the channel as its third argument, so `scripts/build-binary.sh bun-linux-x64 <outfile> packaged` is the whole downstream story. Documented in CLAUDE.md/AGENTS.md.

Default stays `github`, so nothing changes for existing users or for the release workflow.

## Related Issues

Closes #130

## Testing

- [x] New unit tests: `src/build-flags.test.ts` (default channel is `github`, self-update on), `src/cli/commands.test.ts` (help text per channel, `--update` makes no network call on `packaged`, `--uninstall` neither prompts, nor touches PATH, nor calls `rmSync`), and a `packaged` case added to `src/cli/updater.test.ts` (no network even when every other guard is satisfied)
- [x] End-to-end against real compiled binaries, one per channel:
  - `packaged --help` → `Installed and updated by your package manager.`; `github --help` → the `curl … install.sh | bash` line
  - `packaged --update` → `universal-netlist v1.5.2 was installed by a package manager.`, no network
  - `packaged --uninstall` → same explanation, binary still on disk afterwards
- [x] `npm test` passes (747 passed, 10 skipped)
- [x] `npm run type-check`, `npm run lint`, `prettier --check` clean on the changed files

## Note on merge order

Based on `build/standalone-binary-script` (#139), which adds the `[channel]` argument this flag is set through. That one is in turn based on #138. Merge order: #138 → #139 → this.

## Changelog

Binaries can now be built with self-update disabled (`scripts/build-binary.sh <target> <outfile> packaged`), for installs a package manager owns: no startup update check, and `--update` / `--uninstall` explain that the install is managed externally instead of modifying it. Release builds are unaffected.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)