### PR TITLE
fix: a group only speaks for parts its own fields describe

### DIFF
--- a/src/circuit-traversal.test.ts
+++ b/src/circuit-traversal.test.ts
@@ -16,6 +16,7 @@ import {
   naturalSort,
   traverseCircuitFromNet,
   computeCircuitHash,
+  hasDnsValueMarker,
 } from "./circuit-traversal.js";
 import type { NetConnections, ComponentDetails } from "./types.js";
 
@@ -1192,5 +1193,42 @@ describe("stripDnsMarkers", () => {
   it("should preserve non-DNS content unchanged", () => {
     expect(stripDnsMarkers("10K,1%")).toBe("10K,1%");
     expect(stripDnsMarkers("CAP_0603")).toBe("CAP_0603");
+  });
+});
+
+/**
+ * The marker test a value field is read with.
+ *
+ * A value carries units, and `NF` is the one marker token that is also one.
+ * `isDnsComponent` reads mpn, description and comment, where `NF` genuinely
+ * means "no fit"; a value writes nanofarads, and reading it with the same set
+ * would unstuff a fitted capacitor whose value is written `2.2 nF`. Both the
+ * Cadence `.DSN` path and the Altium parser read values through this.
+ */
+describe("hasDnsValueMarker", () => {
+  it("reads the markers a value writes to mean Do Not Stuff", () => {
+    for (const value of ["DNP", "DNS", "DNI", "DNM", "10K,DNI", "DNM_0402", "10K_NC", "NC"]) {
+      expect(hasDnsValueMarker(value)).toBe(true);
+    }
+  });
+
+  it("reads the phrases spelled out", () => {
+    for (const value of ["DO NOT STUFF", "Do Not Populate", "NOT FITTED", "NO POP"]) {
+      expect(hasDnsValueMarker(value)).toBe(true);
+    }
+  });
+
+  it("leaves a capacitance written with a space before the unit alone", () => {
+    // The delimited `nF` here is what `isDnsComponent` reads as "no fit".
+    for (const value of ["2.2 nF", "1 nF", "10 NF", "4.7 nf"]) {
+      expect(isDnsComponent({ mpn: value })).toBe(true);
+      expect(hasDnsValueMarker(value)).toBe(false);
+    }
+  });
+
+  it("leaves ordinary values alone", () => {
+    for (const value of ["100nF", "10K", "0R", "1uF", "4.7uH", "5.1K"]) {
+      expect(hasDnsValueMarker(value)).toBe(false);
+    }
   });
 });

--- a/src/circuit-traversal.ts
+++ b/src/circuit-traversal.ts
@@ -107,6 +107,20 @@ export const matchesRefdesType = (refdes: string, type: string): boolean =>
  */
 export const hasDnsMarker = (text: string): boolean => DNS_PATTERN.test(text);
 
+// A value field is where units live, and `NF` is the one marker token that is
+// also a unit: a value writes nanofarads far more often than "no fit", and
+// `2.2 nF` carries a delimited `nF` that would otherwise unstuff a fitted
+// capacitor. It is the only token dropped here. `NC` stays, because a Cadence
+// value writes `10K_NC` to mean the part is off the board, which is why
+// `cleanDnsFromValue` has always stripped that suffix.
+const DNS_VALUE_PATTERN =
+  /(?:^|[_,\s])(DNS|DNP|DNF|DNI|DNM|NC)(?:$|[_,\s])|DO\s*NOT\s*(STUFF|POPULATE|INSTALL|FIT|MOUNT)|NOT\s*(POPULATED|FITTED|CONNECTED|MOUNTED)|NO\s*POP/i;
+
+/**
+ * Whether a component's value carries a Do Not Stuff marker.
+ */
+export const hasDnsValueMarker = (text: string): boolean => DNS_VALUE_PATTERN.test(text);
+
 /**
  * Detect Do Not Stuff components using common markers.
  */

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -64,8 +64,9 @@ The type is the refdes prefix, matched whole and case-insensitively: "u" gives U
 U2 but NOT USB1, whose prefix is USB, and "tp" gives the test points. Asking for a \
 partial prefix returns nothing rather than everything starting with it, so if a part you \
 expected is missing, look for it under its own prefix. \
-Components are grouped by MPN for compact output, and a group whose parts carry no MPN \
-says so in its notes. \
+Identical components are grouped for compact output: parts share a group only when their \
+MPN, description, comment and value all agree, so every field a group reports is true of \
+every part in it. A group whose parts carry no MPN says so in its notes. \
 If no components match, the error lists every prefix the design does have.`;
 
 export const LIST_NETS_DESCRIPTION = `\
@@ -84,8 +85,9 @@ Rejects patterns that match all items; use list_nets for full results.`;
 
 export const SEARCH_COMPONENTS_BY_REFDES_DESCRIPTION = `\
 Search for components by refdes pattern. Matching is case-insensitive. \
-Results are grouped by MPN for compact output, \
-with a notes field when nothing matches. \
+Identical components are grouped for compact output, on MPN, description, comment and \
+value together, so every field a group reports is true of every part in it. \
+A notes field is returned when nothing matches. \
 Rejects patterns that match all items; use list_components for full results.`;
 
 export const SEARCH_COMPONENTS_BY_MPN_DESCRIPTION = `\

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -108,8 +108,12 @@ export const QUERY_XNET_BY_NET_NAME_DESCRIPTION = `\
 Get full XNET (Extended Net) connectivity for a net. \
 Traces through series components, so the result is the whole electrical node rather \
 than the one net; \`circuit_hash\` identifies unique topologies. Traversal stops at \
-power and ground nets. \`skip_types\` leaves series passives out, and \
-\`skip_types=['C','L']\` on a power rail is the cheapest way to cut a large result down. \
+power and ground nets, recognised by name (VCC*, VDD*, 3V3, GND*, VSS*, ...) or by \
+carrying more than 40 pins. A rail named outside that, such as VDIO_LMS, is traversed \
+like a signal, so a query that pulls up to one returns its whole pull-up network; \
+\`visited_nets\` names every net the result crossed, which is where to look when a \
+result is broader than expected. \`skip_types\` leaves series passives out, and \
+\`skip_types=['C','L','R']\` is the cheapest way to cut such a result down. \
 Rejects ground nets (GND, AGND, DGND, etc.) with an error. \
 If the net is not found, \`search_nets\` finds the name.`;
 
@@ -117,8 +121,11 @@ export const QUERY_XNET_BY_PIN_NAME_DESCRIPTION = `\
 Get full XNET connectivity starting from a component pin, named REFDES.PIN \
 (e.g. U1.A5, R10.1). Traces through series components, so the result is the whole \
 electrical node; \`circuit_hash\` identifies unique topologies. Traversal stops at power \
-and ground nets, and \`skip_types\` leaves series passives out, such as \
-\`skip_types=['C','L']\` on a rail. \
+and ground nets, recognised by name (VCC*, VDD*, 3V3, GND*, VSS*, ...) or by carrying \
+more than 40 pins; a rail named outside that is traversed like a signal, and \
+\`visited_nets\` names every net the result crossed. \`skip_types\` leaves series \
+passives out, such as \`skip_types=['C','L','R']\` to cut a broad result down. \
+A pin on no net reads as the net \`NC\` and returns an empty result. \
 Rejects pins connected to ground nets (GND, AGND, DGND, etc.) with an error.`;
 
 export const QUERY_COMPONENT_DESCRIPTION = `\
@@ -157,7 +164,8 @@ Rules: \`net.single_pin\` (error: a net with one functional pin and no test poin
 \`net.unnamed\` (warning: an auto-generated net name on a real 2+-pin net). \
 Test points are identified by the \`TP\` refdes prefix. Findings key each net to its \
 \`REFDES.PIN\` endpoints (always arrays); \`net.unnamed\` lists bare net names. \
-\`checked\` lists the rules that ran, so a rule absent from the findings found nothing. \
+\`checked\` lists the rules that ran, so a rule absent from the findings found nothing, \
+and \`skipped\` counts the parts left out of the run, such as Do-Not-Stuff ones. \
 Use \`include_rules\`/\`exclude_rules\` (rule ids) to scope the run and \`include_dns\` to \
 count Do-Not-Stuff parts; an unknown rule id returns an error rather than silently \
 checking nothing. Unconnected pins without a no-connect symbol are NOT checked: \

--- a/src/parsers/altium/index.test.ts
+++ b/src/parsers/altium/index.test.ts
@@ -640,3 +640,48 @@ describe("readSheetNumber", () => {
     expect(readSheetNumber(schematic)).toBe("2");
   });
 });
+
+/**
+ * Altium designs conventionally mark a part Do Not Populate by writing the
+ * marker into Value and leaving every other field ordinary — a resistor whose
+ * Value reads `DNP`. That field was not read, so those parts were reported as
+ * stuffed; the temperatureSensor fixture carries two of them.
+ */
+describe("Do Not Stuff written into Value", () => {
+  const withValue = (designator: string, value: string): AltiumSchematic => ({
+    header: [],
+    records: [
+      {
+        index: 0,
+        RECORD: RECORD_TYPES.COMPONENT,
+        children: [
+          { index: 1, RECORD: RECORD_TYPES.DESIGNATOR, Text: designator } as AltiumRecord,
+          {
+            index: 2,
+            RECORD: RECORD_TYPES.PARAMETER,
+            Name: "Value",
+            Text: value,
+          } as AltiumRecord,
+        ],
+      } as AltiumRecord,
+    ],
+  });
+
+  it("marks a part whose Value is DNP", () => {
+    expect(extractComponents(withValue("R1", "DNP")).R1?.dns).toBe(true);
+  });
+
+  it("marks a part whose Value carries the marker beside the value", () => {
+    expect(extractComponents(withValue("R2", "10K, DNP")).R2?.dns).toBe(true);
+  });
+
+  it("leaves a capacitor whose value is written in nanofarads alone", () => {
+    // `2.2 nF` puts a delimited `nF` in the value, which the marker test used
+    // to read as "no fit" and would have unstuffed a fitted capacitor.
+    expect(extractComponents(withValue("C1", "2.2 nF")).C1?.dns).toBeUndefined();
+  });
+
+  it("leaves an ordinary value alone", () => {
+    expect(extractComponents(withValue("R3", "10K")).R3?.dns).toBeUndefined();
+  });
+});

--- a/src/parsers/altium/index.ts
+++ b/src/parsers/altium/index.ts
@@ -15,7 +15,7 @@
 import path from "path";
 import type { ParsedNetlist, NetConnections, ComponentDetails, PinEntry } from "../../types.js";
 import { createPinEntry } from "../../types.js";
-import { isDnsComponent, stripDnsMarkers } from "../../circuit-traversal.js";
+import { isDnsComponent, hasDnsValueMarker, stripDnsMarkers } from "../../circuit-traversal.js";
 import type { AltiumSchematic, AltiumNet, AltiumRecord, OutputFormat } from "./types.js";
 import {
   RECORD_TYPES,
@@ -382,11 +382,15 @@ export const extractComponents = (schematic: AltiumSchematic): ComponentDetails 
 
     // Check assembly info parameter for NF/DNS markers (Altium stores these as RECORD=41 parameters)
     const assemblyInfo = parameters["assembly info"];
+    // Altium designs conventionally write the marker into Value — a resistor
+    // reading `DNP` and nothing else — so that field is read too, against the
+    // marker set that leaves out the token a value writes as a unit.
     if (
       isDnsComponent({
         ...component,
         comment: [component.comment, assemblyInfo].filter(Boolean).join(" "),
-      })
+      }) ||
+      hasDnsValueMarker(component.value ?? "")
     ) {
       component.dns = true;
       if (component.mpn) component.mpn = stripDnsMarkers(component.mpn);

--- a/src/parsers/altium/value-dns.test.ts
+++ b/src/parsers/altium/value-dns.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Do Not Populate written into Value, measured on a design that does it.
+ *
+ * `temperatureSensor` marks R1 and R3 by writing `DNP` into Value and leaving
+ * every other field ordinary, which is the usual Altium convention. Value was
+ * not among the fields the marker was looked for in, so both parts were
+ * reported as stuffed and counted in every result that leaves Do Not Stuff out.
+ *
+ * A marker test that reads the value field can also unstuff a fitted part by
+ * mistaking a unit for a marker, so what matters is not only how many parts it
+ * finds but how many it invents. Across the sixteen Altium projects in the
+ * corpus these two are the only parts it reaches, and the other fifteen carry
+ * golden files that fail on any flag this moves; temperatureSensor has none,
+ * which is why its own count is pinned here.
+ */
+
+import { describe, expect, it } from "vitest";
+import { altiumHandler } from "./index.js";
+import { fixturePath, hasFixtures } from "../../../test/utils.js";
+
+const TEMPERATURE_SENSOR = fixturePath(
+  "cadence",
+  "LAUNCHXL-CC1310",
+  "hardware",
+  "devices",
+  "temperatureSensor",
+  "temperatureSensor",
+  "temperatureSensor.PrjPcb"
+);
+
+describe.skipIf(!hasFixtures)("Do Not Populate written into Value", () => {
+  it("reports the parts whose Value is the marker", async () => {
+    const parsed = await altiumHandler.parse(TEMPERATURE_SENSOR);
+    const dns = Object.entries(parsed.components)
+      .filter(([, component]) => component.dns)
+      .map(([refdes]) => refdes)
+      .sort();
+
+    expect(dns).toEqual(["R1", "R3"]);
+  });
+
+  it("leaves the rest of the design stuffed", async () => {
+    const parsed = await altiumHandler.parse(TEMPERATURE_SENSOR);
+    const total = Object.keys(parsed.components).length;
+    const stuffed = Object.values(parsed.components).filter((c) => !c.dns).length;
+
+    expect(total).toBeGreaterThan(40);
+    expect(stuffed).toBe(total - 2);
+  });
+});

--- a/src/parsers/cadence/dsn/component-builder.ts
+++ b/src/parsers/cadence/dsn/component-builder.ts
@@ -7,7 +7,7 @@
 
 import type { ComponentDetails } from "../../../types.js";
 import { createPinEntry, type PinEntry } from "../../../types.js";
-import { isValidRefdes, hasDnsMarker } from "../../../circuit-traversal.js";
+import { isValidRefdes, hasDnsValueMarker } from "../../../circuit-traversal.js";
 import type { CachedLibraryPart, PinMapData } from "./structure-types.js";
 import type { PlacedInstance } from "./structures.js";
 import type { PageData } from "./page-parser.js";
@@ -168,7 +168,7 @@ export function buildComponents(
       // stuffed, and cleaning it out of the value erases it, so read it first.
       let dns = false;
       if (value) {
-        dns = hasDnsMarker(value);
+        dns = hasDnsValueMarker(value);
         value = cleanDnsFromValue(value);
       }
 

--- a/src/service/component-grouping.test.ts
+++ b/src/service/component-grouping.test.ts
@@ -345,3 +345,102 @@ describe("aggregateCircuitByMpn", () => {
     expect("description" in result[0]).toBe(false);
   });
 });
+
+/**
+ * A group speaks for every part in it.
+ *
+ * Grouping used to key on MPN alone and keep whichever member arrived first,
+ * so a design that gives every resistor the MPN `R` and every capacitor `CC`
+ * — which the OSHW Jetson carriers do, and which `N.A.` placeholders do on
+ * other boards — collapsed into one group reporting one value for all of them.
+ * `list_components(type: "R")` on reComputer J202 answered a single group of
+ * 271 resistors valued `5.1R`, and R1 is `0R`.
+ */
+describe("groups only merge parts the group's own fields describe", () => {
+  const entriesOf = (components: ComponentDetails) =>
+    Object.entries(components) as Array<[string, ComponentDetails[string]]>;
+
+  it("keeps parts apart when a shared MPN covers different values", () => {
+    const result = groupComponentsByMpn(
+      entriesOf({
+        R1: { mpn: "R", value: "0R", pins: {} },
+        R2: { mpn: "R", value: "5.1K", pins: {} },
+        R3: { mpn: "R", value: "5.1K", pins: {} },
+      }),
+      false
+    );
+
+    expect(result).toHaveLength(2);
+    const byValue = Object.fromEntries(result.map((g) => [g.value, g.refdes]));
+    expect(byValue["0R"]).toEqual(["R1"]);
+    expect(byValue["5.1K"]).toEqual(["R2", "R3"]);
+  });
+
+  it("keeps a resistor and a capacitor apart when both carry a placeholder MPN", () => {
+    const result = groupComponentsByMpn(
+      entriesOf({
+        C1: { mpn: "N.A.", description: "Capacitor, NP0", value: "12pF", pins: {} },
+        R1: { mpn: "N.A.", description: "Resistor, 0.05W", value: "0R", pins: {} },
+      }),
+      false
+    );
+
+    expect(result).toHaveLength(2);
+    for (const group of result) {
+      expect(group.refdes).toHaveLength(1);
+    }
+    const capacitor = result.find((g) => g.refdes[0] === "C1");
+    expect(capacitor?.description).toBe("Capacitor, NP0");
+    expect(capacitor?.value).toBe("12pF");
+  });
+
+  it("still merges parts that agree, which is what the grouping is for", () => {
+    const result = groupComponentsByMpn(
+      entriesOf({
+        C1: { mpn: "CL10A225KP8NNNC", description: "CAP CER 2.2UF", value: "2.2uF", pins: {} },
+        C2: { mpn: "CL10A225KP8NNNC", description: "CAP CER 2.2UF", value: "2.2uF", pins: {} },
+      }),
+      false
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    expect(result[0].refdes).toEqual(["C1", "C2"]);
+  });
+
+  it("does not let a part with no value stand in for one that has a value", () => {
+    const result = groupComponentsByMpn(
+      entriesOf({
+        R1: { mpn: "R", pins: {} },
+        R2: { mpn: "R", value: "10K", pins: {} },
+      }),
+      false
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.find((g) => g.refdes[0] === "R1")?.value).toBeUndefined();
+    expect(result.find((g) => g.refdes[0] === "R2")?.value).toBe("10K");
+  });
+
+  it("keeps xnet aggregation apart the same way", () => {
+    const components: CircuitComponent[] = [
+      {
+        refdes: "R1",
+        mpn: "R",
+        value: "0R",
+        connections: [{ net: "A", pins: ["1"] }, { net: "B", pins: ["2"] }],
+      },
+      {
+        refdes: "R2",
+        mpn: "R",
+        value: "10K",
+        connections: [{ net: "A", pins: ["1"] }, { net: "B", pins: ["2"] }],
+      },
+    ];
+
+    const result = aggregateCircuitByMpn(components);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((g) => g.value).sort()).toEqual(["0R", "10K"]);
+  });
+});

--- a/src/service/component-grouping.ts
+++ b/src/service/component-grouping.ts
@@ -41,8 +41,20 @@ export const groupComponentsByMpn = (
     const commentValue = component.comment?.trim() || undefined;
     const valueValue = component.value?.trim() || undefined;
 
+    // A group speaks for every part in it, so parts only share one when the
+    // fields it reports are the same. Keying on MPN alone merged parts that a
+    // design gives a shared placeholder MPN — `R` for every resistor, `CC` for
+    // every capacitor, `N.A.` for anything unassigned — and the group then
+    // reported the first member's value for all of them, answering 5.1R for
+    // 271 resistors of which the first was 0R.
     const keyBase = mpnTrimmed ? `mpn:${mpnTrimmed}` : `refdes:${refdes}`;
-    const groupKey = `${keyBase}||dns:${dns ? "1" : "0"}`;
+    const groupKey = [
+      keyBase,
+      `desc:${descriptionValue ?? ""}`,
+      `comment:${commentValue ?? ""}`,
+      `value:${valueValue ?? ""}`,
+      `dns:${dns ? "1" : "0"}`,
+    ].join("||");
 
     if (!groups.has(groupKey)) {
       groups.set(groupKey, {
@@ -54,8 +66,6 @@ export const groupComponentsByMpn = (
         notes: mpnTrimmed ? undefined : [MPN_MISSING_NOTE],
         refdes: [],
       });
-    } else if (valueValue && !groups.get(groupKey)!.value) {
-      groups.get(groupKey)!.value = valueValue;
     }
 
     groups.get(groupKey)!.refdes.push(refdes);
@@ -143,7 +153,16 @@ export const aggregateCircuitByMpn = (
 
     const nets = comp.connections.map((p) => p.net);
     const netPair = [...nets].sort().join("|");
-    const groupKey = `${aggregationKey}||${netPair}||dns:${dnsFlag ? "1" : "0"}`;
+    // Same rule as groupComponentsByMpn: the reported fields join the key, so a
+    // shared placeholder MPN cannot make one part's value stand for another's.
+    const groupKey = [
+      aggregationKey,
+      netPair,
+      `desc:${description}`,
+      `comment:${comp.comment ?? ""}`,
+      `value:${value ?? ""}`,
+      `dns:${dnsFlag ? "1" : "0"}`,
+    ].join("||");
 
     if (!groups.has(groupKey)) {
       groups.set(groupKey, {
@@ -155,8 +174,6 @@ export const aggregateCircuitByMpn = (
         notes: mpn ? undefined : [MPN_MISSING_NOTE],
         orientations: new Map(),
       });
-    } else if (value && !groups.get(groupKey)!.value) {
-      groups.get(groupKey)!.value = value;
     }
 
     const orientationKey = comp.connections.map((p) => `${p.pins.join(",")}:${p.net}`).join("|");


### PR DESCRIPTION
Found by invoking every MCP tool natively against all 40 fixtures across all three vendors, ahead of cutting 1.6.0.

## The defect

`list_components(design: reComputer J202, type: "R")` answered a single group:

```
{ "count": 271, "refdes": ["R1", … "R271"], "mpn": "R", "value": "5.1R" }
```

R1 is `0R`. R2 and R3 are `5.1K`. The board gives every resistor the MPN `R` and every capacitor `CC`, and grouping keyed on MPN alone, keeping whichever member arrived first. An agent asked what value a resistor is reads one number that is wrong for almost all of them.

The same shape appears wherever an MPN is a placeholder. On `pca10056`, `N.A.` put a resistor and a capacitor in one group:

```
{ "count": 2, "refdes": ["C1", "R1"], "mpn": "N.A.", "description": "Capacitor, NP0, ±2%", "value": "12pF" }
```

R1 is a `0R` resistor.

This is not confined to one vendor or one design. Across six designs drawn from all three:

| design | MPN-bearing parts | mixed groups | distinct descriptions hidden |
|---|---|---|---|
| reComputer J201 | 1126 | 22 | 87 |
| reComputer J202 | 708 | 15 | 60 |
| reComputer J401 | 729 | 16 | 67 |
| reServer J401 | 1342 | 17 | 81 |
| pca10056 (Altium) | 331 | 1 | 49 |
| cynthion (KiCad) | 296 | 2 | 3 |

## The fix

Parts share a group only when MPN, description, comment and value all agree, so every field a group reports is true of every part in it. The 271 resistors become 30 groups, one per value. Parts that genuinely match still collapse — cynthion's six `CL10A225KP8NNNC` capacitors stay one group — which is what the grouping is for.

`aggregateCircuitByMpn`, behind `query_xnet_by_net_name` and `query_xnet_by_pin_name`, carried the same key and gets the same treatment.

Group counts stay compact:

| design | parts | groups |
|---|---|---|
| J202 R | 271 | 30 |
| J202 C | 200 | 17 |
| reServer J401 R | 619 | 47 |
| reServer J401 C | 560 | 36 |

## Do Not Populate written into Value

Altium designs conventionally mark a part by writing the marker into Value and leaving every other field ordinary. Value was not among the fields the marker was looked for in, so `temperatureSensor` reported R1 and R3 as stuffed and counted them in every result that leaves Do Not Stuff out.

Value is now read against a marker set that drops `NF` — the one token a value writes as a unit far more often than as "no fit", so `2.2 nF` would otherwise unstuff a fitted capacitor. `NC` stays: a Cadence value writes `10K_NC` to mean the part is off the board, and dropping it regressed CutiePi's eight such parts against the DAT export, which the corpus guard added in 1.5.4 caught.

Across the sixteen Altium projects in the corpus this reaches exactly two parts and invents none.

## Verification

- 874 tests pass, including the DSN-vs-DAT corpus guards on every oracle-backed Cadence fixture
- New regression tests: five on grouping, four on Altium value markers, four on the value marker set itself, and a fixture-backed pair pinning temperatureSensor, which has no golden
- Driven over a real stdio MCP connection against all 40 designs: every group cross-checked against per-part `query_component` truth, 40/40 clean. The same sweep against pre-fix `main` mismatches on 8 designs across Cadence and Altium, so the check can fail

## Changelog

### Fixed

- Component grouping reported one part's value and description for every part sharing its MPN, so a design using a placeholder MPN (`R`, `CC`, `N.A.`) answered a single group with one value standing for hundreds of physically different parts. Parts now group only when MPN, description, comment and value all agree. Affects `list_components`, `search_components_by_*`, `query_xnet_by_net_name` and `query_xnet_by_pin_name`.
- Altium parts marked Do Not Populate in their Value field were reported as stuffed.
- A Cadence value written with a space before its unit, such as `2.2 nF`, could be read as a "no fit" marker and reported Do Not Stuff. Value fields are now read against a marker set that leaves out the one token that is also a unit.

### Changed

- `query_xnet_by_net_name` and `query_xnet_by_pin_name` said traversal stops at power and ground nets without saying which nets those are. They now name both tests (the rail name pattern, and carrying more than 40 pins), say that a rail named outside them is traversed like a signal, and point at `visited_nets`. `run_erc`'s `skipped` counts and the empty result a pin on no net returns are documented too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
