### PR TITLE
fix: refuse arguments a tool does not define

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@intelligentelectron/universal-netlist",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",
@@ -18,7 +18,7 @@
         "@opentelemetry/sdk-logs": "^0.219.0",
         "@opentelemetry/sdk-metrics": "^2.8.0",
         "@opentelemetry/sdk-node": "^0.219.0",
-        "zod": "^4.1.12",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/node": "^22.15.21",
@@ -120,7 +120,7 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -716,7 +716,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/api-logs": "^0.219.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",
@@ -22,7 +22,7 @@
         "@opentelemetry/sdk-logs": "^0.219.0",
         "@opentelemetry/sdk-metrics": "^2.8.0",
         "@opentelemetry/sdk-node": "^0.219.0",
-        "zod": "^4.1.12"
+        "zod": "^4.4.3"
       },
       "bin": {
         "universal-netlist": "dist/index.js"
@@ -699,10 +699,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4365,7 +4367,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://github.com/IntelligentElectron/universal-netlist#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.219.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.219.0",
@@ -80,7 +80,7 @@
     "@opentelemetry/sdk-logs": "^0.219.0",
     "@opentelemetry/sdk-metrics": "^2.8.0",
     "@opentelemetry/sdk-node": "^0.219.0",
-    "zod": "^4.1.12"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.15.21",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -16,10 +16,14 @@ import { createServer } from "./server.js";
 /** The one tool that writes: it runs Cadence's exporter and lands files on disk. */
 const WRITING_TOOLS = ["export_cadence_netlist"];
 
+/** As much of a tool result as these assertions read. */
+type ToolResult = { isError?: boolean; content?: Array<{ text?: string }> };
+
 type ListedTool = {
   name: string;
   title?: string;
   description?: string;
+  inputSchema?: { additionalProperties?: boolean; properties?: Record<string, unknown> };
   annotations?: {
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
@@ -29,10 +33,11 @@ type ListedTool = {
 };
 
 let tools: ListedTool[];
+let client: Client;
 
 beforeAll(async () => {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: "test", version: "0.0.0" });
+  client = new Client({ name: "test", version: "0.0.0" });
   await Promise.all([client.connect(clientTransport), createServer().connect(serverTransport)]);
   tools = (await client.listTools()).tools as ListedTool[];
 });
@@ -76,5 +81,62 @@ describe("tool annotations", () => {
   it("gives every tool a description", () => {
     const undescribed = tools.filter((t) => !t.description?.trim()).map((t) => t.name);
     expect(undescribed).toEqual([]);
+  });
+});
+
+/**
+ * Arguments the schema does not define are refused rather than dropped.
+ *
+ * A tool declared with a plain shape is parsed by an object that strips what it
+ * does not recognise, so a misspelled argument arrives as no argument at all.
+ * Where the argument was optional that is silent: the default runs and the tool
+ * answers a question nobody asked, in a well-formed result with nothing in it to
+ * check. `list_designs` searched the server's working directory that way, and
+ * `run_erc` ran every rule that way. Declaring each tool with `z.strictObject`
+ * turns both into an error naming the argument.
+ */
+describe("unrecognised arguments", () => {
+  it("declares every tool closed to arguments it does not define", () => {
+    const open = tools
+      .filter((t) => t.inputSchema?.additionalProperties !== false)
+      .map((t) => t.name);
+    expect(open).toEqual([]);
+  });
+
+  /** The refusal arrives as an error result, and it names the argument. */
+  const refusalFor = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const result = (await client.callTool({ name, arguments: args })) as ToolResult;
+    expect(result.isError, `${name} accepted ${JSON.stringify(args)}`).toBe(true);
+    return result.content?.[0]?.text ?? "";
+  };
+
+  it("refuses a misspelled optional argument instead of running the default", async () => {
+    // The real mistake: `path` is what the tool takes, `searchPath` is what the
+    // function behind it takes, and the near-miss used to search the server's
+    // working directory without saying so.
+    expect(await refusalFor("list_designs", { search_path: "/tmp" })).toContain(
+      'Unrecognized key: "search_path"'
+    );
+  });
+
+  it("refuses a misspelled optional argument on a tool that selects its own work", async () => {
+    // `include_rules` is the argument; `rules` used to be dropped, which ran
+    // every rule and reported that as the selection.
+    expect(
+      await refusalFor("run_erc", {
+        design: "/does/not/matter.kicad_pro",
+        rules: ["net.single_pin"],
+      })
+    ).toContain('Unrecognized key: "rules"');
+  });
+
+  it("still accepts the arguments a tool does define", async () => {
+    const result = (await client.callTool({
+      name: "list_designs",
+      arguments: { path: "/nonexistent-on-purpose", max_results: 1 },
+    })) as ToolResult;
+    // Reaching the tool at all is the point; the directory is missing, so it
+    // reports that rather than a validation failure.
+    expect(result.content?.[0]?.text ?? "").toContain("Failed to search");
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,7 +110,7 @@ export const createServer = (): McpServer => {
       title: "List designs",
       description: LIST_DESIGNS_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         path: z.string().optional().describe("Path to directory to search for designs"),
         pattern: z.string().optional().describe("Regex pattern to filter design names"),
         max_depth: z
@@ -126,7 +126,7 @@ export const createServer = (): McpServer => {
           .optional()
           .default(50)
           .describe("Max designs to return. Default: 50."),
-      },
+      }),
     },
     withTelemetry("list_designs", async ({ path, pattern, max_depth, max_results }) => {
       const result = await listDesigns({
@@ -148,7 +148,7 @@ export const createServer = (): McpServer => {
       title: "List components",
       description: LIST_COMPONENTS_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file, as returned by list_designs"),
         type: z.string().describe("Component prefix: U, C, R, L, etc."),
         include_dns: z
@@ -156,7 +156,7 @@ export const createServer = (): McpServer => {
           .optional()
           .default(false)
           .describe("Include DNS (Do Not Stuff) components"),
-      },
+      }),
     },
     withTelemetry("list_components", async ({ design, type, include_dns }) => {
       const result = await listComponents(design, type, include_dns);
@@ -173,9 +173,9 @@ export const createServer = (): McpServer => {
       title: "List nets",
       description: LIST_NETS_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file"),
-      },
+      }),
     },
     withTelemetry("list_nets", async ({ design }) => {
       const result = await listNets(design);
@@ -192,10 +192,10 @@ export const createServer = (): McpServer => {
       title: "Search nets",
       description: SEARCH_NETS_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         pattern: z.string().describe("Regex pattern"),
         design: z.string().describe("Path to design file"),
-      },
+      }),
     },
     withTelemetry("search_nets", async ({ pattern, design }) => {
       const result = await searchNets(pattern, design);
@@ -212,11 +212,11 @@ export const createServer = (): McpServer => {
       title: "Search components by refdes",
       description: SEARCH_COMPONENTS_BY_REFDES_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         pattern: z.string().describe("Regex pattern for refdes"),
         design: z.string().describe("Path to design file"),
         include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
-      },
+      }),
     },
     withTelemetry("search_components_by_refdes", async ({ pattern, design, include_dns }) => {
       const result = await searchComponentsByRefdes(pattern, design, include_dns);
@@ -233,11 +233,11 @@ export const createServer = (): McpServer => {
       title: "Search components by MPN",
       description: SEARCH_COMPONENTS_BY_MPN_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         pattern: z.string().describe("Regex pattern for MPN"),
         design: z.string().describe("Path to design file"),
         include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
-      },
+      }),
     },
     withTelemetry("search_components_by_mpn", async ({ pattern, design, include_dns }) => {
       const result = await searchComponentsByMpn(pattern, design, include_dns);
@@ -254,11 +254,11 @@ export const createServer = (): McpServer => {
       title: "Search components by description",
       description: SEARCH_COMPONENTS_BY_DESCRIPTION_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         pattern: z.string().describe("Regex pattern for description"),
         design: z.string().describe("Path to design file"),
         include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
-      },
+      }),
     },
     withTelemetry("search_components_by_description", async ({ pattern, design, include_dns }) => {
       const result = await searchComponentsByDescription(pattern, design, include_dns);
@@ -275,7 +275,7 @@ export const createServer = (): McpServer => {
       title: "Trace XNET from a net",
       description: QUERY_XNET_BY_NET_NAME_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file"),
         net_name: z.string().describe("Exact net name"),
         skip_types: z
@@ -283,7 +283,7 @@ export const createServer = (): McpServer => {
           .optional()
           .describe("Component prefixes to exclude (e.g., ['C', 'L'])"),
         include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
-      },
+      }),
     },
     withTelemetry(
       "query_xnet_by_net_name",
@@ -303,12 +303,12 @@ export const createServer = (): McpServer => {
       title: "Trace XNET from a pin",
       description: QUERY_XNET_BY_PIN_NAME_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file"),
         pin_name: z.string().describe("Pin spec: REFDES.PIN (e.g., U2.10, U1.A5)"),
         skip_types: z.array(z.string()).optional().describe("Component prefixes to exclude"),
         include_dns: z.boolean().optional().default(false).describe("Include DNS components"),
-      },
+      }),
     },
     withTelemetry(
       "query_xnet_by_pin_name",
@@ -328,10 +328,10 @@ export const createServer = (): McpServer => {
       title: "Get component details",
       description: QUERY_COMPONENT_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file"),
         refdes: z.string().describe("Component reference designator"),
-      },
+      }),
     },
     withTelemetry("query_component", async ({ design, refdes }) => {
       const result = await queryComponent(design, refdes);
@@ -348,7 +348,7 @@ export const createServer = (): McpServer => {
       title: "Run electrical rule checks",
       description: RUN_ERC_DESCRIPTION,
       annotations: READ_ONLY,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to design file"),
         include_dns: z
           .boolean()
@@ -360,7 +360,7 @@ export const createServer = (): McpServer => {
           .optional()
           .describe("Only run these rule ids (e.g., ['net.single_pin']). Omit for all"),
         exclude_rules: z.array(z.string()).optional().describe("Skip these rule ids"),
-      },
+      }),
     },
     withTelemetry("run_erc", async ({ design, include_dns, include_rules, exclude_rules }) => {
       const result = await runErc(design, {
@@ -381,9 +381,9 @@ export const createServer = (): McpServer => {
       title: "Export Cadence netlist (deprecated)",
       description: EXPORT_CADENCE_NETLIST_DESCRIPTION,
       annotations: WRITES_TO_DISK,
-      inputSchema: {
+      inputSchema: z.strictObject({
         design: z.string().describe("Path to .DSN schematic file"),
-      },
+      }),
     },
     withTelemetry("export_cadence_netlist", async ({ design }) => {
       const result = await exportCadenceNetlist(design);


### PR DESCRIPTION
## Summary

Every tool declared its inputs as a plain shape. The SDK wraps a shape in an object that **strips** what it does not recognise, so a misspelled argument arrives as no argument at all. Where that argument is optional, the tool runs its default and answers a question nobody asked, in a well-formed result whose every value is real and which says nothing about which question it answers.

I found this by making the mistake twice against this server, in the same session, on two different tools:

- `search_path` instead of `path` on `list_designs` searched the server's working directory and returned 50 designs out of a 41,105-project corpus, in answer to a question about a Cadence fixture tree.
- `rules` instead of `include_rules` on `run_erc` ran all four rules and reported that as the selection.

The second is pointed. `run_erc` already refuses a rule id it does not know, with a comment explaining exactly why:

```ts
// Reject typo'd rule ids: otherwise include_rules: ["net.singel_pin"] yields
// checked: [] with no findings, which an agent reads as "design is clean".
```

That is the same class of mistake one level down, and the tool was defenceless against it.

`list_designs` has an extra trap: the tool argument is `path`, but the function behind it takes `searchPath`, so the wrong guess is the right name one layer down.

## Changes

- All 12 tools declared with `z.strictObject` instead of a raw shape. An unrecognised argument is now an error naming it, and the published JSON Schema carries `additionalProperties: false` so a client is told rather than left to infer it from the answer.
- `@modelcontextprotocol/sdk` `^1.25.2` → `^1.30.0`, `zod` `^4.1.12` → `^4.4.3`. Both lockfiles regenerated in this commit.

The dependency bump is in the same PR deliberately: the stripping behaviour lives in the SDK's zod-compat layer, so the fix and the version it is verified against belong together. I checked the behaviour on the previously installed pair (SDK 1.27.1 / Zod 4.3.6) and on the new one (1.30.0 / 4.4.3) before committing to the approach; identical on both, with a cleaner message on the newer.

Before and after, same call:

```
list_designs({ search_path: "/tmp" })
  before  ->  { root: "<server cwd>", designs: [ ...50 real designs... ] }
  after   ->  MCP error -32602: Unrecognized key: "search_path"
```

## What this does not change

A misspelled **required** argument already failed loudly, because stripping it leaves the field undefined and a required field rejects that. Only optional arguments degraded silently, which is why both of my mistakes landed there. Nothing about correct calls changes.

## Relationship to #165

#165 made the consequence visible on one tool by reporting `root`. That is still worth having, since it says which directory a search actually ran in even when the call was well formed. This closes the underlying gap for all twelve.

## Testing

- [x] Added/updated tests
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (901 passed, 11 skipped)

Four new tests in `server.test.ts`, which already stands a real server up over `InMemoryTransport` and reads the tool list off the wire:

- every tool publishes `additionalProperties: false`, so a tool added later that forgets is caught
- `list_designs` refuses `search_path`, naming it
- `run_erc` refuses `rules`, naming it
- the arguments a tool does define still work

The two refusal tests use the mistakes actually made, with comments recording why each was invisible.

Handler type inference needed no annotations: `z.strictObject` infers exactly as a raw shape does, and `tsc --noEmit --strict` is clean.

Verified natively over a real stdio MCP connection across all 40 fixtures in the pinned submodule (14 Cadence, 16 Altium, 10 KiCad), 371 tool calls, zero problems, plus a probe confirming each of the 12 tools refuses an undefined argument and names it:

```
12 tools refuse undefined arguments
designs: 40   tool calls: 371   problems: 0
CLEAN
```

## Changelog

- A tool now refuses an argument its schema does not define, rather than dropping it. Every tool declared its inputs as a plain shape, which is parsed by an object that strips what it does not recognise, so a misspelled argument arrived as no argument: `list_designs` given `search_path` instead of `path` searched the server's working directory, and `run_erc` given `rules` instead of `include_rules` ran every rule and reported that as the selection. Both returned well-formed results with nothing in them to check. Misspelling a required argument always failed loudly; only optional ones were silent, and correct calls are unaffected. Each tool's published schema now carries `additionalProperties: false`, so a client is told the tool is closed to arguments it does not define.
- `@modelcontextprotocol/sdk` moves to 1.30.0 and `zod` to 4.4.3.
