### PR TITLE
fix: list_designs says which directory it searched

### DIFF
--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -42,12 +42,12 @@ and it is what every other tool takes. \
 Always use this tool to discover designs instead of searching the filesystem manually.
 
 The result names the directory it searched in \`root\`, and reading it is worth the \
-glance: \`path\` is optional, and omitting it searches the server's working directory, \
-which is where the server was launched and not necessarily where you are. An argument \
-the schema does not define is dropped before it arrives, so a misspelled \`path\` \
-behaves exactly like an omitted one. Either way the answer is a list of real designs \
-from a directory nobody asked about, and \`root\` is what distinguishes it from a \
-correct one. A result cut short by \`max_results\` says so in its notes.
+glance: \`path\` is optional, and omitting it or leaving it blank searches the server's \
+working directory, which is where the server was launched and not necessarily where you \
+are. An argument the schema does not define is dropped before it arrives, so a \
+misspelled \`path\` behaves exactly like an omitted one. Each of those returns a list of \
+real designs from a directory nobody asked about, and \`root\` is what tells it apart \
+from a correct answer. A result cut short by \`max_results\` says so in its notes.
 
 Cadence: the path is the .DSN schematic. It is the design as it stands, and it carries \
 what an exported netlist cannot: a part a CIS variant leaves off the board is written to \

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -41,6 +41,14 @@ List all design projects in the given directory, one path each: a .DSN, a .PrjPc
 and it is what every other tool takes. \
 Always use this tool to discover designs instead of searching the filesystem manually.
 
+The result names the directory it searched in \`root\`, and reading it is worth the \
+glance: \`path\` is optional, and omitting it searches the server's working directory, \
+which is where the server was launched and not necessarily where you are. An argument \
+the schema does not define is dropped before it arrives, so a misspelled \`path\` \
+behaves exactly like an omitted one. Either way the answer is a list of real designs \
+from a directory nobody asked about, and \`root\` is what distinguishes it from a \
+correct one. A result cut short by \`max_results\` says so in its notes.
+
 Cadence: the path is the .DSN schematic. It is the design as it stands, and it carries \
 what an exported netlist cannot: a part a CIS variant leaves off the board is written to \
 the .dat triad exactly like a part that is stuffed, with an ordinary value and all of its \

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -447,7 +447,21 @@ describe("listDesigns search root", () => {
 
     const result = await listDesigns();
 
-    expect(notesOf(result).join(" ")).toContain("No path was given");
+    expect(notesOf(result).join(" ")).toContain("No directory was named");
+  });
+
+  // `path` is an optional string, so a caller can send it empty. That is not a
+  // directory, and it reaches the working directory by the same route an absent
+  // argument does, so it earns the same note rather than passing for a choice.
+  it("treats a blank path as no path", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    for (const blank of ["", "   ", "\t"]) {
+      const result = await listDesigns({ searchPath: blank });
+
+      expect((result as { root: string }).root).toBe("C:\\projects");
+      expect(notesOf(result).join(" ")).toContain("No directory was named");
+    }
   });
 
   it("says nothing about the working directory when a path is given", async () => {
@@ -455,7 +469,7 @@ describe("listDesigns search root", () => {
 
     const result = await listDesigns({ searchPath: "sub\\dir" });
 
-    expect(notesOf(result).join(" ")).not.toContain("No path was given");
+    expect(notesOf(result).join(" ")).not.toContain("No directory was named");
   });
 });
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -150,6 +150,17 @@ describe("resolvePath", () => {
 // listDesigns — absolute output paths
 // =============================================================================
 
+/**
+ * The designs of a successful result.
+ *
+ * A result carries the search root alongside them, so a test that wants the
+ * designs unwraps rather than indexing the result itself.
+ */
+const designsOf = (result: unknown): Array<{ name: string; path: string; error?: string }> => {
+  expect(result).toHaveProperty("designs");
+  return (result as { designs: Array<{ name: string; path: string; error?: string }> }).designs;
+};
+
 describe("listDesigns output paths", () => {
   it("returns absolute paths", async () => {
     vi.mocked(parsers.discoverDesigns).mockResolvedValue([
@@ -163,8 +174,7 @@ describe("listDesigns output paths", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    const designPath = (result as Array<{ path: string }>)[0]?.path;
+    const designPath = designsOf(result)[0]?.path;
     expect(designPath).toBe("C:\\projects\\Board\\Board.PrjPcb");
     expect(path.isAbsolute(designPath)).toBe(true);
   });
@@ -203,15 +213,13 @@ describe("listDesigns searchPath and pattern", () => {
 
     const result = await listDesigns({ pattern: "^Alpha" });
 
-    expect(Array.isArray(result)).toBe(true);
-    const names = (result as Array<{ name: string }>).map((d) => d.name);
+    const names = designsOf(result).map((d) => d.name);
     expect(names).toEqual(["Alpha", "AlphaV2"]);
   });
 
   it("returns error for invalid regex pattern", async () => {
     const result = await listDesigns({ pattern: "[invalid" });
 
-    expect(Array.isArray(result)).toBe(false);
     expect(result).toHaveProperty("error");
     expect((result as { error: string }).error).toContain("Invalid regex pattern");
   });
@@ -238,8 +246,7 @@ describe("listDesigns Cadence path priority", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string }>)[0];
+    const design = designsOf(result)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
     // One path, and it is the design. The netlist beside it is not reported.
     expect(design).not.toHaveProperty("source");
@@ -258,8 +265,7 @@ describe("listDesigns Cadence path priority", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ path: string }>)[0];
+    const design = designsOf(result)[0];
     expect(design.path).toBe("C:\\projects\\Board.DSN");
   });
 });
@@ -282,8 +288,7 @@ describe("listDesigns error passthrough", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ name: string; error?: string }>)[0];
+    const design = designsOf(result)[0];
     expect(design.error).toBe("Netlist files not exported.");
   });
 
@@ -294,8 +299,7 @@ describe("listDesigns error passthrough", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    const design = (result as Array<{ name: string; error?: string }>)[0];
+    const design = designsOf(result)[0];
     expect(design.error).toBeUndefined();
   });
 });
@@ -314,7 +318,6 @@ describe("listDesigns filesystem errors", () => {
 
     const result = await listDesigns({ searchPath: "C:\\nonexistent" });
 
-    expect(Array.isArray(result)).toBe(false);
     expect((result as { error: string }).error).toContain("Failed to search");
     expect((result as { error: string }).error).toContain("ENOENT");
   });
@@ -328,7 +331,6 @@ describe("listDesigns filesystem errors", () => {
 
     const result = await listDesigns({ searchPath: "C:\\file.txt" });
 
-    expect(Array.isArray(result)).toBe(false);
     expect((result as { error: string }).error).toContain("Failed to search");
     expect((result as { error: string }).error).toContain("ENOTDIR");
   });
@@ -352,8 +354,7 @@ describe("listDesigns maxResults", () => {
 
     const result = await listDesigns();
 
-    expect(Array.isArray(result)).toBe(true);
-    expect((result as unknown[]).length).toBe(50);
+    expect(designsOf(result).length).toBe(50);
   });
 
   it("respects custom maxResults", async () => {
@@ -361,8 +362,7 @@ describe("listDesigns maxResults", () => {
 
     const result = await listDesigns({ maxResults: 10 });
 
-    expect(Array.isArray(result)).toBe(true);
-    expect((result as unknown[]).length).toBe(10);
+    expect(designsOf(result).length).toBe(10);
   });
 
   it("returns all results when fewer than maxResults", async () => {
@@ -370,8 +370,7 @@ describe("listDesigns maxResults", () => {
 
     const result = await listDesigns({ maxResults: 10 });
 
-    expect(Array.isArray(result)).toBe(true);
-    expect((result as unknown[]).length).toBe(3);
+    expect(designsOf(result).length).toBe(3);
   });
 });
 
@@ -413,5 +412,91 @@ describe("exportCadenceNetlist output paths", () => {
 
     expect(result.outputDir).toBe("C:\\repo\\schem\\Allegro");
     expect(path.isAbsolute(result.outputDir)).toBe(true);
+  });
+});
+
+// =============================================================================
+// listDesigns — search root and notes
+// =============================================================================
+
+describe("listDesigns search root", () => {
+  const notesOf = (result: unknown): string[] => (result as { notes?: string[] }).notes ?? [];
+
+  it("reports the resolved directory it searched", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    const result = await listDesigns({ searchPath: "sub\\dir" });
+
+    expect((result as { root: string }).root).toBe("C:\\projects\\sub\\dir");
+  });
+
+  it("reports the working directory as the root when no path is given", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    const result = await listDesigns();
+
+    expect((result as { root: string }).root).toBe("C:\\projects");
+  });
+
+  // The failure this guards is a search that answers from a directory nobody
+  // asked about: an unrecognised argument is dropped before it reaches the tool,
+  // so a misspelled path arrives as no path and quietly searches the default.
+  // Real designs come back and nothing about them looks wrong.
+  it("notes that the search fell back to the working directory", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    const result = await listDesigns();
+
+    expect(notesOf(result).join(" ")).toContain("No path was given");
+  });
+
+  it("says nothing about the working directory when a path is given", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([]);
+
+    const result = await listDesigns({ searchPath: "sub\\dir" });
+
+    expect(notesOf(result).join(" ")).not.toContain("No path was given");
+  });
+});
+
+describe("listDesigns truncation notes", () => {
+  const makeDesigns = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      name: `Design${i}`,
+      sourcePath: `C:\\projects\\Design${i}\\Design${i}.PrjPcb`,
+      format: "altium" as const,
+      schdocPaths: [],
+    }));
+
+  const notesOf = (result: unknown): string[] => (result as { notes?: string[] }).notes ?? [];
+
+  it("says how many designs were left out", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue(makeDesigns(100));
+
+    const result = await listDesigns({ searchPath: "sub", maxResults: 10 });
+
+    expect(notesOf(result).join(" ")).toContain("Showing 10 of 100 designs");
+  });
+
+  // The count is of designs that matched the pattern, not of everything found,
+  // so a filtered search reports what the filter left rather than what the walk
+  // saw.
+  it("counts what the pattern matched, not what the walk found", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue([
+      ...makeDesigns(40),
+      { name: "Other", sourcePath: "C:\\Other.PrjPcb", format: "altium" as const, schdocPaths: [] },
+    ]);
+
+    const result = await listDesigns({ searchPath: "sub", pattern: "^Design", maxResults: 10 });
+
+    expect(notesOf(result).join(" ")).toContain("Showing 10 of 40 designs");
+  });
+
+  it("says nothing when every design fits", async () => {
+    vi.mocked(parsers.discoverDesigns).mockResolvedValue(makeDesigns(3));
+
+    const result = await listDesigns({ searchPath: "sub", maxResults: 10 });
+
+    expect(notesOf(result)).toEqual([]);
   });
 });

--- a/src/service/tools/list-designs.ts
+++ b/src/service/tools/list-designs.ts
@@ -1,7 +1,7 @@
 import { discoverDesigns } from "../../parsers/index.js";
 import { resolvePath } from "../../paths.js";
 import { parseRegexPattern } from "../regex-helpers.js";
-import type { ErrorResult, DesignInfo } from "../../types.js";
+import type { ErrorResult, ListDesignsResult } from "../../types.js";
 
 /**
  * Options for listDesigns.
@@ -18,7 +18,7 @@ export interface ListDesignsOptions {
  */
 export const listDesigns = async (
   options: ListDesignsOptions = {}
-): Promise<DesignInfo[] | ErrorResult> => {
+): Promise<ListDesignsResult | ErrorResult> => {
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
   const resolvedPath = resolvePath(searchPath ?? ".");
 
@@ -36,11 +36,37 @@ export const listDesigns = async (
 
   const filtered = designs.filter((design) => regex.test(design.name));
   const limited = filtered.slice(0, maxResults);
-  return limited.map((design) => ({
-    name: design.name,
-    // The design's own file: a .DSN, a .PrjPcb, a .kicad_pro, or the netlist of
-    // a design that is only a netlist. One path, which is the one to query.
-    path: design.sourcePath,
-    error: design.error,
-  }));
+
+  const notes: string[] = [];
+  // A caller who names no directory rarely means "wherever this server happens
+  // to have been launched", and a caller who misspells the argument means it
+  // even less: an unrecognised argument is dropped before it arrives, so a typo
+  // arrives here as no path at all and searches the same default. Both return
+  // real designs from a directory nobody asked about, which is indistinguishable
+  // from a correct answer unless the result says where it looked.
+  if (searchPath === undefined) {
+    notes.push(
+      `No path was given, so the search ran in the server's working directory. ` +
+        `That is where the server was launched, which is not necessarily where you are. ` +
+        `Pass 'path' to search a directory you choose.`
+    );
+  }
+  if (filtered.length > limited.length) {
+    notes.push(
+      `Showing ${limited.length} of ${filtered.length} designs. ` +
+        `Narrow the search with a more specific 'path', a 'pattern', or a smaller 'max_depth'.`
+    );
+  }
+
+  return {
+    root: resolvedPath,
+    designs: limited.map((design) => ({
+      name: design.name,
+      // The design's own file: a .DSN, a .PrjPcb, a .kicad_pro, or the netlist of
+      // a design that is only a netlist. One path, which is the one to query.
+      path: design.sourcePath,
+      error: design.error,
+    })),
+    ...(notes.length > 0 ? { notes } : {}),
+  };
 };

--- a/src/service/tools/list-designs.ts
+++ b/src/service/tools/list-designs.ts
@@ -20,7 +20,14 @@ export const listDesigns = async (
   options: ListDesignsOptions = {}
 ): Promise<ListDesignsResult | ErrorResult> => {
   const { searchPath, pattern = ".*", maxDepth, maxResults = 50 } = options;
-  const resolvedPath = resolvePath(searchPath ?? ".");
+  // A blank string is not a directory, and it reaches the working directory by
+  // the same route an absent argument does: `path.normalize("")` is ".". Treated
+  // as a path it would resolve to that default while skipping the note saying
+  // so, which is the silent fallback this function reports. The untrimmed string
+  // is what gets resolved, so a directory whose name really does carry spaces
+  // still resolves to itself.
+  const requestedPath = searchPath?.trim() ? searchPath : undefined;
+  const resolvedPath = resolvePath(requestedPath ?? ".");
 
   const parsed = parseRegexPattern(pattern);
   if ("error" in parsed) return parsed;
@@ -44,9 +51,9 @@ export const listDesigns = async (
   // arrives here as no path at all and searches the same default. Both return
   // real designs from a directory nobody asked about, which is indistinguishable
   // from a correct answer unless the result says where it looked.
-  if (searchPath === undefined) {
+  if (requestedPath === undefined) {
     notes.push(
-      `No path was given, so the search ran in the server's working directory. ` +
+      `No directory was named, so the search ran in the server's working directory. ` +
         `That is where the server was launched, which is not necessarily where you are. ` +
         `Pass 'path' to search a directory you choose.`
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,21 @@ export interface DesignInfo {
 }
 
 /**
+ * Result from listDesigns.
+ *
+ * `root` is the absolute directory the search actually ran in. It is reported on
+ * every result because the search root is the one thing a caller cannot check
+ * from the designs alone: a mistyped or omitted `path` falls back to the
+ * server's working directory and returns a list of real designs from somewhere
+ * else entirely, which reads exactly like a correct answer.
+ */
+export interface ListDesignsResult {
+  root: string;
+  designs: DesignInfo[];
+  notes?: string[];
+}
+
+/**
  * Component entry grouped by MPN for list/search results.
  */
 export interface ComponentGroup {


### PR DESCRIPTION
## Summary

`list_designs` searched a directory nobody asked about and answered as if nothing were wrong.

`path` is optional, and omitting it searches the server's working directory: where the server was launched, not where the caller is. An argument the schema does not define is dropped before the tool sees it, so a misspelled `path` arrives as no path at all and searches that same default.

I hit this while triaging something else. Calling the tool with `search_path` instead of `path`, against this workspace, returned 50 KiCad autosave files out of a 40,798-project private corpus, in answer to a question about a Cadence fixture tree. The response was well-formed, every design in it was real, and there was nothing in it to check.

The result now names the directory it searched.

## Changes

- `listDesigns` returns `{ root, designs, notes? }` in place of a bare `DesignInfo[]`. `root` is the absolute directory the search ran in.
- A note when no path was given, saying the search fell back to the server's working directory and that this is where the server was launched.
- A note when `max_results` cut the list short, with both counts: `Showing 10 of 100 designs`. This was silent too, and it is the same class of bug: I received exactly 50 results with no way to know there were 40,798.
- `LIST_DESIGNS_DESCRIPTION` documents the default and the dropped-argument behaviour, neither of which was written down anywhere.

`path` stays optional. Searching the working directory is the right default when the server is launched in the project it serves, which is the ordinary case; the defect is that it happened silently.

## Testing

- [x] Added/updated tests
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (885 passed, 11 skipped)

Seven new tests cover the root on both paths, the fallback note and its absence, and the truncation note including that its count is of pattern matches rather than of everything the walk found. Existing `listDesigns` tests move to the new shape through a shared `designsOf` helper.

Verified end to end against the real filesystem, not only the mocks:

```
--- no path given ---
"root": "/Users/valentino/Developer/IntelligentElectron/universal-netlist",
"notes": [
  "No path was given, so the search ran in the server's working directory. ...",
  "Showing 3 of 40 designs. ..."
]

--- path given ---
"root": "/Users/valentino/Developer/IntelligentElectron/test-fixtures/cadence",
"notes": ["Showing 3 of 14 designs. ..."]
```

## Changelog

- `list_designs` now reports `root`, the directory it actually searched. `path` is optional and omitting it searches the server's working directory, which is where the server was launched rather than where you are; an argument the schema does not define is dropped before the tool sees it, so a misspelled `path` behaves exactly like an omitted one. Both returned a list of real designs from an unrelated directory with nothing to distinguish it from a correct answer. A result cut short by `max_results` now says so, with the number found alongside the number shown.
