### PR TITLE
fix: a netlist-only design answers to its directory, not to pstxnet

### DIFF
--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -92,6 +92,7 @@ vi.mock("./parsers/index.js", () => ({
 // =============================================================================
 
 let resolvePath: typeof import("./paths.js").resolvePath;
+let getDesignName: typeof import("./paths.js").getDesignName;
 let listDesigns: typeof import("./service/index.js").listDesigns;
 let exportCadenceNetlist: typeof import("./service/index.js").exportCadenceNetlist;
 let parsers: typeof import("./parsers/index.js");
@@ -105,7 +106,7 @@ const definePlatform = (value: string) => {
 
 beforeAll(async () => {
   path = await import("path");
-  ({ resolvePath } = await import("./paths.js"));
+  ({ resolvePath, getDesignName } = await import("./paths.js"));
   parsers = await import("./parsers/index.js");
   ({ listDesigns, exportCadenceNetlist } = await import("./service/index.js"));
 });
@@ -143,6 +144,67 @@ describe("resolvePath", () => {
 
   it("normalizes forward slashes to backslashes", () => {
     expect(resolvePath("sub/dir/design.dsn")).toBe("C:\\projects\\sub\\dir\\design.dsn");
+  });
+});
+
+// =============================================================================
+// getDesignName
+// =============================================================================
+
+// Forward slashes throughout: the win32 path module accepts them as separators
+// and the posix one does not accept backslashes, so these read the same on
+// either host. `process.platform` is mocked to win32 above and has no bearing
+// here, since getDesignName never reads it.
+describe("getDesignName", () => {
+  it("strips the directory and extension", () => {
+    expect(getDesignName("/projects/board-rev-c/top.dsn")).toBe("top");
+    expect(getDesignName("/projects/Board.PrjPcb")).toBe("Board");
+    expect(getDesignName("/projects/Board.kicad_pro")).toBe("Board");
+  });
+
+  it("keeps a name that contains dots", () => {
+    expect(getDesignName("/projects/CutiePi_V2.3-20210409.DSN")).toBe("CutiePi_V2.3-20210409");
+  });
+
+  // A design that is only a netlist is addressed by a file every such design
+  // names identically, so stripping the extension gave all of them the name
+  // "pstxnet" and two of them side by side were indistinguishable in a result.
+  it("names a netlist-only design after its directory", () => {
+    expect(getDesignName("/fixtures/cadence/BeagleBone-Black-copy/pstxnet.dat")).toBe(
+      "BeagleBone-Black-copy"
+    );
+    expect(getDesignName("/fixtures/cadence/BeagleBone-Black-barebone/pstxnet.dat")).toBe(
+      "BeagleBone-Black-barebone"
+    );
+  });
+
+  it("distinguishes two netlist-only designs", () => {
+    const first = getDesignName("/fixtures/cadence/BeagleBone-Black-copy/pstxnet.dat");
+    const second = getDesignName("/fixtures/cadence/BeagleBone-Black-barebone/pstxnet.dat");
+    expect(first).not.toBe(second);
+  });
+
+  it("names a design after its directory for any file of the triad", () => {
+    for (const file of ["pstxnet.dat", "pstxprt.dat", "pstchip.dat"]) {
+      expect(getDesignName(`/fixtures/cadence/Board/${file}`)).toBe("Board");
+    }
+  });
+
+  // Cadence writes these lowercase, and a Windows filesystem hands back whatever
+  // case it was stored in.
+  it("recognises the triad whatever its case", () => {
+    expect(getDesignName("/fixtures/cadence/Board/PSTXNET.DAT")).toBe("Board");
+    expect(getDesignName("/fixtures/cadence/Board/PstXNet.Dat")).toBe("Board");
+  });
+
+  it("leaves an unrelated .dat named after its file", () => {
+    expect(getDesignName("/fixtures/cadence/Board/netlist.dat")).toBe("netlist");
+  });
+
+  // There is no directory to be named after, and an empty name is worse than
+  // the one this replaces.
+  it("falls back to the filename for a triad file at the filesystem root", () => {
+    expect(getDesignName("/pstxnet.dat")).toBe("pstxnet");
   });
 });
 

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -153,9 +153,15 @@ describe("resolvePath", () => {
 
 // Forward slashes throughout: the win32 path module accepts them as separators
 // and the posix one does not accept backslashes, so these read the same on
-// either host. `process.platform` is mocked to win32 above and has no bearing
-// here, since getDesignName never reads it.
+// either host. The platform and working directory the surrounding suite sets up
+// for the Windows path tests are replaced here, since getDesignName resolves
+// relative paths and a Windows-shaped cwd makes those unreadable.
 describe("getDesignName", () => {
+  beforeEach(() => {
+    definePlatform("linux");
+    vi.spyOn(process, "cwd").mockReturnValue("/work/BeagleBone-Black-copy");
+  });
+
   it("strips the directory and extension", () => {
     expect(getDesignName("/projects/board-rev-c/top.dsn")).toBe("top");
     expect(getDesignName("/projects/Board.PrjPcb")).toBe("Board");
@@ -199,6 +205,31 @@ describe("getDesignName", () => {
 
   it("leaves an unrelated .dat named after its file", () => {
     expect(getDesignName("/fixtures/cadence/Board/netlist.dat")).toBe("netlist");
+  });
+
+  // Resolving is what makes these work. Read as typed, a bare filename has "."
+  // for a directory and would be named ".", which is worse than the "pstxnet"
+  // this replaces; resolved, it is a file in the working directory and takes
+  // that directory's name.
+  it("names a relative path after the directory it resolves to", () => {
+    expect(getDesignName("pstxnet.dat")).toBe("BeagleBone-Black-copy");
+    expect(getDesignName("./pstxnet.dat")).toBe("BeagleBone-Black-copy");
+    expect(getDesignName("../BeagleBone-Black-copy/pstxnet.dat")).toBe("BeagleBone-Black-copy");
+  });
+
+  it("names a relative non-triad path after its own file", () => {
+    expect(getDesignName("Board.DSN")).toBe("Board");
+    expect(getDesignName("./sub/Board.DSN")).toBe("Board");
+  });
+
+  // Agents send Windows-style paths whatever the host, which is what resolvePath
+  // exists to absorb. Read as typed on a Unix host, none of this is a separator
+  // and the whole string is the name.
+  it("reads a Windows-style path on a Unix host", () => {
+    expect(getDesignName("C:\\fixtures\\BeagleBone-Black-copy\\pstxnet.dat")).toBe(
+      "BeagleBone-Black-copy"
+    );
+    expect(getDesignName("C:\\fixtures\\Board.DSN")).toBe("Board");
   });
 
   // There is no directory to be named after, and an empty name is worse than

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -33,9 +33,25 @@ export const resolvePath = (inputPath: string): string => {
  * directory and file extension.
  *
  * Example: "/projects/board-rev-c/top.dsn" -> "top"
+ *
+ * A design that is only a netlist is addressed by one of its three .dat files,
+ * which every such design names identically, so stripping the extension called
+ * all of them "pstxnet" and two side by side answered to the same name. Their
+ * directory holds the identity instead: discovery collects a triad per
+ * directory, so a directory contains at most one of these designs.
+ *
+ * Example: "/projects/BeagleBone-Black-copy/pstxnet.dat" -> "BeagleBone-Black-copy"
  */
-export const getDesignName = (design: string): string =>
-  path.basename(design, path.extname(design));
+export const getDesignName = (design: string): string => {
+  const base = path.basename(design);
+  if (REQUIRED_DAT_FILES.includes(base.toLowerCase() as (typeof REQUIRED_DAT_FILES)[number])) {
+    // A .dat sitting at the root of a filesystem has no directory to be named
+    // after, and an empty name is worse than the one this replaces.
+    const parent = path.basename(path.dirname(design));
+    if (parent) return parent;
+  }
+  return path.basename(design, path.extname(design));
+};
 
 /**
  * Suffix of the directory `export_cadence_netlist` writes a design's netlist to.

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -43,14 +43,21 @@ export const resolvePath = (inputPath: string): string => {
  * Example: "/projects/BeagleBone-Black-copy/pstxnet.dat" -> "BeagleBone-Black-copy"
  */
 export const getDesignName = (design: string): string => {
-  const base = path.basename(design);
+  // Resolved the same way `loadNetlist` resolves it, so the name describes the
+  // file that was actually read rather than whatever string the caller typed.
+  // A bare filename, a relative path and a Windows-style path on a Unix host all
+  // reach the same design, and this makes all three name it the same way.
+  const resolved = resolvePath(design);
+  const base = path.basename(resolved);
   if (REQUIRED_DAT_FILES.includes(base.toLowerCase() as (typeof REQUIRED_DAT_FILES)[number])) {
-    // A .dat sitting at the root of a filesystem has no directory to be named
-    // after, and an empty name is worse than the one this replaces.
-    const parent = path.basename(path.dirname(design));
+    // Resolving first is what makes one guard enough here: an absolute path's
+    // directory is either a real directory or the root, so `.` and `..` cannot
+    // reach this. The root has no name to give, and an empty one is worse than
+    // the name it replaces.
+    const parent = path.basename(path.dirname(resolved));
     if (parent) return parent;
   }
-  return path.basename(design, path.extname(design));
+  return path.basename(resolved, path.extname(resolved));
 };
 
 /**


### PR DESCRIPTION
Stacked on #165. Review that one first; this branch contains its commit.

## Summary

Every query result for a design that ships without its schematic came back keyed `pstxnet`.

Such a design is addressed by one of its three `.dat` files, and every design names those files identically, so `getDesignName` stripped the extension and produced the same name for all of them.

Within one call that costs nothing: the caller supplied the path and knows what they asked. It costs when two results sit side by side, which is the rev-against-rev comparison this server exists for. Both BeagleBone fixtures are different designs and both answered to `pstxnet`:

```
search_nets(BeagleBone-Black-barebone/pstxnet.dat) -> { "pstxnet": ["DDR_A0", "DDR_A1"] }
search_components_by_refdes(BeagleBone-Black-copy/pstxnet.dat) -> { "pstxnet": [ {R1 ...} ] }
```

Affects all eight query call sites: `search_nets`, the three `search_components_by_*`, `list_components`, `query_component`, and both `query_xnet_*`.

## Changes

- `getDesignName` names a design after its directory when the path is one of the triad, and strips the extension as before for everything else.

The directory is the right identity because discovery collects a triad per directory (`datFilesByDir` in `parsers/cadence/discovery.ts`), so a directory contains at most one of these designs. Two distinct designs therefore get two distinct names.

After:

```
BeagleBone-Black-barebone/pstxnet.dat -> [ 'BeagleBone-Black-barebone' ]
BeagleBone-Black-copy/pstxnet.dat     -> [ 'BeagleBone-Black-copy' ]
```

## Two things worth stating

**This does not reproduce `list_designs` names.** Those read `BEAGLEBONEBLK_C_51a4` and `BEAGLEBONEBLK_C_d80f`: the ROOT_DRAWING recorded in `pstxprt.dat`, plus a path hash when two designs would collide. That hash is computed by comparing the designs found in one search, so a lookup holding a single path cannot know a collision exists, and reading ROOT_DRAWING here would give both designs the same `BEAGLEBONEBLK_C` and collide again. Distinct and meaningful is what a single-path lookup can deliver.

**`test/integration/golden.test.ts` already works around this** at line 65, mapping a `pstxnet.dat` to the fixture directory name with the comment `use the fixture directory name instead of "pstxnet"`. Independent corroboration that the directory is the identity. I left it alone: it names golden files on disk rather than labelling results, it keys off `fixture.name` rather than the containing directory, and the two coincide only while a netlist-only fixture keeps its triad at its root. Renaming committed goldens on that assumption buys nothing.

## Testing

- [x] Added/updated tests
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (893 passed, 11 skipped)

Eight new tests, `getDesignName` having had none. They cover the existing behaviour it had to keep (directory and extension stripped, a name containing dots left whole), naming after the directory for each of the three triad files and in any case, two netlist-only designs coming out distinct, an unrelated `.dat` still named after its file, and a triad file at the filesystem root falling back rather than returning an empty name.

Verified end to end through `search_nets` and `search_components_by_refdes` against both fixtures, output above.

## Changelog

- A Cadence design that ships without its schematic is queried through its exported netlist, and every result for one came back keyed `pstxnet` rather than named after the design. Every such design names its three `.dat` files identically, so all of them shared that one key and two placed side by side were indistinguishable. Each is now named after its directory, which holds at most one exported netlist. Affects `search_nets`, `search_components_by_*`, `list_components`, `query_component` and `query_xnet_*`.
