### PR TITLE
test: name the fixture path helper for what it returns

### DIFF
--- a/src/parsers/cadence/dsn/dsn-parser.test.ts
+++ b/src/parsers/cadence/dsn/dsn-parser.test.ts
@@ -9,9 +9,9 @@ import { OleReader } from "../../ole-reader/ole-reader.js";
 import { parseDsnFile } from "./dsn-parser.js";
 import { parseCadence, buildCadencePinMap } from "../index.js";
 import { traverseCircuitFromNet, computeCircuitHash } from "../../../circuit-traversal.js";
-import { fixture, hasFixtures } from "../../../../test/utils.js";
+import { fixturePath, hasFixtures } from "../../../../test/utils.js";
 
-const FIXTURE_DIR = fixture("cadence", "BeagleBone-Black", "ALLEGRO");
+const FIXTURE_DIR = fixturePath("cadence", "BeagleBone-Black", "ALLEGRO");
 const DSN_FIXTURE = join(FIXTURE_DIR, "BEAGLEBONEBLK_C3.DSN");
 const PSTXNET_FIXTURE = join(FIXTURE_DIR, "pstxnet.dat");
 const PSTXPRT_FIXTURE = join(FIXTURE_DIR, "pstxprt.dat");

--- a/src/parsers/kicad/index.test.ts
+++ b/src/parsers/kicad/index.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { kicadHandler, parseKicadDesign } from "./index.js";
 import { discoverKicadDesigns, isKicadFile } from "./discovery.js";
-import { fixture, hasFixtures } from "../../../test/utils.js";
+import { fixturePath, hasFixtures } from "../../../test/utils.js";
 
-const KICAD_FIXTURES = fixture("kicad");
+const KICAD_FIXTURES = fixturePath("kicad");
 
 describe("kicadHandler", () => {
   it("declares the kicad name and project extensions", () => {

--- a/src/service/tools/query-xnet.test.ts
+++ b/src/service/tools/query-xnet.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { existsSync } from "node:fs";
 import type { ParsedNetlist, ErrorResult } from "../../types.js";
 import * as parsersModule from "../../parsers/index.js";
-import { fixture, hasFixtures } from "../../../test/utils.js";
+import { fixturePath, hasFixtures } from "../../../test/utils.js";
 
 const isErrorResult = (result: unknown): result is ErrorResult =>
   typeof result === "object" && result !== null && "error" in result;
 
 // OpenMD's committed .net declares its ground as the hierarchical "/GND", so it
 // parses without kicad-cli and exercises the real classify+reject path in CI.
-const OPENMD = fixture("kicad", "openmd-motordriver", "OpenMD.kicad_pro");
+const OPENMD = fixturePath("kicad", "openmd-motordriver", "OpenMD.kicad_pro");
 const hasOpenMd = hasFixtures && existsSync(OPENMD);
 
 describe("queryXnetByNetName - ground net blocking", () => {

--- a/src/service/tools/run-erc.test.ts
+++ b/src/service/tools/run-erc.test.ts
@@ -4,7 +4,7 @@ import type { ParsedNetlist } from "../../types.js";
 import { isErrorResult } from "../../types.js";
 import * as parsersModule from "../../parsers/index.js";
 import { runErc, type ErcResult } from "./run-erc.js";
-import { fixture, hasFixtures } from "../../../test/utils.js";
+import { fixturePath, hasFixtures } from "../../../test/utils.js";
 
 const DESIGN = "/mock/design.dsn";
 
@@ -167,7 +167,7 @@ describe("runErc rule selection", () => {
 // Integration against a real committed KiCad .net (no kicad-cli, no mocks). This design
 // naturally exercises 3 of the 4 rules; net.testpoint_orphan has no fixture (clean designs
 // don't leave nets with only test points), so it is covered by the mock tests above.
-const RDIMM = fixture("kicad", "rdimm-ddr4-tester", "data-center-rdimm-ddr4-tester.kicad_pro");
+const RDIMM = fixturePath("kicad", "rdimm-ddr4-tester", "data-center-rdimm-ddr4-tester.kicad_pro");
 const hasRdimm = hasFixtures && existsSync(RDIMM);
 
 const nonEmptyMap = (v: unknown): Record<string, string[]> => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,10 +24,10 @@ export const FIXTURES = FIXTURES_DIR;
  * Resolve a path inside the fixtures submodule.
  *
  * ```ts
- * const OPENMD = fixture("kicad", "openmd-motordriver", "OpenMD.kicad_pro");
+ * const OPENMD = fixturePath("kicad", "openmd-motordriver", "OpenMD.kicad_pro");
  * ```
  */
-export const fixture = (...segments: string[]): string => path.join(FIXTURES, ...segments);
+export const fixturePath = (...segments: string[]): string => path.join(FIXTURES, ...segments);
 
 /**
  * Whether the fixtures submodule is checked out.


### PR DESCRIPTION
## Summary

Follow-up to the review comment on #137, which entered the merge queue before the fix could be pushed to its branch.

`test/utils.ts` already used `fixture` as its conventional parameter name for a `Fixture`-typed value — `findDesignFiles(fixture: Fixture)`, `findDsnFiles(fixture: Fixture)`, `findDesignFile(fixture: Fixture)` — so the exported `fixture()` path builder was shadowed inside those functions, and the same identifier meant two unrelated things depending on scope.

## Changes

- `fixture()` → `fixturePath()` in `test/utils.ts`, including its doc example.
- The four call sites follow: `src/parsers/kicad/index.test.ts`, `src/parsers/cadence/dsn/dsn-parser.test.ts`, `src/service/tools/query-xnet.test.ts`, `src/service/tools/run-erc.test.ts`.

Rename only, no behaviour change.

## Related Issues

Follow-up to #132 / #137.

## Testing

- [x] `npm test` passes (740 passed, 10 skipped)
- [x] `npm run type-check` reports nothing in the changed files
- [x] `npm run lint` and `prettier --check` clean on the changed files

## Changelog

Nothing user-visible: test helper rename.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)