### PR TITLE
build: reject a channel the build script does not know

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -27,13 +27,29 @@ set -euo pipefail
 
 TARGET="${1:-}"
 OUTFILE="${2:-}"
-CHANNEL="${3:-github}"
+# `-` rather than `:-`: an omitted third argument means "the default channel",
+# but one passed as an empty string means the caller meant to name a channel and
+# their variable was unset. Defaulting that to `github` is how a packaged build
+# ends up self-updating in a prefix it does not own, so let it fail below.
+CHANNEL="${3-github}"
 
 if [ -z "$TARGET" ] || [ -z "$OUTFILE" ]; then
     echo "Usage: $0 <target> <outfile> [channel]" >&2
     echo "  e.g. $0 bun-linux-x64 bin/universal-netlist-linux-x64" >&2
     exit 1
 fi
+
+# Only `github` turns self-update on, so any other spelling — `packagd`, an
+# empty string, tomorrow's channel name — produces a binary with self-update
+# silently off. Reject it here, where the typo was made, rather than shipping a
+# quietly degraded build that nothing downstream can tell apart from a good one.
+case "$CHANNEL" in
+    github | packaged) ;;
+    *)
+        echo "Unknown channel: $CHANNEL (expected 'github' or 'packaged')" >&2
+        exit 1
+        ;;
+esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/test/build-binary.test.ts
+++ b/test/build-binary.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Argument handling in scripts/build-binary.sh.
+ *
+ * Only the rejection paths are exercised: they fail before Bun is invoked, so
+ * these tests need no toolchain and cost nothing. A channel the script does not
+ * know would otherwise compile a binary with self-update silently off, which is
+ * indistinguishable downstream from a build that meant it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const TEST_DIR = path.dirname(new URL(import.meta.url).pathname);
+const SCRIPT = path.join(TEST_DIR, "..", "scripts", "build-binary.sh");
+
+const run = (...args: string[]): { status: number | null; stderr: string } => {
+  const result = spawnSync("bash", [SCRIPT, ...args], { encoding: "utf-8" });
+  return { status: result.status, stderr: result.stderr };
+};
+
+describe("build-binary.sh argument handling", () => {
+  it("rejects a channel it does not know", () => {
+    const { status, stderr } = run("host", "/dev/null", "packagd");
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Unknown channel: packagd");
+  });
+
+  it("rejects an empty channel rather than defaulting it", () => {
+    const { status, stderr } = run("host", "/dev/null", "");
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Unknown channel");
+  });
+
+  it("prints usage when the target and outfile are missing", () => {
+    const { status, stderr } = run();
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Usage:");
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the review comment on #140: `scripts/build-binary.sh` accepted any string as its channel argument, and only `github` enables self-update. Every other spelling — `packagd`, tomorrow's channel name, an empty `$CHANNEL` the caller believed was set — produced a binary with self-update silently off, and nothing downstream distinguishes that build from one that meant it.

#140 was already in the merge queue when the comment landed, so this ships separately. It stands on its own: the script itself is already on `main` via #139.

## Changes

- `scripts/build-binary.sh` validates the channel against the known set (`github`, `packaged`) and fails with the offending value, at the point the typo was made rather than at some point downstream.
- The default now uses `${3-github}` instead of `${3:-github}`. An omitted third argument still means `github`; one passed as an *empty string* fails. That distinction is the one that matters: a downstream packager running `build-binary.sh host out "$CHANNEL"` with `CHANNEL` unset was silently getting a self-updating binary in a prefix it does not own, which is exactly the failure #130 exists to prevent.
- `test/build-binary.test.ts` covers the three rejection paths. They fail before Bun is invoked, so the tests need no toolchain and run in milliseconds.

Validation lives in the build script rather than in `src/build-flags.ts` deliberately: throwing at module load would turn a build-time typo into an MCP server that crashes on every start for the end user, whereas failing the build stops the bad binary from existing at all.

## Related Issues

Follow-up to #130 / #140.

## Testing

- [x] `scripts/build-binary.sh host /dev/null packagd` → exit 1, `Unknown channel: packagd`
- [x] An empty channel argument → exit 1; an omitted one still builds `channel=github`
- [x] Both valid channels still build and behave: `npm run compile` (github), and a `packaged` build whose `--update` reports it was installed by a package manager
- [x] `npm test` passes (750 passed, 10 skipped)
- [x] `npm run type-check`, `prettier --check`, `bash -n` clean

## Changelog

Nothing user-visible: the binary build script rejects an unknown build channel instead of quietly compiling a binary with self-update disabled.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)