### PR TITLE
fix: list_components suggests only prefixes it would return, and says when a prefix is all DNS

### DIFF
--- a/docs/schemas/shared-types.md
+++ b/docs/schemas/shared-types.md
@@ -430,6 +430,7 @@ The `notes` field provides contextual information:
 |------|---------|
 | `"MPN not found in exported netlist data..."` | Component lacks MPN; suggest user provide BOM |
 | `"No nets matched pattern '...'"` | Search returned empty results |
+| `"All N components with prefix '...' ... are DNS ..."` | `list_components` found the prefix, but every part under it is DNS; pass `include_dns: true` |
 | `"This netlist has no MPN data..."` | Design has no MPN information |
 
 ## Case Sensitivity

--- a/docs/tools/list_components.md
+++ b/docs/tools/list_components.md
@@ -6,7 +6,7 @@ List components of a specific type in a design.
 
 Lists the components whose reference designator prefix is exactly `type` (e.g., `U` for ICs, `R` for resistors). Components are grouped by MPN for compact output.
 
-The prefix is matched whole, not as a leading substring: `U` returns `U1` and `U2` but **not** `USB1`, whose prefix is `USB`. A partial prefix therefore returns nothing rather than everything beneath it, so a part that seems to be missing is usually filed under a prefix of its own. The error for an unmatched type lists every prefix the design actually has.
+The prefix is matched whole, not as a leading substring: `U` returns `U1` and `U2` but **not** `USB1`, whose prefix is `USB`. A partial prefix therefore returns nothing rather than everything beneath it, so a part that seems to be missing is usually filed under a prefix of its own. The error for an unmatched type lists the prefixes the same query would return, and names apart any prefix whose components are all DNS (those need `include_dns: true`).
 
 ## Input Parameters
 
@@ -18,11 +18,12 @@ The prefix is matched whole, not as a leading substring: `U` returns `U1` and `U
 
 ## Response Schema
 
-Returns an array of [`ComponentGroup`](../schemas/shared-types.md#componentgroup) objects:
+Returns an array of [`ComponentGroup`](../schemas/shared-types.md#componentgroup) objects, with a `notes` array when the list is empty because every component under the prefix is DNS:
 
 ```json
 {
-  "components": [ComponentGroup, ...]
+  "components": [ComponentGroup, ...],
+  "notes": ["string"]
 }
 ```
 
@@ -70,7 +71,15 @@ Response:
 **Error (invalid prefix):**
 ```json
 {
-  "error": "No components with prefix 'X' found in design 'PowerBoard'. Available prefixes: [C, D, FB, J, L, Q, R, RS, U]"
+  "error": "No components with prefix 'X' found in design 'PowerBoard'. Available prefixes: [C, D, FB, J, L, Q, R, RS, U] Prefixes whose components are all DNS, listed only with include_dns=true: [TP]"
+}
+```
+
+**Every component under the prefix is DNS:**
+```json
+{
+  "components": [],
+  "notes": ["All 7 components with prefix 'TP' in design 'PowerBoard' are DNS (Do Not Stuff) and were left out. Pass include_dns=true to list them."]
 }
 ```
 
@@ -80,7 +89,7 @@ Response:
 - `type` matches the whole prefix, so `U` does not return `USB1`, and `TP` returns the test points. Query each prefix you need, or read the list the unmatched-type error gives you
 - Components are grouped by MPN; components without MPN are listed individually
 - Components without MPN include a `notes` field suggesting next steps
-- Use `include_dns: true` to see DNS components (marked with `dns: true`)
+- Use `include_dns: true` to see DNS components (marked with `dns: true`). A prefix whose components are all DNS returns an empty list with a `notes` entry saying so, and the unmatched-type error lists such prefixes apart from the ones the query would return
 
 ## See Also
 

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -76,7 +76,9 @@ expected is missing, look for it under its own prefix. \
 Identical components are grouped for compact output: parts share a group only when their \
 MPN, description, comment and value all agree, so every field a group reports is true of \
 every part in it. A group whose parts carry no MPN says so in its notes. \
-If no components match, the error lists every prefix the design does have.`;
+If no components match, the error lists the prefixes the same query would return, and \
+names apart any prefix whose components are all DNS. A prefix whose components are all \
+DNS returns an empty list with a note saying so; pass include_dns=true to list them.`;
 
 export const LIST_NETS_DESCRIPTION = `\
 List all net names in a design, sorted alphabetically. \

--- a/src/service/tools/list-components.test.ts
+++ b/src/service/tools/list-components.test.ts
@@ -99,3 +99,77 @@ describe("listComponents - available prefixes suggestion", () => {
     expect((result as ListComponentsResult).components.flatMap((c) => c.refdes)).toContain("U1");
   });
 });
+
+// Issue #169: the unmatched-type error suggested prefixes that the same
+// query, at the same default, then returned nothing for; and a prefix whose
+// parts are all DNS came back as a bare empty list, which reads as "none".
+describe("listComponents - DNS and the suggestion list", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const netlist: ParsedNetlist = {
+    nets: { VDD: { U1: ["1"], R1: ["1"], TP1: ["1"], TP2: ["1"] } },
+    components: {
+      U1: { mpn: "PART-1", pins: { "1": "VDD" } },
+      R1: { value: "1k", dns: true, pins: { "1": "VDD" } },
+      R2: { value: "2k", pins: { "1": "" } },
+      TP1: { description: "TEST POINT", dns: true, pins: { "1": "VDD" } },
+      TP2: { description: "TEST POINT", dns: true, pins: { "1": "VDD" } },
+    },
+  };
+
+  beforeEach(() => mockParse(netlist));
+
+  it("suggests only prefixes the same query would return, and names the DNS-only ones apart", async () => {
+    const result = await listComponents(DESIGN, "X");
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toBe(
+      "No components with prefix 'X' found in design 'design'. Available prefixes: [R, U] " +
+        "Prefixes whose components are all DNS, listed only with include_dns=true: [TP]"
+    );
+  });
+
+  it("suggests every prefix when include_dns is true, with no DNS clause", async () => {
+    const result = await listComponents(DESIGN, "X", true);
+    expect(isErrorResult(result)).toBe(true);
+    expect((result as ErrorResult).error).toBe(
+      "No components with prefix 'X' found in design 'design'. Available prefixes: [R, TP, U]"
+    );
+  });
+
+  it("says so when every component under the prefix is DNS", async () => {
+    const result = await listComponents(DESIGN, "TP");
+    expect(isErrorResult(result)).toBe(false);
+    expect(result).toEqual({
+      components: [],
+      notes: [
+        "All 2 components with prefix 'TP' in design 'design' are DNS (Do Not Stuff) and were left out. Pass include_dns=true to list them.",
+      ],
+    });
+  });
+
+  it("lists the DNS-only prefix with include_dns=true", async () => {
+    const result = (await listComponents(DESIGN, "TP", true)) as ListComponentsResult;
+    expect(result.notes).toBeUndefined();
+    expect(result.components.flatMap((c) => c.refdes).sort()).toEqual(["TP1", "TP2"]);
+    expect(result.components.every((c) => c.dns === true)).toBe(true);
+  });
+
+  it("adds no note when some parts under the prefix are stuffed", async () => {
+    const result = (await listComponents(DESIGN, "R")) as ListComponentsResult;
+    expect(result.notes).toBeUndefined();
+    expect(result.components.flatMap((c) => c.refdes)).toEqual(["R2"]);
+  });
+
+  it("the DNS clause is absent when no prefix is DNS-only", async () => {
+    mockParse({
+      nets: {},
+      components: { U1: { pins: {} }, C1: { dns: true, pins: {} }, C2: { pins: {} } },
+    });
+    const result = await listComponents(DESIGN, "X");
+    expect((result as ErrorResult).error).toBe(
+      "No components with prefix 'X' found in design 'design'. Available prefixes: [C, U]"
+    );
+  });
+});

--- a/src/service/tools/list-components.ts
+++ b/src/service/tools/list-components.ts
@@ -29,27 +29,51 @@ export const listComponents = async (
   const entries = Object.entries(netlist.components).filter(([refdes]) =>
     matchesRefdesType(refdes, prefix)
   );
+  const designName = getDesignName(design);
 
   if (entries.length === 0) {
     // Derive the suggestion list with the same prefix logic the matcher uses
     // (getRefdesPrefix), so it can never contradict a query. Filtering to
     // purely-alphabetic prefixes drops Cadence-path junk ("@DESIGN…") and
     // numeric-only keys, while keeping unannotated refdes ("C?" -> "C").
-    const availablePrefixes = Array.from(
-      new Set(
-        Object.keys(netlist.components)
-          .map(getRefdesPrefix)
-          .filter((p) => /^[A-Z]+$/.test(p))
-      )
-    ).sort((a, b) => a.localeCompare(b));
+    //
+    // A prefix is suggested only if querying it with the same include_dns
+    // would return something. A prefix whose every part is DNS is listed
+    // apart, with the argument that reaches it, so the suggestion never
+    // points at a query that comes back empty.
+    const stuffed = new Set<string>();
+    const dnsOnly = new Set<string>();
+    for (const [refdes, component] of Object.entries(netlist.components)) {
+      const candidate = getRefdesPrefix(refdes);
+      if (!/^[A-Z]+$/.test(candidate)) continue;
+      if (includeDns || !component.dns) stuffed.add(candidate);
+      else dnsOnly.add(candidate);
+    }
+    for (const candidate of stuffed) dnsOnly.delete(candidate);
+    const sorted = (set: Set<string>): string => [...set].sort((a, b) => a.localeCompare(b)).join(", ");
 
-    const designName = getDesignName(design);
+    const dnsClause =
+      dnsOnly.size > 0
+        ? ` Prefixes whose components are all DNS, listed only with include_dns=true: [${sorted(dnsOnly)}]`
+        : "";
     return {
-      error: `No components with prefix '${prefix}' found in design '${designName}'. Available prefixes: [${availablePrefixes.join(", ")}]`,
+      error: `No components with prefix '${prefix}' found in design '${designName}'. Available prefixes: [${sorted(stuffed)}]${dnsClause}`,
     };
   }
 
-  return {
-    components: groupComponentsByMpn(entries, includeDns),
-  };
+  const components = groupComponentsByMpn(entries, includeDns);
+
+  // The prefix exists, and every part under it is DNS. An empty list here
+  // reads as "the design has none", which is the opposite of the truth, so
+  // the result says what it left out and how to see it.
+  if (components.length === 0) {
+    return {
+      components,
+      notes: [
+        `All ${entries.length} components with prefix '${prefix}' in design '${designName}' are DNS (Do Not Stuff) and were left out. Pass include_dns=true to list them.`,
+      ],
+    };
+  }
+
+  return { components };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,7 @@ export interface ComponentGroup {
  */
 export interface ListComponentsResult {
   components: ComponentGroup[];
+  notes?: string[];
 }
 
 /**


### PR DESCRIPTION
Closes #169

## Summary
- The unmatched-type error listed every prefix in the design, DNS parts included, while the query leaves DNS parts out unless `include_dns=true`, so it could suggest a prefix that then returned nothing. The suggestion list is now built with the same `include_dns` the query used; prefixes whose components are all DNS are named apart, with the argument that reaches them
- A prefix that exists but whose components are all DNS no longer answers with a bare `{"components": []}`. The result carries a `notes` entry: how many parts were left out and that `include_dns=true` lists them. `ListComponentsResult` gains the optional `notes` field other tools already use
- Tool description and docs updated to match

## Test plan
- [x] `npm run type-check && npm run lint && npm test`
- [x] Unit: suggestion list excludes DNS-only prefixes at the default and names them apart; includes them with `include_dns=true`; all-DNS prefix returns the note; partial-DNS prefix returns no note; no DNS clause when no prefix is DNS-only

## Changelog
- `list_components`: the unmatched-type error suggests only prefixes the same query would return and names apart those whose components are all DNS; a prefix whose components are all DNS returns an empty list with a note saying so instead of a silent empty list (#169)