### PR TITLE
feat(cli): document export-json and take an output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ The server checks for updates on startup. To update manually:
 universal-netlist update
 ```
 
+### Export a design to JSON
+
+```bash
+universal-netlist export-json MyBoard.kicad_pro          # writes ./MyBoard.json
+universal-netlist export-json MyBoard.DSN out/board.json
+```
+
+Writes the design's netlist in the [Universal Netlist schema](docs/schemas/universal-netlist.md). The written file is itself a design: `list_designs` finds it and every tool reads it, so an export is a snapshot you can query, diff, or hand to another tool.
+
 ## Alternative: Install via npm
 
 For developers who prefer npm:

--- a/docs/schemas/universal-netlist.md
+++ b/docs/schemas/universal-netlist.md
@@ -260,7 +260,7 @@ This reduces output size by ~30% for typical designs while preserving important 
 
 ## Loading a Universal Netlist file
 
-A `.json` file in this schema is itself a design: `list_designs` discovers it, and every tool accepts its path. `--export-json` writes this format, so an exported design round-trips.
+A `.json` file in this schema is itself a design: `list_designs` discovers it, and every tool accepts its path. `universal-netlist export-json <design> [output.json]` writes this format, so an exported design round-trips.
 
 The file is validated on load, because the EDA parsers build a consistent netlist by construction and a file may have been written or edited by anyone. A file is refused, naming the first defect, when:
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -62,6 +62,8 @@ Commands:
   update|upgrade       Check for updates and install if available
   uninstall            Remove the binary and its PATH entries
   export-telemetry     Export telemetry data as a zip file
+  export-json <design> [out]
+                       Write a design's netlist as Universal Netlist JSON
   coverage [path]      Compare DSN parser output against DAT netlist exports
 
 Installation:
@@ -205,19 +207,32 @@ export const handleExportTelemetryCommand = async (): Promise<void> => {
 };
 
 /**
- * Handle --export-json command.
- * Parses a design file and writes the universal netlist JSON to cwd.
+ * Handle the export-json command.
+ *
+ * Parses a design file and writes its netlist as Universal Netlist JSON
+ * (docs/schemas/universal-netlist.md), to `<design>.json` in the working
+ * directory or to the given output path. The written file is itself a design
+ * every tool reads.
  */
-export const handleExportJsonCommand = async (designPath?: string): Promise<void> => {
+export const handleExportJsonCommand = async (
+  designPath?: string,
+  outPath?: string
+): Promise<void> => {
   if (!designPath) {
-    console.error("Usage: universal-netlist export-json <path>");
+    console.error("Usage: universal-netlist export-json <design> [output.json]");
     process.exit(1);
   }
 
   const absolutePath = resolve(designPath);
-  const result = await parseDesign(absolutePath);
+  let result;
+  try {
+    result = await parseDesign(absolutePath);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
   const name = basename(absolutePath, extname(absolutePath));
-  const outFile = resolve(`${name}.json`);
+  const outFile = resolve(outPath ?? `${name}.json`);
   writeFileSync(outFile, JSON.stringify(result, null, 2) + "\n");
   console.log(outFile);
 };

--- a/src/cli/export-json.test.ts
+++ b/src/cli/export-json.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { handleExportJsonCommand } from "./commands.js";
+import { parseUniversalNetlist } from "../parsers/universal/reader.js";
+
+const TEST_DIR = path.dirname(new URL(import.meta.url).pathname);
+const DEMO = path.resolve(TEST_DIR, "../../test/universal/demo-board.netlist.json");
+
+describe("handleExportJsonCommand", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes the netlist to the given output path and prints it", async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "export-json-"));
+    const out = path.join(dir, "board.json");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleExportJsonCommand(DEMO, out);
+
+    expect(log).toHaveBeenCalledWith(out);
+    const written = await readFile(out, "utf-8");
+    // The export is itself a loadable Universal Netlist.
+    const netlist = parseUniversalNetlist(written, "board.json");
+    expect(netlist.components.U1.mpn).toBe("REG-3V3-SOT23");
+    expect(netlist.components.D1.dns).toBe(true);
+  });
+
+  it("defaults the output to <design>.json in the working directory", async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "export-json-"));
+    const previous = process.cwd();
+    process.chdir(dir);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await handleExportJsonCommand(DEMO);
+    } finally {
+      process.chdir(previous);
+    }
+
+    const expected = path.join(await realpath(dir), "demo-board.netlist.json");
+    expect(log).toHaveBeenCalledWith(expected);
+    expect(JSON.parse(await readFile(path.join(dir, "demo-board.netlist.json"), "utf-8")).components.U1.mpn).toBe(
+      "REG-3V3-SOT23"
+    );
+  });
+
+  it("exits with the usage line when no design is given", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+
+    await expect(handleExportJsonCommand()).rejects.toThrow("exit");
+    expect(error).toHaveBeenCalledWith("Usage: universal-netlist export-json <design> [output.json]");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with the parser's message on a design that does not load", async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "export-json-"));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+
+    const broken = path.resolve(TEST_DIR, "../../test/universal/broken/pin-on-other-net.json");
+    await expect(handleExportJsonCommand(broken, path.join(dir, "x.json"))).rejects.toThrow("exit");
+    expect(error).toHaveBeenCalledWith(
+      "pin-on-other-net.json: net 'VCC' lists C1.1, but C1.1 is on 'GND'"
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+const realpath = async (p: string): Promise<string> => {
+  const { realpath } = await import("node:fs/promises");
+  return realpath(p);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
  *   update|upgrade     Check for and install updates
  *   uninstall          Remove binary and PATH entries
  *   export-telemetry   Export telemetry data as a zip file
+ *   export-json <design> [out]  Write a design's netlist as Universal Netlist JSON
  *   coverage [path]    Compare DSN parser output against DAT netlist exports
  */
 
@@ -64,10 +65,11 @@ const main = async (): Promise<void> => {
     return;
   }
 
-  // Handle --export-json <path>
+  // Handle export-json <design> [output.json]
   if (args.includes("--export-json")) {
     const idx = args.indexOf("--export-json");
-    await handleExportJsonCommand(args[idx + 1]);
+    const outArg = args[idx + 2];
+    await handleExportJsonCommand(args[idx + 1], outArg?.startsWith("--") ? undefined : outArg);
     return;
   }
 


### PR DESCRIPTION
## Summary
- `export-json` is a documented command: listed in `help` (`export-json <design> [out]`), shown in the README with a short section, and named in the schema doc's round-trip note
- Takes an optional output path; without one it writes `<design>.json` into the working directory as before, and it prints the path it wrote either way
- A design that does not load exits 1 with the parser's message (it used to surface as an unhandled `Server error:`)

## Test plan
- [x] `npm run type-check && npm run lint && npm test`
- [x] Unit: writes to the given path and the written file is a loadable Universal Netlist; defaults to `<design>.json` in cwd; usage line without a design; parser message and exit 1 on a broken design
- [x] Smoke: `node --import tsx src/index.ts export-json test/universal/demo-board.netlist.json $TMPDIR/demo-out.json`

## Changelog
- CLI: `export-json` is a documented command: `universal-netlist export-json <design> [output.json]` writes the design's netlist in the Universal Netlist schema. The written file is itself a design every tool reads, so an export round-trips