### PR TITLE
feat: hand out the schematic, not the netlist exported from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is compatible with Cadence, Altium, and KiCad, with plans to integrate more E
 
 | Format | Input Files | Description |
 |--------|------------|-------------|
-| Cadence (CIS / HDL) | `.DSN` schematic, or `.dat` netlist files | The `.DSN` binary schematic is parsed natively. Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) are preferred where they sit beside the design. Do Not Stuff includes the parts a CIS variant leaves off the board, read from the schematic's variant store, so the count agrees with the alternate BOM CIS generates (`*_bom_alts.xlsx`) rather than with the netlist files alone |
+| Cadence (CIS / HDL) | `.DSN` schematic (preferred), or `.dat` netlist files | The `.DSN` binary schematic is parsed natively and is what `list_designs` hands you. Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) are also readable. Do Not Stuff includes the parts a CIS variant leaves off the board, read from the schematic, so the count agrees with the alternate BOM CIS generates (`*_bom_alts.xlsx`) rather than with the netlist files alone |
 | Altium Designer | `.SchDoc` | Altium schematic documents (discovered via `.PrjPcb` project files) |
 | KiCad | `.kicad_pro` (or root `.kicad_sch`) | Reads a resolved `kicadsexpr` netlist export: a committed `.net` beside the project if present, otherwise generated on demand via `kicad-cli` (requires KiCad installed; set `KICAD_CLI_PATH` for a non-standard location) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The Universal Netlist MCP Server provides tools for querying electronic design n
 
 | Format | Input Files | Description |
 |--------|------------|-------------|
-| Cadence (CIS / HDL) | `.dat` files (preferred) or `.DSN` (fallback) | Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) are preferred. When unavailable, the `.DSN` binary schematic is parsed directly. |
+| Cadence (CIS / HDL) | `.DSN` schematic (preferred), or `.dat` netlist files | The `.DSN` binary schematic is parsed directly and is what `list_designs` returns. Exported Allegro netlist files (`pstxnet.dat`, `pstxprt.dat`, `pstchip.dat`) are also readable, though a part a CIS variant leaves off the board is written to them exactly like a stuffed one. |
 | Altium Designer | `.SchDoc` | Altium schematic documents (discovered via `.PrjPcb` project files) |
 | KiCad | `.kicad_pro` (or root `.kicad_sch`) | A committed `kicadsexpr` netlist export (`.net`) beside the project is parsed directly (preferred). When unavailable, one is generated on demand via `kicad-cli` (requires KiCad installed; set `KICAD_CLI_PATH` for a non-standard location). |
 
@@ -41,7 +41,7 @@ The schema captures identification (MPN, description) but not electrical specifi
 | [`query_xnet_by_net_name`](tools/query_xnet_by_net_name.md) | Trace circuit connectivity from a net |
 | [`query_xnet_by_pin_name`](tools/query_xnet_by_pin_name.md) | Trace circuit connectivity from a component pin |
 | [`run_erc`](tools/run_erc.md) | Run electrical rule checks (ERC) on the netlist |
-| [`export_cadence_netlist`](tools/export_cadence_netlist.md) | Export Cadence schematic to Allegro format (Windows) |
+| [`export_cadence_netlist`](tools/export_cadence_netlist.md) | Deprecated. Export Cadence schematic to Allegro format (Windows); not needed to query a design |
 
 ## Schematic Authoring
 

--- a/docs/schemas/shared-types.md
+++ b/docs/schemas/shared-types.md
@@ -450,3 +450,4 @@ Different operations have different case sensitivity behaviors:
 - `search_nets("USB")` matches `USB_DP` but not `usb_dp`
 - `search_components_by_refdes("u1")` matches `U1`, `u1`, and `U1A`
 - `query_component("u15")` finds component `U15`
+- `list_components("u")` returns `U1` and `U15` but not `USB1`: the type is the whole prefix, not a leading substring

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -13,4 +13,4 @@
 | [`query_xnet_by_net_name`](query_xnet_by_net_name.md) | Get full XNET (Extended Net) connectivity for a net |
 | [`query_xnet_by_pin_name`](query_xnet_by_pin_name.md) | Get full XNET connectivity starting from a component pin |
 | [`run_erc`](run_erc.md) | Run electrical rule checks (ERC) on the netlist |
-| [`export_cadence_netlist`](export_cadence_netlist.md) | Export Cadence schematic netlist to Allegro PCB format (Windows only) |
+| [`export_cadence_netlist`](export_cadence_netlist.md) | Deprecated. Export Cadence schematic netlist to Allegro PCB format (Windows only); not needed to query a design |

--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -127,4 +127,4 @@ Response (success):
 - Timeout is set to 2 minutes for large designs
 - Concurrent calls are queued and run one at a time to avoid Cadence license conflicts
 - `.DSNlck` lock files are automatically relocated during export and restored afterward
-- After a successful export, re-run `list_designs` to see the netlist beside the design. For a CIS design `path` stays the `.DSN`, which is what to query; the exported netlist is reported as `netlist`
+- After a successful export, the netlist sits beside the design. `list_designs` keeps reporting the `.DSN`, which is what to query

--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -1,5 +1,7 @@
 # export_cadence_netlist
 
+> **Deprecated.** This tool is kept for backward compatibility and will eventually be removed. It is not needed to query a Cadence design: every tool reads the `.DSN` schematic directly, which is what `list_designs` returns as `path`. Reach for it only when the exported netlist files are themselves what you want, such as handing them to Allegro.
+
 Export Cadence schematic netlist to Allegro PCB format.
 
 ## Description

--- a/docs/tools/export_cadence_netlist.md
+++ b/docs/tools/export_cadence_netlist.md
@@ -127,4 +127,4 @@ Response (success):
 - Timeout is set to 2 minutes for large designs
 - Concurrent calls are queued and run one at a time to avoid Cadence license conflicts
 - `.DSNlck` lock files are automatically relocated during export and restored afterward
-- After a successful export, re-run `list_designs` to get the updated `pstxnet.dat` path
+- After a successful export, re-run `list_designs` to see the netlist beside the design. For a CIS design `path` stays the `.DSN`, which is what to query; the exported netlist is reported as `netlist`

--- a/docs/tools/list_components.md
+++ b/docs/tools/list_components.md
@@ -4,14 +4,16 @@ List components of a specific type in a design.
 
 ## Description
 
-Lists all components matching a reference designator prefix (e.g., `U` for ICs, `R` for resistors). Components are grouped by MPN for compact output.
+Lists the components whose reference designator prefix is exactly `type` (e.g., `U` for ICs, `R` for resistors). Components are grouped by MPN for compact output.
+
+The prefix is matched whole, not as a leading substring: `U` returns `U1` and `U2` but **not** `USB1`, whose prefix is `USB`. A partial prefix therefore returns nothing rather than everything beneath it, so a part that seems to be missing is usually filed under a prefix of its own. The error for an unmatched type lists every prefix the design actually has.
 
 ## Input Parameters
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `design` | string | Yes | - | Path to design file (e.g., `./Design.PrjPcb`) |
-| `type` | string | Yes | - | Component prefix: `U`, `C`, `R`, `L`, `J`, `D`, `Q`, etc. |
+| `type` | string | Yes | - | Whole refdes prefix: `U`, `C`, `R`, `L`, `J`, `D`, `Q`, `TP`, `USB`, etc. |
 | `include_dns` | boolean | No | `false` | Include DNS (Do Not Stuff) components |
 
 ## Response Schema
@@ -75,6 +77,7 @@ Response:
 ## Notes
 
 - The `type` parameter is case-insensitive (`u` and `U` both work)
+- `type` matches the whole prefix, so `U` does not return `USB1`, and `TP` returns the test points. Query each prefix you need, or read the list the unmatched-type error gives you
 - Components are grouped by MPN; components without MPN are listed individually
 - Components without MPN include a `notes` field suggesting next steps
 - Use `include_dns: true` to see DNS components (marked with `dns: true`)

--- a/docs/tools/list_designs.md
+++ b/docs/tools/list_designs.md
@@ -6,7 +6,7 @@ List all design projects in a directory.
 
 Discovers Cadence, Altium, and KiCad design files by scanning the specified directory recursively. Returns the best available path for each design. Use this tool first to find available projects before querying them.
 
-For Cadence designs, `path` is the `.DSN` schematic, which is what you should query: it is the design as it stands, and a part a CIS variant leaves off the board is written to the `.dat` triad exactly like a stuffed one. Where a netlist has been exported beside the design, `netlist` gives its `pstxnet.dat`. For Altium, `path` is the `.PrjPcb`. For KiCad, `path` is the `.kicad_pro` project (discovery keys off `.kicad_pro`, even when the directory name differs from the project basename).
+Every design reports one path, and that path is the design: for Cadence the `.DSN` schematic, which is what you should query, because a part a CIS variant leaves off the board is written to the `.dat` triad exactly like a stuffed one. A design that is only an exported netlist reports that netlist. For Altium, `path` is the `.PrjPcb`. For KiCad, `path` is the `.kicad_pro` project (discovery keys off `.kicad_pro`, even when the directory name differs from the project basename).
 
 ## Input Parameters
 
@@ -35,14 +35,6 @@ Returns an array of design info objects:
       "path": {
         "type": "string",
         "description": "Best available path to query this design"
-      },
-      "source": {
-        "type": "string",
-        "description": "Schematic source path (same as path for a Cadence design, which is read from its schematic)"
-      },
-      "netlist": {
-        "type": "string",
-        "description": "Exported netlist path (present for a Cadence design with a pstxnet.dat beside it)"
       },
       "error": {
         "type": "string",
@@ -77,9 +69,7 @@ Response:
   },
   {
     "name": "MainBoard",
-    "path": "MainBoard/schematic.DSN",
-    "source": "MainBoard/schematic.DSN",
-    "netlist": "MainBoard/Allegro/pstxnet.dat"
+    "path": "MainBoard/schematic.DSN"
   },
   {
     "name": "AudioModule",
@@ -98,8 +88,6 @@ Response:
 ## Notes
 
 - `path` is always the recommended path to pass to other tools
-- `source` names the schematic, which is what it has always named. It now holds what `path` holds, and is kept rather than dropped for being redundant
-- `netlist` is present only for a Cadence design with an exported `pstxnet.dat` beside it. Reading it is supported and agrees with the schematic on Do Not Stuff, because the schematic's variant data is read alongside it, but it is a snapshot of the design at export time rather than the design
 - Generating a netlist is not a step towards querying a Cadence design. Every tool reads the `.DSN` directly, on every platform
 - For KiCad designs, `path` is the `.kicad_pro`; the netlist is resolved automatically when queried (committed `.net` export if present, otherwise generated via `kicad-cli`), so no manual export step is needed
 - The `pattern` parameter filters on the design `name`, not the full path

--- a/docs/tools/list_designs.md
+++ b/docs/tools/list_designs.md
@@ -6,7 +6,7 @@ List all design projects in a directory.
 
 Discovers Cadence, Altium, and KiCad design files by scanning the specified directory recursively. Returns the best available path for each design. Use this tool first to find available projects before querying them.
 
-For Cadence designs with exported `.dat` files, `path` points to `pstxnet.dat` (preferred, more complete data) and `source` provides the `.DSN` schematic path. Without `.dat` files, `path` is the `.DSN` directly. For Altium, `path` is the `.PrjPcb`. For KiCad, `path` is the `.kicad_pro` project (discovery keys off `.kicad_pro`, even when the directory name differs from the project basename).
+For Cadence designs, `path` is the `.DSN` schematic, which is what you should query: it is the design as it stands, and a part a CIS variant leaves off the board is written to the `.dat` triad exactly like a stuffed one. Where a netlist has been exported beside the design, `netlist` gives its `pstxnet.dat`. For Altium, `path` is the `.PrjPcb`. For KiCad, `path` is the `.kicad_pro` project (discovery keys off `.kicad_pro`, even when the directory name differs from the project basename).
 
 ## Input Parameters
 
@@ -36,9 +36,9 @@ Returns an array of design info objects:
         "type": "string",
         "description": "Best available path to query this design"
       },
-      "source": {
+      "netlist": {
         "type": "string",
-        "description": "Schematic source path (present when path differs from source, e.g. Cadence with .dat files)"
+        "description": "Exported netlist path (present for a Cadence design with a pstxnet.dat beside it)"
       },
       "error": {
         "type": "string",
@@ -73,8 +73,8 @@ Response:
   },
   {
     "name": "MainBoard",
-    "path": "MainBoard/Allegro/pstxnet.dat",
-    "source": "MainBoard/schematic.DSN"
+    "path": "MainBoard/schematic.DSN",
+    "netlist": "MainBoard/Allegro/pstxnet.dat"
   },
   {
     "name": "AudioModule",
@@ -93,7 +93,7 @@ Response:
 ## Notes
 
 - `path` is always the recommended path to pass to other tools
-- `source` is present only when `path` differs from the schematic source (i.e., Cadence designs with exported `.dat` files)
-- For Cadence designs where `path` is a `.DSN`: on Windows, run `export_cadence_netlist` to generate `.dat` files, then re-run `list_designs` to get the updated `pstxnet.dat` path; on macOS/Linux, query using the `.DSN` path directly (DSN fallback parser)
+- `netlist` is present only for a Cadence design with an exported `pstxnet.dat` beside it. Reading it is supported and agrees with the schematic on Do Not Stuff, because the schematic's variant data is read alongside it, but it is a snapshot of the design at export time rather than the design
+- Generating a netlist is not a step towards querying a Cadence design. Every tool reads the `.DSN` directly, on every platform
 - For KiCad designs, `path` is the `.kicad_pro`; the netlist is resolved automatically when queried (committed `.net` export if present, otherwise generated via `kicad-cli`), so no manual export step is needed
 - The `pattern` parameter filters on the design `name`, not the full path

--- a/docs/tools/list_designs.md
+++ b/docs/tools/list_designs.md
@@ -36,6 +36,10 @@ Returns an array of design info objects:
         "type": "string",
         "description": "Best available path to query this design"
       },
+      "source": {
+        "type": "string",
+        "description": "Schematic source path (same as path for a Cadence design, which is read from its schematic)"
+      },
       "netlist": {
         "type": "string",
         "description": "Exported netlist path (present for a Cadence design with a pstxnet.dat beside it)"
@@ -74,6 +78,7 @@ Response:
   {
     "name": "MainBoard",
     "path": "MainBoard/schematic.DSN",
+    "source": "MainBoard/schematic.DSN",
     "netlist": "MainBoard/Allegro/pstxnet.dat"
   },
   {
@@ -93,6 +98,7 @@ Response:
 ## Notes
 
 - `path` is always the recommended path to pass to other tools
+- `source` names the schematic, which is what it has always named. It now holds what `path` holds, and is kept rather than dropped for being redundant
 - `netlist` is present only for a Cadence design with an exported `pstxnet.dat` beside it. Reading it is supported and agrees with the schematic on Do Not Stuff, because the schematic's variant data is read alongside it, but it is a snapshot of the design at export time rather than the design
 - Generating a netlist is not a step towards querying a Cadence design. Every tool reads the `.DSN` directly, on every platform
 - For KiCad designs, `path` is the `.kicad_pro`; the netlist is resolved automatically when queried (committed `.net` export if present, otherwise generated via `kicad-cli`), so no manual export step is needed

--- a/manifest.json
+++ b/manifest.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "export_cadence_netlist",
-      "description": "Export Cadence schematic to Allegro PCB format (Windows only)"
+      "description": "DEPRECATED, kept for backward compatibility: export Cadence schematic to Allegro PCB format (Windows only). Not needed to query a design."
     }
   ]
 }

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -13,19 +13,25 @@ export const SERVER_INSTRUCTIONS = `
 This server provides tools to query EDA netlists for circuit design review.
 
 Supported formats:
-- **Cadence CIS/HDL**: Supports both exported .dat files (preferred) and .DSN binary schematics (fallback).
+- **Cadence CIS/HDL**: Reads the .DSN binary schematic directly (preferred). Exported .dat netlist files (pstxnet.dat, pstxprt.dat, pstchip.dat) are also readable.
 - **Altium Designer**: Reads .SchDoc schematic documents associated to a .PrjPcb project file.
 - **KiCad**: Reads a .kicad_pro project (or root .kicad_sch). Prefers a committed kicadsexpr netlist export (.net) beside the project; otherwise generates one via kicad-cli (requires KiCad installed; set KICAD_CLI_PATH for a non-standard location). Nets declared inside a hierarchical sheet are sheet-path-prefixed (e.g. "/Peripherals/D0", not "/D0"); when using \`search_nets\`, prefer unanchored patterns so you do not miss bussed/hierarchical nets.
 
 ## Cadence Design Priority
 
-\`list_designs\` returns the best available path for each Cadence design:
-- If exported .dat files exist: returns pstxnet.dat path (preferred, more complete data)
-- If no .dat files exist: returns the .DSN path
+\`list_designs\` returns the .DSN schematic as \`path\` for every Cadence design.
+**Query the .DSN.** It is the design as it stands, and it carries what an exported
+netlist cannot: a part a CIS variant leaves off the board is written to the .dat
+triad exactly like a part that is stuffed, with an ordinary value and all of its
+connections, so nothing in those files marks it.
 
-When \`list_designs\` returns a .DSN path (no .dat files available):
-1. On Windows: run \`export_cadence_netlist\` with the .DSN path to generate .dat files, then re-run \`list_designs\`
-2. If export fails or on macOS/Linux: query using the .DSN path directly (DSN fallback parser)
+Where a netlist has been exported beside the design, its pstxnet.dat is reported
+as \`netlist\`. Reading it is supported and answers alike for Do Not Stuff, since
+the schematic's variant data is read alongside it, but it is a snapshot taken when
+it was exported rather than the design itself. Prefer \`path\`.
+
+Reading a .DSN takes longer than reading an exported netlist, which is the cost of
+reading the design rather than a summary of it.
 
 ## KiCad Design Priority
 
@@ -65,9 +71,9 @@ Results with an \`error\` field indicate a problem:
 
 export const LIST_DESIGNS_DESCRIPTION = `\
 List all design projects in the given directory. \
-Returns the best available path for each design. \
-For Cadence with exported .dat files: path is pstxnet.dat (preferred), \
-source has the .DSN schematic. Without .dat files: path is the .DSN. \
+Returns the path to query for each design. \
+For Cadence: path is the .DSN schematic, which is what you should query; \
+where a netlist has been exported beside it, netlist has that pstxnet.dat. \
 For Altium: path is the .PrjPcb. \
 For KiCad: path is the .kicad_pro; its netlist resolves automatically when queried \
 (a committed .net export if present, otherwise generated via kicad-cli), so no manual export is needed. \
@@ -129,7 +135,12 @@ Returns MPN, description, value, and pin-to-net mappings when available. \
 Errors include guidance and suggestions.`;
 
 export const EXPORT_CADENCE_NETLIST_DESCRIPTION = `\
-Export Cadence schematic netlist to Allegro PCB format. \
+DEPRECATED. This tool is kept for backward compatibility and will eventually be \
+removed. You do not need it to query a Cadence design: every tool reads the .DSN \
+schematic directly, which is what \`list_designs\` returns as \`path\`. Call it only \
+when the exported netlist files are themselves the goal, such as handing them to \
+Allegro. Do not call it to make a design queryable. \
+Exports a Cadence schematic netlist to Allegro PCB format. \
 Windows only. Requires Cadence SPB installation. \
 Calls are queued internally so it is safe to call in parallel \
 for multiple designs, but serialize calls if you encounter \
@@ -138,7 +149,7 @@ Output goes to \`<design>_netlist/\` beside the .DSN, so several designs \
 in one folder no longer overwrite each other's netlist; a folder holding a \
 single design that already has an \`allegro/\` directory keeps using it. \
 After a successful export, re-run \`list_designs\` \
-to get the updated pstxnet.dat path.`;
+to see the netlist beside the design.`;
 
 export const RUN_ERC_DESCRIPTION = `\
 Run electrical rule checks (ERC) on a design's netlist and return findings grouped \

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -13,56 +13,22 @@ export const SERVER_INSTRUCTIONS = `
 This server provides tools to query EDA netlists for circuit design review.
 
 Supported formats:
-- **Cadence CIS/HDL**: Reads the .DSN binary schematic directly (preferred). Exported .dat netlist files (pstxnet.dat, pstxprt.dat, pstchip.dat) are also readable.
-- **Altium Designer**: Reads .SchDoc schematic documents associated to a .PrjPcb project file.
-- **KiCad**: Reads a .kicad_pro project (or root .kicad_sch). Prefers a committed kicadsexpr netlist export (.net) beside the project; otherwise generates one via kicad-cli (requires KiCad installed; set KICAD_CLI_PATH for a non-standard location). Nets declared inside a hierarchical sheet are sheet-path-prefixed (e.g. "/Peripherals/D0", not "/D0"); when using \`search_nets\`, prefer unanchored patterns so you do not miss bussed/hierarchical nets.
+- **Cadence CIS/HDL**: .DSN binary schematics, and exported .dat netlist files (pstxnet.dat, pstxprt.dat, pstchip.dat).
+- **Altium Designer**: .SchDoc schematic documents, discovered through their .PrjPcb project.
+- **KiCad**: .kicad_pro projects, or a root .kicad_sch.
 
-## Cadence Design Priority
+## Workflow
 
-\`list_designs\` returns the .DSN schematic as \`path\` for every Cadence design.
-**Query the .DSN.** It is the design as it stands, and it carries what an exported
-netlist cannot: a part a CIS variant leaves off the board is written to the .dat
-triad exactly like a part that is stuffed, with an ordinary value and all of its
-connections, so nothing in those files marks it.
+1. \`list_designs\` first: it finds the designs and gives you the path to query
+2. \`search_nets\` and \`search_components_by_*\` to find things by pattern
+3. \`query_component\` and \`query_xnet_*\` for detail and connectivity
+4. \`run_erc\` for electrical rule checks
 
-Where a netlist has been exported beside the design, its pstxnet.dat is reported
-as \`netlist\`. Reading it is supported and answers alike for Do Not Stuff, since
-the schematic's variant data is read alongside it, but it is a snapshot taken when
-it was exported rather than the design itself. Prefer \`path\`.
+## Conventions
 
-Reading a .DSN takes longer than reading an exported netlist, which is the cost of
-reading the design rather than a summary of it.
-
-## KiCad Design Priority
-
-\`list_designs\` surfaces each \`.kicad_pro\` project. When you query a KiCad design the server resolves its netlist automatically; you do NOT need to export anything by hand:
-1. If a committed kicadsexpr export (\`<project>.net\`) sits beside the project, it is parsed directly (no KiCad install needed).
-2. Otherwise the server runs \`kicad-cli\` on the root \`.kicad_sch\` to generate one on demand (requires KiCad installed; set \`KICAD_CLI_PATH\` for a non-standard install location).
-3. If neither a committed \`.net\` nor a usable \`kicad-cli\` is available, the result has an \`error\` saying so.
-
-## Workflow Guidance
-
-1. Use \`list_designs\` first to discover available projects in a directory
-2. Use \`search_nets\` with regex patterns before querying specific nets
-3. Use \`search_components_by_*\` to find components by refdes, MPN, or description
-4. Use \`query_xnet_by_net_name\` or \`query_xnet_by_pin_name\` to trace signal paths
-5. For token optimization, use \`skip_types=['C','L']\` to skip series passives on power rails
-
-## Tool Usage Tips
-
-- Pin names use REFDES.PIN format (e.g., U1.A5, R10.1)
-- DNS (Do Not Stuff) components are excluded by default; use \`include_dns=true\` to include them
-- \`query_xnet_*\` traces through series components; \`circuit_hash\` identifies unique topologies
-- \`query_xnet_*\` stops traversal at power/ground nets; use \`skip_types\` to reduce noise on rails
-- Design paths are relative to the working directory (absolute paths also accepted)
-
-## Error Handling
-
-Results with an \`error\` field indicate a problem:
-- Design not found: Check available designs with \`list_designs\`
-- Net not found: Use \`search_nets\` to find available nets
-- Component not found: Use \`search_components_by_refdes\` to find available components
-- Missing netlist files: for a CIS design there is nothing to fix. It is read from its .DSN, which is what \`list_designs\` returns as \`path\`; if the path you used was a pstxnet.dat, re-run \`list_designs\` and use the .DSN. An HDL (.cpm) design has no .DSN and does need a netlist, but \`export_cadence_netlist\` cannot write one: it drives pstswp, which needs a schematic. Those are written from Cadence, Tools → Create Netlist → PCB Editor format
+- Design paths are relative to the working directory; absolute paths are also accepted
+- DNS (Do Not Stuff) components are left out of results, and the tools that can include them take \`include_dns=true\`
+- A result carrying an \`error\` field failed, and the message names the tool that finds the value you wanted
 `.trim();
 
 // =============================================================================
@@ -70,14 +36,32 @@ Results with an \`error\` field indicate a problem:
 // =============================================================================
 
 export const LIST_DESIGNS_DESCRIPTION = `\
-List all design projects in the given directory. \
-Returns the path to query for each design. \
-For Cadence: path is the .DSN schematic, which is what you should query; \
-where a netlist has been exported beside it, netlist has that pstxnet.dat. \
-For Altium: path is the .PrjPcb. \
-For KiCad: path is the .kicad_pro; its netlist resolves automatically when queried \
-(a committed .net export if present, otherwise generated via kicad-cli), so no manual export is needed. \
-Always use this tool to discover designs instead of searching the filesystem manually.`;
+List all design projects in the given directory, with the path to query for each. \
+Always use this tool to discover designs instead of searching the filesystem manually.
+
+Cadence: \`path\` is the .DSN schematic, and that is what to query. It is the design as \
+it stands, and it carries what an exported netlist cannot: a part a CIS variant leaves \
+off the board is written to the .dat triad exactly like a part that is stuffed, with an \
+ordinary value and all of its connections, so nothing in those files marks it. Where a \
+netlist has been exported beside the design, its pstxnet.dat is reported as \`netlist\`; \
+reading that is supported and agrees on Do Not Stuff, because the schematic is read \
+alongside it, but it is a snapshot taken when it was exported rather than the design. \
+Reading a .DSN takes longer, which is the cost of reading the design rather than a \
+summary of it. A design that has only a netlist reports it as \`path\`, there being no \
+schematic to prefer.
+
+If a query reports missing netlist files: a CIS design has nothing to fix, re-run this \
+tool and use the .DSN it reports. An HDL (.cpm) design has no .DSN and does need a \
+netlist, which \`export_cadence_netlist\` cannot write; those are written from Cadence, \
+Tools → Create Netlist → PCB Editor format.
+
+Altium: \`path\` is the .PrjPcb.
+
+KiCad: \`path\` is the .kicad_pro, and its netlist resolves automatically when queried, so \
+nothing needs exporting by hand. A committed kicadsexpr export (<project>.net) beside the \
+project is parsed directly, needing no KiCad install; otherwise kicad-cli generates one on \
+demand (requires KiCad installed; set KICAD_CLI_PATH for a non-standard location). If \
+neither is available the result carries an \`error\` saying so.`;
 
 export const LIST_COMPONENTS_DESCRIPTION = `\
 List components of a specific type in a design. \
@@ -121,18 +105,27 @@ Rejects patterns that match all items; use list_components for full results.`;
 
 export const QUERY_XNET_BY_NET_NAME_DESCRIPTION = `\
 Get full XNET (Extended Net) connectivity for a net. \
-Rejects ground nets (GND, AGND, DGND, etc.) with an error.`;
+Traces through series components, so the result is the whole electrical node rather \
+than the one net; \`circuit_hash\` identifies unique topologies. Traversal stops at \
+power and ground nets. \`skip_types\` leaves series passives out, and \
+\`skip_types=['C','L']\` on a power rail is the cheapest way to cut a large result down. \
+Rejects ground nets (GND, AGND, DGND, etc.) with an error. \
+If the net is not found, \`search_nets\` finds the name.`;
 
 export const QUERY_XNET_BY_PIN_NAME_DESCRIPTION = `\
-Get full XNET connectivity starting from a component pin. \
-Rejects pins connected to ground nets (GND, AGND, DGND, etc.) \
-with an error.`;
+Get full XNET connectivity starting from a component pin, named REFDES.PIN \
+(e.g. U1.A5, R10.1). Traces through series components, so the result is the whole \
+electrical node; \`circuit_hash\` identifies unique topologies. Traversal stops at power \
+and ground nets, and \`skip_types\` leaves series passives out, such as \
+\`skip_types=['C','L']\` on a rail. \
+Rejects pins connected to ground nets (GND, AGND, DGND, etc.) with an error.`;
 
 export const QUERY_COMPONENT_DESCRIPTION = `\
 Get full component details including all pin connections. \
 Refdes lookup is case-insensitive. \
 Returns MPN, description, value, and pin-to-net mappings when available. \
-Errors include guidance and suggestions.`;
+If the refdes is not found, \`search_components_by_refdes\` finds it; \
+errors include guidance and suggestions.`;
 
 export const EXPORT_CADENCE_NETLIST_DESCRIPTION = `\
 DEPRECATED. This tool is kept for backward compatibility and will eventually be \

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -62,7 +62,7 @@ Results with an \`error\` field indicate a problem:
 - Design not found: Check available designs with \`list_designs\`
 - Net not found: Use \`search_nets\` to find available nets
 - Component not found: Use \`search_components_by_refdes\` to find available components
-- Missing netlist files: Run \`export_cadence_netlist\` to generate .dat files
+- Missing netlist files: a Cadence design is read from its .DSN, so a missing .dat triad is not an error to fix. If the design path was a pstxnet.dat, re-run \`list_designs\` and use the .DSN it reports
 `.trim();
 
 // =============================================================================

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -36,28 +36,23 @@ Supported formats:
 // =============================================================================
 
 export const LIST_DESIGNS_DESCRIPTION = `\
-List all design projects in the given directory, with the path to query for each. \
+List all design projects in the given directory, one path each: a .DSN, a .PrjPcb, a \
+.kicad_pro, or the netlist of a design that is only a netlist. That path is the design, \
+and it is what every other tool takes. \
 Always use this tool to discover designs instead of searching the filesystem manually.
 
-Cadence: \`path\` is the .DSN schematic, and that is what to query. It is the design as \
-it stands, and it carries what an exported netlist cannot: a part a CIS variant leaves \
-off the board is written to the .dat triad exactly like a part that is stuffed, with an \
-ordinary value and all of its connections, so nothing in those files marks it. Where a \
-netlist has been exported beside the design, its pstxnet.dat is reported as \`netlist\`; \
-reading that is supported and agrees on Do Not Stuff, because the schematic is read \
-alongside it, but it is a snapshot taken when it was exported rather than the design. \
-Reading a .DSN takes longer, which is the cost of reading the design rather than a \
-summary of it. A design that has only a netlist reports it as \`path\`, there being no \
-schematic to prefer.
+Cadence: the path is the .DSN schematic. It is the design as it stands, and it carries \
+what an exported netlist cannot: a part a CIS variant leaves off the board is written to \
+the .dat triad exactly like a part that is stuffed, with an ordinary value and all of its \
+connections, so nothing in those files marks it. Reading a .DSN takes longer than reading \
+a triad, which is the cost of reading the design rather than a summary of it.
 
 If a query reports missing netlist files: a CIS design has nothing to fix, re-run this \
 tool and use the .DSN it reports. An HDL (.cpm) design has no .DSN and does need a \
 netlist, which \`export_cadence_netlist\` cannot write; those are written from Cadence, \
 Tools → Create Netlist → PCB Editor format.
 
-Altium: \`path\` is the .PrjPcb.
-
-KiCad: \`path\` is the .kicad_pro, and its netlist resolves automatically when queried, so \
+KiCad: the path is the .kicad_pro, and its netlist resolves automatically when queried, so \
 nothing needs exporting by hand. A committed kicadsexpr export (<project>.net) beside the \
 project is parsed directly, needing no KiCad install; otherwise kicad-cli generates one on \
 demand (requires KiCad installed; set KICAD_CLI_PATH for a non-standard location). If \
@@ -141,8 +136,8 @@ license or timeout errors. DSN lock files are handled automatically. \
 Output goes to \`<design>_netlist/\` beside the .DSN, so several designs \
 in one folder no longer overwrite each other's netlist; a folder holding a \
 single design that already has an \`allegro/\` directory keeps using it. \
-After a successful export, re-run \`list_designs\` \
-to see the netlist beside the design.`;
+After a successful export the netlist sits beside the design; \
+\`list_designs\` keeps reporting the .DSN, which is what to query.`;
 
 export const RUN_ERC_DESCRIPTION = `\
 Run electrical rule checks (ERC) on a design's netlist and return findings grouped \

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -13,11 +13,11 @@ export const SERVER_INSTRUCTIONS = `
 This server provides tools to query EDA netlists for circuit design review.
 
 Supported formats:
-- **Cadence CIS/HDL**: .DSN binary schematics, and exported .dat netlist files (pstxnet.dat, pstxprt.dat, pstchip.dat).
+- **Cadence CIS/HDL**: .DSN binary schematics, which is what to read. Exported .dat netlist files (pstxnet.dat, pstxprt.dat, pstchip.dat) are a fallback, for a design that ships without its schematic.
 - **Altium Designer**: .SchDoc schematic documents, discovered through their .PrjPcb project.
 - **KiCad**: .kicad_pro projects, or a root .kicad_sch.
 
-## Workflow
+## Example Workflow
 
 1. \`list_designs\` first: it finds the designs and gives you the path to query
 2. \`search_nets\` and \`search_components_by_*\` to find things by pattern
@@ -60,9 +60,13 @@ neither is available the result carries an \`error\` saying so.`;
 
 export const LIST_COMPONENTS_DESCRIPTION = `\
 List components of a specific type in a design. \
-The type prefix is case-insensitive, so "u" matches U1, U2, etc. \
-Components are grouped by MPN for compact output. \
-If no components match, the error lists the available prefixes in the design.`;
+The type is the refdes prefix, matched whole and case-insensitively: "u" gives U1 and \
+U2 but NOT USB1, whose prefix is USB, and "tp" gives the test points. Asking for a \
+partial prefix returns nothing rather than everything starting with it, so if a part you \
+expected is missing, look for it under its own prefix. \
+Components are grouped by MPN for compact output, and a group whose parts carry no MPN \
+says so in its notes. \
+If no components match, the error lists every prefix the design does have.`;
 
 export const LIST_NETS_DESCRIPTION = `\
 List all net names in a design, sorted alphabetically. \
@@ -119,6 +123,9 @@ export const QUERY_COMPONENT_DESCRIPTION = `\
 Get full component details including all pin connections. \
 Refdes lookup is case-insensitive. \
 Returns MPN, description, value, and pin-to-net mappings when available. \
+Each pin maps to its net name, or to {name, net} where the pin has a function name that \
+differs from its number. A pin on no net reads as the net "NC", which is a marker rather \
+than a net you can look up. \
 If the refdes is not found, \`search_components_by_refdes\` finds it; \
 errors include guidance and suggestions.`;
 

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -62,7 +62,7 @@ Results with an \`error\` field indicate a problem:
 - Design not found: Check available designs with \`list_designs\`
 - Net not found: Use \`search_nets\` to find available nets
 - Component not found: Use \`search_components_by_refdes\` to find available components
-- Missing netlist files: a Cadence design is read from its .DSN, so a missing .dat triad is not an error to fix. If the design path was a pstxnet.dat, re-run \`list_designs\` and use the .DSN it reports
+- Missing netlist files: for a CIS design there is nothing to fix. It is read from its .DSN, which is what \`list_designs\` returns as \`path\`; if the path you used was a pstxnet.dat, re-run \`list_designs\` and use the .DSN. An HDL (.cpm) design has no .DSN and does need a netlist, but \`export_cadence_netlist\` cannot write one: it drives pstswp, which needs a schematic. Those are written from Cadence, Tools → Create Netlist → PCB Editor format
 `.trim();
 
 // =============================================================================

--- a/src/parsers/cadence/discovery.ts
+++ b/src/parsers/cadence/discovery.ts
@@ -276,9 +276,8 @@ const matchDatSetsToDesigns = (
   // left in mid-migration: one design re-exported to its own directory, the
   // shared one they used to overwrite each other in now orphaned.
   //
-  // Leaving it unassigned costs a fallback to parsing the schematic directly,
-  // which now reproduces the DAT export exactly, so the cost is time rather
-  // than fidelity.
+  // Leaving it unassigned costs nothing but time: the schematic is read
+  // directly, and it reproduces the DAT export exactly.
   const bestByDatSet = new Map<string, { score: number; designs: Set<string> }>();
   for (const c of candidates) {
     const seen = bestByDatSet.get(c.datSet.directory);

--- a/src/parsers/cadence/index.ts
+++ b/src/parsers/cadence/index.ts
@@ -170,12 +170,12 @@ export const parseCadence = async (paths: CadenceFilePaths): Promise<CadenceRawN
 const parseCadenceDesign = async (designPath: string): Promise<ParsedNetlist> => {
   const ext = path.extname(designPath).toLowerCase();
 
-  // DSN binary parsing (fallback when .dat files unavailable)
+  // The schematic itself, which is the path list_designs hands out.
   if (ext === ".dsn") {
     return parseDsnFile(designPath);
   }
 
-  // DAT file parsing (fallback, or dat-only designs)
+  // An exported netlist, either named directly or as a dat-only design.
   const datFiles = await findCadenceDatFiles(designPath);
   if (datFiles.pstxnet && datFiles.pstxprt) {
     const raw = await parseCadence({

--- a/src/parsers/cadence/index.ts
+++ b/src/parsers/cadence/index.ts
@@ -195,12 +195,14 @@ const parseCadenceDesign = async (designPath: string): Promise<ParsedNetlist> =>
     return { nets: raw.nets, components };
   }
 
-  // export_cadence_netlist drives pstswp, which needs the .DSN schematic, so
-  // naming it to an HDL design sent the caller to a tool that refuses the input.
+  // A CIS design is read from its schematic, so reaching here means the caller
+  // named an incomplete triad and the schematic is the way out. An HDL design
+  // has no schematic to fall back to, and export_cadence_netlist drives pstswp,
+  // which needs one, so sending it there is sending it to a refusal.
   throw new Error(
     ext === ".cpm"
       ? `Missing netlist files for ${path.basename(designPath)}. Design Entry HDL writes them from Cadence: Tools → Create Netlist → PCB Editor format. export_cadence_netlist cannot do it, it drives pstswp, which needs a .DSN schematic.`
-      : `Missing netlist files for ${path.basename(designPath)}. Run export_cadence_netlist to generate them.`
+      : `Missing netlist files for ${path.basename(designPath)}. Query the .DSN schematic instead, which list_designs returns as the design's path.`
   );
 };
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -222,7 +222,7 @@ describe("listDesigns searchPath and pattern", () => {
 // =============================================================================
 
 describe("listDesigns Cadence path priority", () => {
-  it("returns .DSN as path and source, and pstxnet.dat as netlist, when .dat files exist", async () => {
+  it("returns the .DSN as the one path when .dat files exist beside it", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
@@ -239,14 +239,14 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; source?: string; netlist?: string }>)[0];
+    const design = (result as Array<{ path: string }>)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
-    expect(design.netlist).toBe("C:\\projects\\Allegro\\pstxnet.dat");
-    // source has always named the schematic, and still does.
-    expect(design.source).toBe("C:\\projects\\Board.DSN");
+    // One path, and it is the design. The netlist beside it is not reported.
+    expect(design).not.toHaveProperty("source");
+    expect(design).not.toHaveProperty("netlist");
   });
 
-  it("returns .DSN as path with no netlist when no .dat files exist", async () => {
+  it("returns the .DSN as the one path when no .dat files exist", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
@@ -259,9 +259,8 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; source?: string; netlist?: string }>)[0];
+    const design = (result as Array<{ path: string }>)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
-    expect(design.netlist).toBeUndefined();
   });
 });
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -239,9 +239,9 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; source?: string }>)[0];
-    expect(design.path).toBe("C:\\projects\\Allegro\\pstxnet.dat");
-    expect(design.source).toBe("C:\\projects\\Board.DSN");
+    const design = (result as Array<{ path: string; netlist?: string }>)[0];
+    expect(design.path).toBe("C:\\projects\\Board.DSN");
+    expect(design.netlist).toBe("C:\\projects\\Allegro\\pstxnet.dat");
   });
 
   it("returns .DSN as path with no source when no .dat files exist", async () => {
@@ -257,9 +257,9 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; source?: string }>)[0];
+    const design = (result as Array<{ path: string; netlist?: string }>)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
-    expect(design.source).toBeUndefined();
+    expect(design.netlist).toBeUndefined();
   });
 });
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -222,7 +222,7 @@ describe("listDesigns searchPath and pattern", () => {
 // =============================================================================
 
 describe("listDesigns Cadence path priority", () => {
-  it("returns .DSN as path and pstxnet.dat as netlist when .dat files exist", async () => {
+  it("returns .DSN as path and source, and pstxnet.dat as netlist, when .dat files exist", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
@@ -239,9 +239,11 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; netlist?: string }>)[0];
+    const design = (result as Array<{ path: string; source?: string; netlist?: string }>)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
     expect(design.netlist).toBe("C:\\projects\\Allegro\\pstxnet.dat");
+    // source has always named the schematic, and still does.
+    expect(design.source).toBe("C:\\projects\\Board.DSN");
   });
 
   it("returns .DSN as path with no netlist when no .dat files exist", async () => {
@@ -257,7 +259,7 @@ describe("listDesigns Cadence path priority", () => {
     const result = await listDesigns();
 
     expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string; netlist?: string }>)[0];
+    const design = (result as Array<{ path: string; source?: string; netlist?: string }>)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
     expect(design.netlist).toBeUndefined();
   });

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -222,7 +222,7 @@ describe("listDesigns searchPath and pattern", () => {
 // =============================================================================
 
 describe("listDesigns Cadence path priority", () => {
-  it("returns pstxnet.dat as path and .DSN as source when .dat files exist", async () => {
+  it("returns .DSN as path and pstxnet.dat as netlist when .dat files exist", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",
@@ -244,7 +244,7 @@ describe("listDesigns Cadence path priority", () => {
     expect(design.netlist).toBe("C:\\projects\\Allegro\\pstxnet.dat");
   });
 
-  it("returns .DSN as path with no source when no .dat files exist", async () => {
+  it("returns .DSN as path with no netlist when no .dat files exist", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
       {
         name: "Board",

--- a/src/server.ts
+++ b/src/server.ts
@@ -378,7 +378,7 @@ export const createServer = (): McpServer => {
   server.registerTool(
     "export_cadence_netlist",
     {
-      title: "Export Cadence netlist",
+      title: "Export Cadence netlist (deprecated)",
       description: EXPORT_CADENCE_NETLIST_DESCRIPTION,
       annotations: WRITES_TO_DISK,
       inputSchema: {

--- a/src/service/tools/cadence-export.ts
+++ b/src/service/tools/cadence-export.ts
@@ -345,7 +345,7 @@ export const exportCadenceNetlist = async (
         // detach the child at the cap, it kills it: the export died partway
         // through writing the netlist and the failure was reported as Cadence's
         // ("stdout maxBuffer length exceeded"), deterministically, on exactly the
-        // largest designs that most need the DAT path over the DSN fallback.
+        // largest designs, whose exports are the ones worth having.
         maxBuffer: 64 * 1024 * 1024,
       });
 

--- a/src/service/tools/list-designs.ts
+++ b/src/service/tools/list-designs.ts
@@ -23,11 +23,21 @@ export interface ListDesignsOptions {
  *
  * Where a netlist has been exported beside it, its `pstxnet.dat` is reported as
  * `netlist`, so a caller that wants it can still name it.
+ *
+ * `source` keeps naming the schematic, which is what it has always named. It now
+ * holds what `path` holds, and is kept rather than dropped for being redundant:
+ * a caller reading it is asking for the schematic and still gets it.
  */
-export const getDesignPaths = (design: DiscoveredDesign): { path: string; netlist?: string } => {
+export const getDesignPaths = (
+  design: DiscoveredDesign
+): { path: string; source?: string; netlist?: string } => {
   if (design.format === "cadence-cis" || design.format === "cadence-hdl") {
     if (design.datFiles.pstxnet) {
-      return { path: design.sourcePath, netlist: design.datFiles.pstxnet };
+      return {
+        path: design.sourcePath,
+        source: design.sourcePath,
+        netlist: design.datFiles.pstxnet,
+      };
     }
   }
   return { path: design.sourcePath };
@@ -39,7 +49,8 @@ export const getDesignPaths = (design: DiscoveredDesign): { path: string; netlis
 export const listDesigns = async (
   options: ListDesignsOptions = {}
 ): Promise<
-  Array<{ name: string; path: string; netlist?: string; error?: string }> | ErrorResult
+  | Array<{ name: string; path: string; source?: string; netlist?: string; error?: string }>
+  | ErrorResult
 > => {
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");

--- a/src/service/tools/list-designs.ts
+++ b/src/service/tools/list-designs.ts
@@ -15,14 +15,19 @@ export interface ListDesignsOptions {
 
 /**
  * Build the path fields for a discovered design.
- * For Cadence CIS/HDL with .dat files: path=pstxnet.dat (preferred), source=.DSN
- * For Cadence CIS/HDL without .dat files: path=.DSN
- * For all others: path=sourcePath
+ *
+ * `path` is the design's own file, which for Cadence is the `.DSN` schematic.
+ * It is the design as it stands, and it carries what an exported netlist cannot:
+ * a part left off the board by a CIS variant is written to the `.dat` triad
+ * exactly like a part that is stuffed.
+ *
+ * Where a netlist has been exported beside it, its `pstxnet.dat` is reported as
+ * `netlist`, so a caller that wants it can still name it.
  */
-export const getDesignPaths = (design: DiscoveredDesign): { path: string; source?: string } => {
+export const getDesignPaths = (design: DiscoveredDesign): { path: string; netlist?: string } => {
   if (design.format === "cadence-cis" || design.format === "cadence-hdl") {
     if (design.datFiles.pstxnet) {
-      return { path: design.datFiles.pstxnet, source: design.sourcePath };
+      return { path: design.sourcePath, netlist: design.datFiles.pstxnet };
     }
   }
   return { path: design.sourcePath };
@@ -34,7 +39,7 @@ export const getDesignPaths = (design: DiscoveredDesign): { path: string; source
 export const listDesigns = async (
   options: ListDesignsOptions = {}
 ): Promise<
-  Array<{ name: string; path: string; source?: string; error?: string }> | ErrorResult
+  Array<{ name: string; path: string; netlist?: string; error?: string }> | ErrorResult
 > => {
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");

--- a/src/service/tools/list-designs.ts
+++ b/src/service/tools/list-designs.ts
@@ -1,7 +1,7 @@
 import { discoverDesigns } from "../../parsers/index.js";
 import { resolvePath } from "../../paths.js";
 import { parseRegexPattern } from "../regex-helpers.js";
-import type { ErrorResult, DiscoveredDesign } from "../../types.js";
+import type { ErrorResult, DesignInfo } from "../../types.js";
 
 /**
  * Options for listDesigns.
@@ -14,44 +14,11 @@ export interface ListDesignsOptions {
 }
 
 /**
- * Build the path fields for a discovered design.
- *
- * `path` is the design's own file, which for Cadence is the `.DSN` schematic.
- * It is the design as it stands, and it carries what an exported netlist cannot:
- * a part left off the board by a CIS variant is written to the `.dat` triad
- * exactly like a part that is stuffed.
- *
- * Where a netlist has been exported beside it, its `pstxnet.dat` is reported as
- * `netlist`, so a caller that wants it can still name it.
- *
- * `source` keeps naming the schematic, which is what it has always named. It now
- * holds what `path` holds, and is kept rather than dropped for being redundant:
- * a caller reading it is asking for the schematic and still gets it.
- */
-export const getDesignPaths = (
-  design: DiscoveredDesign
-): { path: string; source?: string; netlist?: string } => {
-  if (design.format === "cadence-cis" || design.format === "cadence-hdl") {
-    if (design.datFiles.pstxnet) {
-      return {
-        path: design.sourcePath,
-        source: design.sourcePath,
-        netlist: design.datFiles.pstxnet,
-      };
-    }
-  }
-  return { path: design.sourcePath };
-};
-
-/**
  * List all designs in a directory.
  */
 export const listDesigns = async (
   options: ListDesignsOptions = {}
-): Promise<
-  | Array<{ name: string; path: string; source?: string; netlist?: string; error?: string }>
-  | ErrorResult
-> => {
+): Promise<DesignInfo[] | ErrorResult> => {
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");
 
@@ -71,7 +38,9 @@ export const listDesigns = async (
   const limited = filtered.slice(0, maxResults);
   return limited.map((design) => ({
     name: design.name,
-    ...getDesignPaths(design),
+    // The design's own file: a .DSN, a .PrjPcb, a .kicad_pro, or the netlist of
+    // a design that is only a netlist. One path, which is the one to query.
+    path: design.sourcePath,
     error: design.error,
   }));
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,12 @@ export interface ComponentDetails {
 }
 
 /**
- * Parsed netlist data cached in memory
+ * A design's parsed netlist.
+ *
+ * Built by `loadNetlist` for the tool call that asked for it and discarded when
+ * that call returns: nothing here is held between calls, so every tool call
+ * reads and parses the design again. This said "cached in memory", which it has
+ * never been, and reading a design is the cost of every query as a result.
  */
 export interface ParsedNetlist {
   nets: NetConnections;


### PR DESCRIPTION
## Summary

Chained on #160. `list_designs` returned `pstxnet.dat` as `path` wherever one existed, so a query never saw the design itself, and the server instructions told an agent holding only a `.DSN` to go generate a netlist before querying. This turns that around.

- **`path` is the `.DSN`** for every Cadence design that has one. Where a netlist has been exported beside it, its `pstxnet.dat` is reported as a new `netlist` field. `source` is untouched: it has always named the schematic, and it still does, so nothing is removed from the response
- **A dat-only design is unaffected.** With no schematic to prefer, its `pstxnet.dat` is still `path` — 2 of the 13 fixture designs, both orphaned netlist directories
- **`export_cadence_netlist` is marked deprecated** in its tool description, its title, `manifest.json`, and its docs page: kept for backward compatibility, not needed to query a design. The instruction telling an agent to run it and re-run `list_designs` is gone
- Every place that recommended the triad now recommends the schematic: `SERVER_INSTRUCTIONS`, `LIST_DESIGNS_DESCRIPTION`, `manifest.json`, `docs/tools/list_designs.md`, `docs/tools/export_cadence_netlist.md`, `docs/README.md`, `README.md`, and the stale "fallback" framing in code comments

## Why the schematic

A part a CIS variant leaves off the board is written to the `.dat` triad exactly like a part that is stuffed: ordinary value, all of its connections, nothing marking it. #160 made both paths agree on Do Not Stuff by reading the schematic's variant data even for a netlist query, so the answers match — but that works because the `.DSN` is there to read. The triad is a snapshot taken at export time; the schematic is the design.

## A correction that came out of this

`ParsedNetlist` was documented as *"Parsed netlist data cached in memory"*. There is no such cache and never has been — `loadNetlist` parses on every tool call and discards the result. Measured, same design, back to back:

```
dat call #1: 13ms      DSN call #1: 2376ms
dat call #2: 12ms      DSN call #2: 2378ms
dat call #3: 13ms      DSN call #3: 2327ms
```

Flat, because each call re-reads from disk. The comment now says what the code does. **Reading a `.DSN` costs 76-298x a netlist read** (63ms vs 10.9s across the corpus), and with no cache that lands on every call. That is a deliberate trade here: the schematic is what carries the design.

## Verification

`list_designs` over the fixture corpus — the queryable path for every design:

| | before | after |
|---|---|---|
| Cadence designs handing out a `.DSN` | 1 of 13 | **11 of 13** |
| Cadence designs handing out a `.dat` | 10 of 13 | 2 of 13 (dat-only, no schematic) |
| Designs exposing a secondary `netlist` | 10 | 10 |

## Test plan

- [x] `npm run type-check && npm run lint && npm test` — 863 passed, 11 skipped, 0 failed
- [x] `src/paths.test.ts` updated for the new shape and asserts both directions
- [x] `list_designs` run over the whole fixture corpus, output inspected per design
- [x] Swept the tree for remaining `.dat`-preferred guidance; the only hits left are historical narrative in code comments, corrected

## Changelog

### Changed

- `list_designs` now returns a Cadence design's `.DSN` schematic as `path`, which is what queries should name, and reports an exported `pstxnet.dat` beside it as a new `netlist` field. `source` keeps naming the schematic as it always has, so no field is removed. Reading the schematic reads the design as it stands; an exported netlist is a snapshot of it, and a part a CIS variant leaves off the board is written there exactly like a part that is stuffed. A design that has only a netlist is unaffected, its `pstxnet.dat` is still `path`. Reading a `.DSN` takes longer than reading a triad, and nothing is cached between calls, so that cost lands on each query
- `export_cadence_netlist` is deprecated. It stays for backward compatibility and still exports a netlist for Allegro, but it is not a step towards querying a design, and the instruction to run it and re-run `list_designs` before querying is gone

### Fixed

- `ParsedNetlist` no longer claims to be "cached in memory". Nothing is held between tool calls: every call reads and parses the design again
