### PR TITLE
build: refuse a release whose lockfile records another version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,18 @@ rather than after it.
 1. Cut a release PR from `main` after the fixes for the release have merged:
    - Update `CHANGELOG.md` with a new version section, written from the merged PRs' own
      Changelog sections
-   - `npm version minor|patch --no-git-tag-version` (bumps `package.json` only, no tag)
+   - `npm version minor|patch --no-git-tag-version` (writes the version, creates no tag)
    - One commit, e.g. `chore: vX.Y.Z changelog`
+
+   That command writes the version to **both `package.json` and `package-lock.json`**,
+   which is why the release commit carries three files rather than two. `bun.lock`
+   records the workspace root's name and no version, so it stays put.
+
+   Run the command rather than editing `package.json` by hand. A hand-edit leaves the
+   lockfile a version behind, and nothing downstream notices: `npm ci` compares
+   dependencies and ignores the root version entirely, so CI passes, `npm publish` takes
+   its version from `package.json` and is correct, and the lockfile just drifts.
+   `tag-release.sh` refuses on the mismatch, which is the only thing that catches it.
 2. Open it as a normal PR and let the merge queue land it
 3. After merge, tag the merge commit and push:
 
@@ -168,7 +178,8 @@ rather than after it.
    The script tags the version in `package.json` and refuses if anything about
    the state is wrong: not on `main`, a dirty tree, local `main` behind
    `origin/main` (which would tag the wrong commit), no changelog section for
-   the version, or a tag that already exists. Pass `--yes` to skip the prompt.
+   the version, a lockfile recording a different version, or a tag that already
+   exists. Pass `--yes` to skip the prompt.
 
    **Note:** Do NOT use `npm version` without `--no-git-tag-version` -- it creates a local git tag that points to the feature branch commit, not the merge commit on main. The tag must be created on the merge commit, which is what the script checks for.
 

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -56,6 +56,16 @@ REMOTE=$(git rev-parse origin/main)
 grep -q "## \[${VERSION}\]" CHANGELOG.md || \
   fail "CHANGELOG.md has no ## [${VERSION}] section. Write the release notes first."
 
+# `npm version` writes the version to package-lock.json as well, so the two agree
+# whenever the bump was made with it. Editing package.json by hand leaves the
+# lockfile a version behind, and nothing downstream says so: `npm ci` compares
+# dependencies and ignores the root version, so CI passes and the release ships
+# with a lockfile describing the version before it. This is the only check on it.
+# (bun.lock records the root's name and no version, so there is nothing to check.)
+LOCK_VERSION=$(node -p 'require("./package-lock.json").version')
+[ "$LOCK_VERSION" = "$VERSION" ] || \
+  fail "package-lock.json is at $LOCK_VERSION, not $VERSION. Run 'npm install --package-lock-only' and commit it."
+
 git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null && \
   fail "tag ${TAG} already exists locally. Delete it, or pick another version."
 git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1 && \


### PR DESCRIPTION
## Summary

Fallout from cutting 1.5.3, which is the first release since `package-lock.json`
was committed in #135. The lockfile carries the root version, and nothing in the
release path said so.

Two changes:

- **`scripts/tag-release.sh` refuses when `package-lock.json` records a different
  version than `package.json`**, alongside its existing checks on the branch, the
  tree, the changelog and the tag. `bun.lock` records the workspace root's name and
  no version, so there is nothing to check there.
- **CLAUDE.md says what a version bump actually moves.** The release step described
  `npm version --no-git-tag-version` as bumping "package.json only", which is wrong:
  it writes `package-lock.json` too, and that is why a release commit carries three
  files rather than two.

## Why this needs a check rather than just a doc fix

Nothing downstream catches the mismatch. I verified `npm ci` against a `package.json`
at `9.9.9` with a lockfile at `1.5.3`: it installs 305 packages and exits 0. The root
version is not part of what it compares. So CI stays green, `npm publish` takes its
version from `package.json` and publishes correctly, and the lockfile silently drifts
a version behind for good.

This is exactly what happened on 1.5.3. I trusted the parenthetical, edited
`package.json` by hand, and caught the stale lockfile by eye rather than by any check.
`tag-release.sh` is the right home for it: it already refuses rather than repairs, and
it is the last gate before the tag that cannot be taken back.

## Test plan

- [x] `bash -n` and `shellcheck` clean
- [x] End-to-end in a throwaway repo with a real origin: lockfile at `1.9.8` against
      `package.json` at `1.9.9` fails with the new message and **pushes no tag**;
      with both at `1.9.9` the script tags and pushes as before
- [x] The check passes on `main` as it stands (both at 1.5.3), so it does not
      retroactively block anything
- [x] `npm test` — 831 passed, 0 failed (pre-commit hook)

## Changelog

None. Release tooling and contributor docs only.