### PR TITLE
fix(altium): map only the HierarchyMode values a design has demonstrated

### DIFF
--- a/src/parsers/altium/project-options.test.ts
+++ b/src/parsers/altium/project-options.test.ts
@@ -13,7 +13,6 @@ describe("parseProjectOptions", () => {
   it("reads a scope the project names outright", () => {
     expect(parseProjectOptions(design("HierarchyMode=3")).scope).toBe("global");
     expect(parseProjectOptions(design("HierarchyMode=2")).scope).toBe("hierarchical");
-    expect(parseProjectOptions(design("HierarchyMode=1")).scope).toBe("flat");
     // `4` is read as Hierarchical: the solarcar-bms board numbers that
     // project's sheet-local labels but leaves GND and CHASSIS bare, so its
     // power ports are global and it cannot be Strict Hierarchical.
@@ -24,7 +23,10 @@ describe("parseProjectOptions", () => {
     expect(parseProjectOptions(design("HierarchyMode=0")).scope).toBeUndefined();
   });
 
-  it("reads a mode it does not know as Automatic rather than guessing", () => {
+  it("reads a mode no design has demonstrated as Automatic rather than guessing", () => {
+    // Automatic resolves the scope from the design's own shape, which is
+    // evidence; a guessed constant would be wrong everywhere at once.
+    expect(parseProjectOptions(design("HierarchyMode=1")).scope).toBeUndefined();
     expect(parseProjectOptions(design("HierarchyMode=97")).scope).toBeUndefined();
   });
 

--- a/src/parsers/altium/project-options.ts
+++ b/src/parsers/altium/project-options.ts
@@ -40,21 +40,29 @@ export interface AltiumProjectOptions {
 }
 
 /**
- * `HierarchyMode` values, in the order the Net Identifier Scope drop-down
- * lists them. `0` is Automatic, which is the default and by far the most
- * common value; a project that names a scope outright has been changed by hand.
+ * What each `HierarchyMode` means, as far as designs have shown. `0` is
+ * Automatic, the default and by far the most common; a project naming a scope
+ * outright has been changed by hand.
  *
- * The mapping is corroborated by the fixtures: the LimeSDR-USB boards record
- * `3` and are drawn with no sheet symbols and no ports at all, so their sheets
- * can only be joined by matching net labels, which is Global; the nRF52840
- * development kit records `2` and is drawn as a full parent/child hierarchy.
+ * This began as the order the Net Identifier Scope drop-down lists them, which
+ * turned out to be wrong: `4` was read as Strict Hierarchical on that basis
+ * until a board contradicted it. So only values a design has actually
+ * demonstrated are mapped here, and each entry says what demonstrates it.
  *
- * A value outside this table is read as Automatic, so a mode we have not seen
- * is resolved from the shape of the design rather than guessed at.
+ * A value not in this table is read as Automatic, which resolves the scope from
+ * the shape of the design. That is deliberately preferred to guessing: a guess
+ * is fixed and wrong everywhere, where the design's own shape is evidence.
  */
 const HIERARCHY_MODE_SCOPE: Readonly<Record<string, NetIdentifierScope>> = {
-  "1": "flat",
+  // The nRF52840 development kit and MiSKo3 record `2` and are drawn as full
+  // parent/child hierarchies; MiSKo3's board numbers its sheet-local labels and
+  // leaves `GND` bare, which is Hierarchical exactly.
   "2": "hierarchical",
+  // The LimeSDR-USB boards record `3` and are drawn with no sheet symbols and
+  // no ports at all, so nothing but matching net labels can be joining their
+  // sheets, which is Global. Note none of them enables
+  // `AppendSheetNumberToLocalNets`, so no board yet confirms this one the way
+  // MiSKo3 and solarcar-bms confirm `2` and `4`.
   "3": "global",
   // `4` was read as Strict Hierarchical until a board said otherwise. The
   // solarcar-bms fixture records it and numbers its sheet-local signals, so its


### PR DESCRIPTION
## Summary

Housekeeping on my own work in #143/#151, prompted by re-reading it rather than by a new failure.

The `HierarchyMode` table was built from the order the Net Identifier Scope drop-down lists its modes, and the comment said so. **That premise is now known to be wrong**: `4` was read as Strict Hierarchical on exactly that basis until `solarcar-bms`'s board, carrying `GND` and `CHASSIS` unnumbered, showed its power ports are global. Fixing `4` in #151 left the comment behind, still asserting drop-down order and still inviting the next reader down the same path.

Two changes:

- **`1` is dropped.** It was mapped to Flat on the drop-down reasoning alone and no design in the corpus records it. It now falls through to `Automatic`, which resolves the scope from the design's actual shape. A guess is fixed and wrong everywhere; the design's own shape is evidence.
- **Each remaining entry states what demonstrates it**, including the honest caveat that `3` rests on the LimeSDR boards being drawn with no ports or sheet symbols, *not* on a board confirming it — none of them enables `AppendSheetNumberToLocalNets`, so the scope has no observable effect there. `2` and `4` are board-confirmed; `3` is structural inference.

No behavior change for any design in the corpus: nothing records `1`, and `HierarchyMode=1` designs previously got Flat where they now get Flat-or-Hierarchical depending on what they actually draw.

## Test plan

- [x] `npm test` — 811 passed, 0 failed, all goldens unchanged
- [x] `npm run type-check`, `npm run lint` clean
- [x] `project-options.test.ts` now asserts `1` resolves as Automatic alongside an unknown value, with the reasoning recorded