### PR TITLE
fix(altium): number a sheet's own nets, not just the ones that collide

### DIFF
--- a/src/parsers/altium/net-scoping.test.ts
+++ b/src/parsers/altium/net-scoping.test.ts
@@ -60,13 +60,21 @@ describe("planLocalNetRenames", () => {
     expect(plans[1].get("SCL")).toBe("SCL_2");
   });
 
-  it("leaves a name only one sheet claims alone", () => {
+  it("numbers a sheet's own net even where no other sheet reuses the name", () => {
+    // Altium suffixes because the net is the sheet's own, not because it
+    // collides: the MiSKo3 board carries `VBAT_8` for a label drawn on sheet 8
+    // alone.
     const plans = planLocalNetRenames(
-      [sheet("1", { SCL: { label: true } }), sheet("2", { SDA: { label: true } })],
+      [sheet("8", { VBAT: { label: true } }), sheet("2", { SDA: { label: true } })],
       "hierarchical"
     );
+    expect(plans[0].get("VBAT")).toBe("VBAT_8");
+    expect(plans[1].get("SDA")).toBe("SDA_2");
+  });
+
+  it("leaves a net named after one of its own pins alone, being unique already", () => {
+    const plans = planLocalNetRenames([sheet("3", { NetC3_1: {} })], "hierarchical");
     expect(plans[0].size).toBe(0);
-    expect(plans[1].size).toBe(0);
   });
 
   it("leaves a name shared through ports alone, because it is one net", () => {

--- a/src/parsers/altium/net-scoping.ts
+++ b/src/parsers/altium/net-scoping.ts
@@ -59,12 +59,17 @@ export interface SheetNetScope {
 }
 
 /**
- * Work out, for every sheet, which of its nets have to be renamed to keep them
- * apart from a same-named net on another sheet.
+ * Work out, for every sheet, which of its nets carry the sheet's number.
  *
- * Only a name genuinely claimed by two or more sheets is taken apart. One sheet
- * claiming a name is the ordinary case and keeps the bare name, which is what
- * keeps this from renaming most of a project.
+ * Altium suffixes a sheet-local net whether or not another sheet happens to
+ * reuse the name: the MiSKo3 board carries `VBAT_8` for a `VBAT` label drawn on
+ * sheet 8 alone. So the suffix follows from the net being the sheet's own, not
+ * from a collision, and a name two sheets do reuse is separated as a
+ * consequence rather than as a special case.
+ *
+ * Only a net a designer named is suffixed. A net named after one of its own
+ * pins, `NetC3_1`, is already unique across the board because the refdes is,
+ * and Altium leaves those alone: every board read for this carries them bare.
  *
  * Returns one rename map per sheet, in the order the sheets were given.
  */
@@ -72,16 +77,11 @@ export const planLocalNetRenames = (
   sheets: readonly SheetNetScope[],
   scope: NetIdentifierScope
 ): Map<string, string>[] => {
-  const sheetsClaiming = new Map<string, number>();
   // Every name the project already uses, on any sheet. A suffixed name that
   // collides with one of these is a name the design gave to something else.
   const namesInUse = new Set<string>();
   for (const sheet of sheets) {
-    for (const [netName, kinds] of sheet.netIdentifiers) {
-      namesInUse.add(netName);
-      if (!isSheetBound(kinds, scope)) continue;
-      sheetsClaiming.set(netName, (sheetsClaiming.get(netName) ?? 0) + 1);
-    }
+    for (const netName of sheet.netIdentifiers.keys()) namesInUse.add(netName);
   }
 
   return sheets.map((sheet) => {
@@ -90,7 +90,10 @@ export const planLocalNetRenames = (
 
     for (const [netName, kinds] of sheet.netIdentifiers) {
       if (!isSheetBound(kinds, scope)) continue;
-      if ((sheetsClaiming.get(netName) ?? 0) < 2) continue;
+      // A name the designer wrote, rather than one derived from a pin. A power
+      // port counts: where the scope makes it local, the supply it names is
+      // this sheet's own and is numbered with the rest.
+      if (!kinds.label && !kinds.powerPort) continue;
 
       // Some sheet may already draw a net actually called `SCL_2`. Folding the
       // renamed net into it would invent a connection that the design does not

--- a/test/golden/altium/MIXR Power.json
+++ b/test/golden/altium/MIXR Power.json
@@ -8,17 +8,6 @@
         "1"
       ]
     },
-    "49V2_EN": {
-      "U2": [
-        "5"
-      ],
-      "Q1": [
-        "3"
-      ],
-      "R14": [
-        "1"
-      ]
-    },
     "NetR11_1": {
       "U2": [
         "1"
@@ -500,6 +489,17 @@
     },
     "NetR13_1": {
       "R13": [
+        "1"
+      ]
+    },
+    "49V2_EN_7": {
+      "U2": [
+        "5"
+      ],
+      "Q1": [
+        "3"
+      ],
+      "R14": [
         "1"
       ]
     },
@@ -1153,22 +1153,6 @@
         "1"
       ]
     },
-    "USB_CC1": {
-      "P1": [
-        "A5"
-      ],
-      "R2": [
-        "1"
-      ]
-    },
-    "USB_CC2": {
-      "P1": [
-        "B5"
-      ],
-      "R1": [
-        "1"
-      ]
-    },
     "NetD1_1": {
       "P1": [
         "A6",
@@ -1228,6 +1212,22 @@
         "7"
       ]
     },
+    "USB_CC1_3": {
+      "P1": [
+        "A5"
+      ],
+      "R2": [
+        "1"
+      ]
+    },
+    "USB_CC2_3": {
+      "P1": [
+        "B5"
+      ],
+      "R1": [
+        "1"
+      ]
+    },
     "ESP32_PWR_PE_GP3_nBAT_CHG_EN": {
       "U5": [
         "12"
@@ -1242,15 +1242,6 @@
       ],
       "R19": [
         "2"
-      ]
-    },
-    "ESP32_PWR_PE_GP7_DEBUG_LEG": {
-      "U5": [
-        "16"
-      ],
-      "R18": [
-        "10",
-        "9"
       ]
     },
     "ESP32_PWR_PE_GP2_49V2_REG_EN": {
@@ -1284,6 +1275,15 @@
       "LED1": [
         "1"
       ]
+    },
+    "ESP32_PWR_PE_GP7_DEBUG_LEG_8": {
+      "U5": [
+        "16"
+      ],
+      "R18": [
+        "10",
+        "9"
+      ]
     }
   },
   "components": {
@@ -1307,7 +1307,7 @@
         },
         "5": {
           "name": "CTRL",
-          "net": "49V2_EN"
+          "net": "49V2_EN_7"
         },
         "6": {
           "name": "VIN",
@@ -1606,7 +1606,7 @@
         },
         "3": {
           "name": "D",
-          "net": "49V2_EN"
+          "net": "49V2_EN_7"
         }
       },
       "mpn": "DMP3099L-7",
@@ -1643,7 +1643,7 @@
     },
     "R14": {
       "pins": {
-        "1": "49V2_EN",
+        "1": "49V2_EN_7",
         "2": "GND"
       },
       "mpn": "RC0402FR-07162KL",
@@ -2744,11 +2744,11 @@
         },
         "A5": {
           "name": "CC1",
-          "net": "USB_CC1"
+          "net": "USB_CC1_3"
         },
         "B5": {
           "name": "CC2",
-          "net": "USB_CC2"
+          "net": "USB_CC2_3"
         },
         "A6": {
           "name": "DP1",
@@ -2886,7 +2886,7 @@
     },
     "R1": {
       "pins": {
-        "1": "USB_CC2",
+        "1": "USB_CC2_3",
         "2": "GND"
       },
       "mpn": "RMCF0402FT5K10",
@@ -2895,7 +2895,7 @@
     },
     "R2": {
       "pins": {
-        "1": "USB_CC1",
+        "1": "USB_CC1_3",
         "2": "GND"
       },
       "mpn": "RMCF0402FT5K10",
@@ -2966,7 +2966,7 @@
         "13": "ESP32_PWR_PE_GP4_BAT_GAUGE_ALRT",
         "14": "ESP32_PWR_PE_GP5_BAT_CHG_nPG",
         "15": "ESP32_PWR_PE_GP6_BAT_CHG_STATUS",
-        "16": "ESP32_PWR_PE_GP7_DEBUG_LEG",
+        "16": "ESP32_PWR_PE_GP7_DEBUG_LEG_8",
         "17": "GND",
         "18": "3V3",
         "19": {
@@ -3009,8 +3009,8 @@
         "6": "3V3",
         "7": "NetLED1_1",
         "8": "NetLED1_1",
-        "9": "ESP32_PWR_PE_GP7_DEBUG_LEG",
-        "10": "ESP32_PWR_PE_GP7_DEBUG_LEG",
+        "9": "ESP32_PWR_PE_GP7_DEBUG_LEG_8",
+        "10": "ESP32_PWR_PE_GP7_DEBUG_LEG_8",
         "11": "ESP32_PWR_PE_GP6_BAT_CHG_STATUS",
         "12": "ESP32_PWR_PE_GP5_BAT_CHG_nPG",
         "13": "ESP32_PWR_PE_GP4_BAT_GAUGE_ALRT",


### PR DESCRIPTION
## Summary

Follow-up to #143, which narrowed the rename to names claimed by two or more sheets. That was wrong, and no fixture in the tree could say so.

I scanned **181 public Altium projects** that set `AppendSheetNumberToLocalNets=1` and checked the candidates against their own `PcbDoc` netlists. Three reproduce the over-merge, and they settle the rule:

- On the **MiSKo3** board, `VBAT` is `VBAT_8` for a label drawn on sheet 8 **alone**. Same for `YU_7`, `XR_7`, `STM_JTMS_5` and six more.
- So Altium numbers a net for being the sheet's own, not for colliding. A name two sheets reuse is separated as a *consequence*, not as a special case.

Two further corrections fall out of the same evidence:

- **Only a net a designer named is numbered.** A net named after one of its own pins (`NetC3_1`) is already unique because the refdes is, and every board read for this carries them bare. Numbering those took mixr-power from 6 unmatched board nets to 57, which is how the error was caught.
- **A power port counts as a designer's name** where the scope makes it local, so Strict Hierarchical still numbers its supplies.

## Measured against each board's own netlist

| Design | Over-merged nets before | after |
|---|---|---|
| MiSKo3 (GPL-3.0, 13 sheets) | 10 | **0** |
| A7-Minima (13 sheets) | 33 | 3 |
| ZXEvoPro (15 sheets) | 163 | 34 |

The residual tail on the latter two is a different defect: nets wired between two sheet entries on a parent sheet are that sheet's own for naming, but our `isSheetBound` treats a sheet entry as carrying the net off-sheet. Left alone here.

## Regression

- The twelve fixtures with the flag off are **byte-identical**, as before.
- `mixr-power` is the only golden that moves: 4 sheet-local labels gain their sheet number, net count unchanged at 92, no connectivity change. `USB_CC1` becomes `USB_CC1_3`, correctly following the schematic's current sheet 3 (that board records `_2` because it is stale relative to its sources; see IntelligentElectron/test-fixtures#4).

## Test plan

- [x] `npm test` — 789 passed, 0 failed
- [x] `npm run type-check`, `npm run lint` clean
- [x] `net-scoping.test.ts` updated: a sheet's own net is numbered with no collision present, and a pin-derived name is left alone
- [x] Over-merge measured against three independent boards, before and after

Depends on IntelligentElectron/test-fixtures#4 for the MiSKo3 fixture and its golden, which land in a follow-up once that merges.