### PR TITLE
build: read the version with Bun, and let the caller set it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,16 @@ no `GITHUB_REF`. The version it bakes in comes from `package.json`, which is the
 source of it; the release workflow validates the tag against `package.json` rather than
 deriving a version from the tag.
 
+`VERSION` overrides that, which is what a downstream packager stamping its own string
+wants instead of patching a tracked file:
+
+```bash
+VERSION=1.5.2-3 scripts/build-binary.sh bun-linux-x64 bin/universal-netlist-linux-x64 packaged
+```
+
+Bun is the only toolchain the script needs, reading that default version included, so a
+container holding just the Bun in `.bun-version` builds this.
+
 The third argument is the build channel, baked in as `BUILD_CHANNEL` (see
 [src/build-flags.ts](src/build-flags.ts)):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ wants instead of patching a tracked file:
 VERSION=1.5.2-3 scripts/build-binary.sh bun-linux-x64 bin/universal-netlist-linux-x64 packaged
 ```
 
+It is held to the characters a version is written with (`A-Za-z0-9` and `. + _ ~ : -`),
+which covers semver, build metadata and a Debian-style `1.5.2~rc1`. The version compiles
+in as raw source text, so anything else is rejected rather than left to truncate itself
+into a binary reporting a version nobody released.
+
 Bun is the only toolchain the script needs, reading that default version included, so a
 container holding just the Bun in `.bun-version` builds this.
 

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -13,15 +13,23 @@
 #            `github` self-updates from GitHub Releases; use `packaged`
 #            for a build a package manager owns.
 #
+# Environment:
+#   VERSION  Version baked into the binary, default the one in package.json.
+#
 # Examples:
 #   ./scripts/build-binary.sh bun-linux-x64 bin/universal-netlist-linux-x64
 #   ./scripts/build-binary.sh host bin/universal-netlist packaged
+#   VERSION=1.5.2-3 ./scripts/build-binary.sh host bin/universal-netlist packaged
 #
 # This compiles and nothing else: no git, no network, no signing, no
 # publishing, no reading GITHUB_REF. The version comes from package.json,
 # which is the single source of it — the release workflow validates the tag
 # against package.json rather than deriving a version from the tag, so a
-# build outside a tag push produces the same binary CI would.
+# build outside a tag push produces the same binary CI would. $VERSION is the
+# one way to say otherwise, for a downstream packager stamping its own.
+#
+# Bun is the whole toolchain this needs. An image holding just the version in
+# `.bun-version` builds this.
 
 set -euo pipefail
 
@@ -54,7 +62,16 @@ esac
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-VERSION="$(node -p "require('$PROJECT_DIR/package.json').version")"
+# A downstream packager stamping its own string (`1.5.2-3`, a snapshot date, a
+# commit-derived name) sets $VERSION rather than patching a tracked file. Here
+# `:-` rather than `-`, unlike the channel above: an unset caller variable falls
+# back to a true upstream version, which is the behaviour every existing caller
+# already has, where the same slip on the channel would arm self-update.
+#
+# Bun reads package.json because the compile below needs Bun anyway. Reading it
+# with Node made a build fail on `node: command not found` in an environment
+# that had installed every toolchain this repo declares.
+VERSION="${VERSION:-$(bun -e "console.log(require('$PROJECT_DIR/package.json').version)")}"
 
 mkdir -p "$(dirname "$OUTFILE")"
 

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -74,7 +74,12 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 # Bun reads package.json because the compile below needs Bun anyway. Reading it
 # with Node made a build fail on `node: command not found` in an environment
 # that had installed every toolchain this repo declares.
-VERSION="${VERSION:-$(bun -e "console.log(require('$PROJECT_DIR/package.json').version)")}"
+#
+# The path travels in the environment rather than inside the snippet: spliced
+# into the source, a checkout under a directory whose name holds a quote, which
+# any name-shaped `O'Brien` gives you, ends the string literal early and the
+# build dies on a JS syntax error naming neither the path nor the reason.
+VERSION="${VERSION:-$(PACKAGE_JSON="$PROJECT_DIR/package.json" bun -e "console.log(require(process.env.PACKAGE_JSON).version)")}"
 
 # --define substitutes this as raw source text rather than as an escaped string,
 # so a `"` in it closes the literal early and the rest is dropped: `1.0.0", "x":

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -15,6 +15,9 @@
 #
 # Environment:
 #   VERSION  Version baked into the binary, default the one in package.json.
+#            Held to A-Za-z0-9 and . + _ ~ : -, the characters a version is
+#            written with, so it cannot break out of the string it compiles
+#            into and leave a binary reporting some truncation of itself.
 #
 # Examples:
 #   ./scripts/build-binary.sh bun-linux-x64 bin/universal-netlist-linux-x64
@@ -72,6 +75,20 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 # with Node made a build fail on `node: command not found` in an environment
 # that had installed every toolchain this repo declares.
 VERSION="${VERSION:-$(bun -e "console.log(require('$PROJECT_DIR/package.json').version)")}"
+
+# --define substitutes this as raw source text rather than as an escaped string,
+# so a `"` in it closes the literal early and the rest is dropped: `1.0.0", "x":
+# "y` compiled clean and reported 1.0.0, and a leading space compiled a version
+# with a space in it. Both produce the binary reporting a version nobody
+# released that the channel check above exists to stop, so hold this to the
+# characters versions are actually written with. `+` and `~` stay in for build
+# metadata and for a Debian-style `1.5.2~rc1`.
+case "$VERSION" in
+    "" | *[!A-Za-z0-9.+_~:-]*)
+        echo "Invalid version: '$VERSION' (allowed: A-Za-z0-9 and . + _ ~ : -)" >&2
+        exit 1
+        ;;
+esac
 
 mkdir -p "$(dirname "$OUTFILE")"
 

--- a/test/build-binary.test.ts
+++ b/test/build-binary.test.ts
@@ -1,23 +1,68 @@
 /**
  * Argument handling in scripts/build-binary.sh.
  *
- * Only the rejection paths are exercised: they fail before Bun is invoked, so
- * these tests need no toolchain and cost nothing. A channel the script does not
- * know would otherwise compile a binary with self-update silently off, which is
- * indistinguishable downstream from a build that meant it.
+ * Every test here stops before a binary is produced, so they need no toolchain
+ * and cost nothing. The rejection paths fail before Bun is invoked at all; the
+ * version tests read the line the script prints before compiling, and hand it a
+ * target Bun rejects so the compile itself is over in milliseconds. CI has no
+ * Bun, which is why the assertions are all on what the script decided rather
+ * than on an artifact.
+ *
+ * A channel the script does not know would compile a binary with self-update
+ * silently off, indistinguishable downstream from a build that meant it. A
+ * mis-resolved version is the same shape of defect: a binary reporting a
+ * version nobody released.
  */
 
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 
 const TEST_DIR = path.dirname(new URL(import.meta.url).pathname);
-const SCRIPT = path.join(TEST_DIR, "..", "scripts", "build-binary.sh");
+const PROJECT_DIR = path.join(TEST_DIR, "..");
+const SCRIPT = path.join(PROJECT_DIR, "scripts", "build-binary.sh");
 
-const run = (...args: string[]): { status: number | null; stderr: string } => {
-  const result = spawnSync("bash", [SCRIPT, ...args], { encoding: "utf-8" });
-  return { status: result.status, stderr: result.stderr };
+/** A target Bun rejects, so the compile fails immediately instead of building. */
+const BAD_TARGET = "bun-nonexistent-target";
+
+const hasBun = spawnSync("bun", ["--version"]).status === 0;
+
+/**
+ * A PATH carrying Bun and the coreutils the script calls, and no Node.
+ *
+ * Reading the default version is the one step that ever wanted Node, so a
+ * fallback exercised on the ambient PATH would pass on a machine that simply
+ * has both installed. `null` where that PATH cannot be built: no Bun, or a Node
+ * in the system directories the script needs anyway.
+ */
+const nodeFreePath = ((): string | null => {
+  const bun = spawnSync("command", ["-v", "bun"], {
+    encoding: "utf-8",
+    shell: true,
+  });
+  if (bun.status !== 0) return null;
+
+  const candidate = `${path.dirname(bun.stdout.trim())}:/usr/bin:/bin`;
+  const node = spawnSync("command", ["-v", "node"], {
+    encoding: "utf-8",
+    shell: true,
+    env: { PATH: candidate },
+  });
+  return node.status === 0 ? null : candidate;
+})();
+
+type Run = { status: number | null; stdout: string; stderr: string };
+
+const runWithEnv = (env: NodeJS.ProcessEnv, ...args: string[]): Run => {
+  const result = spawnSync("bash", [SCRIPT, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 };
+
+const run = (...args: string[]): Run => runWithEnv({}, ...args);
 
 describe("build-binary.sh argument handling", () => {
   it("rejects a channel it does not know", () => {
@@ -39,5 +84,56 @@ describe("build-binary.sh argument handling", () => {
 
     expect(status).toBe(1);
     expect(stderr).toContain("Usage:");
+  });
+});
+
+describe("build-binary.sh version resolution", () => {
+  /** The environment the script sees with no VERSION set, whatever the host has. */
+  const withoutVersion = (): NodeJS.ProcessEnv => {
+    const env = { ...process.env };
+    delete env.VERSION;
+    return env;
+  };
+
+  it("bakes in the version the caller supplies", () => {
+    const { stdout } = runWithEnv({ VERSION: "1.5.2-3" }, BAD_TARGET, "/dev/null");
+
+    expect(stdout).toContain("version=1.5.2-3");
+  });
+
+  it("takes a caller-supplied version without running any JS runtime", () => {
+    // The point of the override: `PATH` holding neither Bun nor Node still
+    // resolves a version. Only the compile below it needs a toolchain.
+    const { stdout } = runWithEnv(
+      { VERSION: "0.0.0-snapshot", PATH: "/usr/bin:/bin" },
+      BAD_TARGET,
+      "/dev/null"
+    );
+
+    expect(stdout).toContain("version=0.0.0-snapshot");
+  });
+
+  it.skipIf(!nodeFreePath)("falls back to package.json with Bun alone, no Node installed", () => {
+    const { version } = JSON.parse(
+      readFileSync(path.join(PROJECT_DIR, "package.json"), "utf-8")
+    ) as { version: string };
+    const result = spawnSync("bash", [SCRIPT, BAD_TARGET, "/dev/null"], {
+      encoding: "utf-8",
+      env: { ...withoutVersion(), PATH: nodeFreePath as string },
+    });
+
+    expect(result.stdout).toContain(`version=${version}`);
+    expect(result.stderr).not.toContain("node: command not found");
+  });
+
+  it.skipIf(!hasBun)("falls back rather than baking an empty version", () => {
+    // `VERSION=$SOME_UNSET_VAR` reaches the script as an empty string. A true
+    // upstream version is the right answer there; `version=` is not one.
+    const result = spawnSync("bash", [SCRIPT, BAD_TARGET, "/dev/null"], {
+      encoding: "utf-8",
+      env: { ...withoutVersion(), VERSION: "" },
+    });
+
+    expect(result.stdout).toMatch(/version=\S+, channel=github/);
   });
 });

--- a/test/build-binary.test.ts
+++ b/test/build-binary.test.ts
@@ -126,6 +126,38 @@ describe("build-binary.sh version resolution", () => {
     expect(result.stderr).not.toContain("node: command not found");
   });
 
+  // `--define` substitutes the version as raw source text, so a `"` closes the
+  // string literal early and Bun compiles the truncated remainder without
+  // complaint: `1.0.0", "X": "y` built clean and reported 1.0.0. A version the
+  // caller never asked for, in a binary nothing downstream can tell apart from
+  // a good one, which is the defect the channel check exists to stop.
+  it.each([
+    ["a quote, which truncated the version silently", '1.0.0", "X": "y'],
+    ["a trailing backslash", "1.0.0\\"],
+    ["a leading space", " 1.5.2"],
+    ["a newline", "1.5.2\nevil"],
+  ])("rejects a version carrying %s", (_label, version) => {
+    const { status, stderr } = runWithEnv({ VERSION: version }, BAD_TARGET, "/dev/null");
+
+    expect(status).toBe(1);
+    expect(stderr).toContain("Invalid version:");
+  });
+
+  // The formats a downstream packager actually stamps. Rejecting one of these
+  // would send them back to patching package.json, which is what #144 asked to
+  // stop doing.
+  it.each([
+    ["plain semver", "1.5.2"],
+    ["a packager revision", "1.5.2-3"],
+    ["build metadata", "1.5.2+2026.08.14"],
+    ["a Debian pre-release", "1.5.2~rc1"],
+    ["a Debian epoch", "1:1.5.2"],
+  ])("accepts %s", (_label, version) => {
+    const { stdout } = runWithEnv({ VERSION: version }, BAD_TARGET, "/dev/null");
+
+    expect(stdout).toContain(`version=${version}`);
+  });
+
   it.skipIf(!hasBun)("falls back rather than baking an empty version", () => {
     // `VERSION=$SOME_UNSET_VAR` reaches the script as an empty string. A true
     // upstream version is the right answer there; `version=` is not one.

--- a/test/build-binary.test.ts
+++ b/test/build-binary.test.ts
@@ -17,7 +17,8 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const TEST_DIR = path.dirname(new URL(import.meta.url).pathname);
 const PROJECT_DIR = path.join(TEST_DIR, "..");
@@ -113,17 +114,43 @@ describe("build-binary.sh version resolution", () => {
     expect(stdout).toContain("version=0.0.0-snapshot");
   });
 
+  /** The version the fallback is expected to find. */
+  const packageVersion = (): string =>
+    (
+      JSON.parse(readFileSync(path.join(PROJECT_DIR, "package.json"), "utf-8")) as {
+        version: string;
+      }
+    ).version;
+
   it.skipIf(!nodeFreePath)("falls back to package.json with Bun alone, no Node installed", () => {
-    const { version } = JSON.parse(
-      readFileSync(path.join(PROJECT_DIR, "package.json"), "utf-8")
-    ) as { version: string };
     const result = spawnSync("bash", [SCRIPT, BAD_TARGET, "/dev/null"], {
       encoding: "utf-8",
       env: { ...withoutVersion(), PATH: nodeFreePath as string },
     });
 
-    expect(result.stdout).toContain(`version=${version}`);
+    expect(result.stdout).toContain(`version=${packageVersion()}`);
     expect(result.stderr).not.toContain("node: command not found");
+  });
+
+  it.skipIf(!hasBun)("falls back from a checkout path that holds a quote", () => {
+    // The path reaches Bun in the environment rather than spliced into the
+    // snippet. Spliced, a quote in it ends the string literal early and the
+    // build dies on a JS syntax error naming neither the path nor the reason;
+    // any name-shaped directory, `O'Brien`, is enough to do it.
+    const dir = mkdtempSync(path.join(tmpdir(), "build-binary-"));
+    try {
+      const checkout = path.join(dir, "o'brien");
+      symlinkSync(PROJECT_DIR, checkout);
+      const result = spawnSync(
+        "bash",
+        [path.join(checkout, "scripts", "build-binary.sh"), BAD_TARGET, "/dev/null"],
+        { encoding: "utf-8", env: withoutVersion() }
+      );
+
+      expect(result.stdout).toContain(`version=${packageVersion()}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   // `--define` substitutes the version as raw source text, so a `"` closes the


### PR DESCRIPTION
## Summary

Closes #144. `scripts/build-binary.sh` shelled out to Node purely to read the version string out of `package.json`. Everything else it does is `bun build --compile`, so an environment carrying the toolchain this repo declares (the Bun pinned in `.bun-version`) failed on `node: command not found` at the one line that had nothing to do with the build.

Both halves of the issue's proposal, since they solve different parts of it: the `VERSION` override serves the packager who wants to stamp their own string, and the Bun fallback drops the undeclared Node dependency for everyone else.

## Changes

- `VERSION="${VERSION:-$(bun -e "...")}"`. A downstream packager stamping `1.5.2-3`, a snapshot date, or a commit-derived name sets one variable instead of patching a tracked file.
- The fallback reads `package.json` with Bun rather than Node. The compile below it needs Bun anyway, so Bun is now the whole toolchain.
- `:-` rather than the `-` the channel argument above it uses, which is a deliberate split. `VERSION=$SOME_UNSET_VAR` falling back to a true upstream version is harmless; the same slip on the channel arms self-update in a prefix nothing owns, which is why #142 made that one strict.
- **The version is validated** (second commit, see below).
- Tests in `test/build-binary.test.ts`, plus the script header and the CLAUDE.md build section.

## The validation, and why it is here

Raised in review, and it turned out to be a real silent-corruption path rather than a theoretical one. `--define` substitutes the version into the compile as raw source text, not as an escaped string, so measured against the actual binary:

| `VERSION` | before | after |
|---|---|---|
| `1.0.0", "X": "y` | **builds, reports `v1.0.0`** | rejected |
| `1.0.0\` | **builds, reports `v1.0.0`** | rejected |
| ` 1.5.2` (leading space) | **builds, reports `v 1.5.2`** | rejected |
| `1.5.2\nevil` | fails on a Bun parse error | rejected with the reason |

The first three are the defect the channel check already guards: a binary reporting a version nobody released, indistinguishable downstream from a good build. Worth closing in the same PR that makes a caller supply the string.

The allow-list is `A-Za-z0-9` and `. + _ ~ : -`, checked against what packagers actually stamp: `1.5.2`, `1.5.2-3`, `1.5.2+2026.08.14`, `1.5.2~rc1`, `1:1.5.2` all build.

## The quoting fix (third commit)

Also raised in review, as a pre-existing note. `$PROJECT_DIR` was spliced into the `bun -e` snippet, so a checkout under a directory whose name holds a single quote (an `O'Brien`) ended the string literal early and the build died on a JS syntax error naming neither the path nor the reason. The path now travels in the environment, where it is just a string, verified by running the script through a symlinked `o'brien` checkout. Inherited from the old `node -p` line rather than introduced here, but the line was being rewritten anyway.

## No change for existing callers

`npm run compile:*` and `release.yml` set no `VERSION` anywhere (no job env, no step env; the workflow's other `VERSION=` assignments are shell-local to their own `run:` blocks), so both keep resolving from `package.json` exactly as before. `release.yml` sets Bun up before the build step, and `ci.yml` never runs this script.

## Testing

- [x] `npm test` — 802 passed, 10 skipped
- [x] `npm run type-check`, `npm run lint`, `shellcheck`, `bash -n` clean
- [x] **Full compile with Node absent from `PATH`**, which is the reported failure: `env -i PATH=<bun>:/usr/bin:/bin bash scripts/build-binary.sh host out packaged` builds, and the binary reports `universal-netlist v1.5.2`
- [x] **The override reaches the binary**, not just the log line: a `VERSION=1.5.2-3` build reports `universal-netlist v1.5.2-3`, and its `--update` still says a package manager owns it, so channel handling is untouched
- [x] Every row of the table above was run against a real compiled binary, before and after
- [x] `npm run compile` (no `VERSION`) still produces `v1.5.2`
- [x] The three behavioural tests were run against the old `node -p` line and **fail** there; the empty-`VERSION` test was run against `${VERSION-...}` and fails there too, so none of them pass vacuously
- [x] Simulated CI with no Bun on `PATH`: the two Bun-dependent tests skip rather than fail

The tests hand the script a target Bun rejects, so they assert on the version line it prints and never build an artifact; the whole file runs in ~330ms.

## Note on scope

An earlier push of this branch briefly carried an unrelated Altium commit (`86c31ee`), which the review picked up on. It has been dropped; that work lives on `fix/altium-number-sheet-own-nets`, byte-identical, and this branch is now the two build-script commits only.

## Changelog

Nothing user-visible in the server itself. Building the binary needs only Bun now, not an undeclared Node install, and `VERSION=<string> scripts/build-binary.sh ...` stamps a version without editing `package.json`, which is what a downstream packager building `1.5.2-3` or a snapshot wants.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
