### PR TITLE
docs: document the command line in docs/cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ universal-netlist export-json MyBoard.kicad_pro          # writes ./MyBoard.json
 universal-netlist export-json MyBoard.DSN out/board.json
 ```
 
-Writes the design's netlist in the [Universal Netlist schema](docs/schemas/universal-netlist.md). The written file is itself a design: `list_designs` finds it and every tool reads it, so an export is a snapshot you can query, diff, or hand to another tool.
+Writes the design's netlist in the [Universal Netlist schema](docs/schemas/universal-netlist.md). The written file is itself a design: `list_designs` finds it and every tool reads it, so an export is a snapshot you can query, diff, or hand to another tool. The command line is documented in [docs/cli.md](docs/cli.md).
 
 ## Alternative: Install via npm
 
@@ -134,7 +134,7 @@ See **[Observability (OpenTelemetry)](docs/observability.md)** for setup, config
 
 ## Documentation
 
-See [docs/](docs/README.md) for API documentation and response schemas.
+See [docs/](docs/README.md) for API documentation and response schemas, and [docs/cli.md](docs/cli.md) for the binary's command line.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,10 @@ The schema captures identification (MPN, description) but not electrical specifi
 
 To get the most out of this MCP, follow the recommended [Net Naming Conventions](net-naming-conventions.md) when naming nets and marking DNS components in your schematics. Net names drive power/ground detection, circuit traversal stop behavior, and `search_nets` pattern matching.
 
+## Command Line
+
+The binary's commands (`export-json`, `update`, `uninstall`, `export-telemetry`, `coverage`) are documented in [cli.md](cli.md). `export-json` writes a design as a Universal Netlist JSON file, which is itself a design every tool reads.
+
 ## Observability
 
 The server can emit OpenTelemetry traces, metrics, and logs for every tool call, so you can integrate your own OTel service. It is disabled by default and configured entirely through standard `OTEL_*` environment variables. See [Observability (OpenTelemetry)](observability.md) for setup and the full list of emitted spans, metrics, and logs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,71 @@
+# Command Line
+
+The `universal-netlist` binary is an MCP server: run with no command, it serves the [tools](README.md) over stdio and is meant to be started by an MCP client. Everything else it can do is a command. Every command is accepted as a word (`universal-netlist update`) and as a flag (`universal-netlist --update`); the pages below use the word form.
+
+```
+Usage: universal-netlist [options] [command]
+
+Options:
+  -v, --version        Output the version number
+  -h, --help           Display help for command
+  --verbose            Show per-design field mismatch breakdowns (with coverage)
+
+Commands:
+  update|upgrade       Check for updates and install if available
+  uninstall            Remove the binary and its PATH entries
+  export-telemetry     Export telemetry data as a zip file
+  export-json <design> [out]
+                       Write a design's netlist as Universal Netlist JSON
+  coverage [path]      Compare DSN parser output against DAT netlist exports
+```
+
+## export-json
+
+```bash
+universal-netlist export-json <design> [output.json]
+```
+
+Parses a design and writes its netlist as one JSON file in the [Universal Netlist schema](schemas/universal-netlist.md). `<design>` is any file the server reads: a Cadence `.DSN`, an Altium `.PrjPcb`, a KiCad `.kicad_pro`, or a Universal Netlist `.json` itself. Without `[output.json]` the file is written as `<design>.json` in the working directory; either way the path written is printed on stdout.
+
+The written file is itself a design: `list_designs` finds it and every tool reads it, so an export round-trips. That makes it a snapshot you can commit, diff between revisions, or hand to another tool, with no EDA installation on the receiving side.
+
+```bash
+universal-netlist export-json MyBoard.kicad_pro          # writes ./MyBoard.json
+universal-netlist export-json MyBoard.DSN out/board.json
+```
+
+A design that does not load exits 1 and prints the parser's message, naming the first defect.
+
+## update
+
+```bash
+universal-netlist update    # upgrade works too
+```
+
+Checks GitHub for a newer release and replaces the binary in place. The server also checks on startup. A binary installed by a package manager (Homebrew, npm, a distro package) is managed by that manager, and this command says so instead of touching the file; npm installs update with `npm update -g @intelligentelectron/universal-netlist`.
+
+## uninstall
+
+```bash
+universal-netlist uninstall
+```
+
+Removes the binary and the PATH entries `install.sh` added to the shell profile. A package-managed install is removed by its package manager, and the command says so.
+
+## export-telemetry
+
+```bash
+universal-netlist export-telemetry
+```
+
+Writes the locally recorded [telemetry](observability.md) as a zip file in the working directory. Telemetry is off by default; this exports only what `OTEL_*` configuration recorded.
+
+## coverage
+
+```bash
+universal-netlist coverage [path] [verbose]
+```
+
+For every Cadence design under `path` (default: the working directory) that has both a `.DSN` schematic and exported `.dat` netlist files, parses both and writes a markdown report to the working directory comparing them. `verbose` adds per-design field mismatch breakdowns. This is a parser-development tool: the `.dat` files are the reference the `.DSN` parser is measured against.
+
+The one ambiguity the word forms carry: a token right after `coverage` is read as its path unless it is itself a command word, so a directory literally named `verbose` is given as `./verbose`. The value after `export-json` is always a path.


### PR DESCRIPTION
Follow-up to #176 (a queued branch cannot take another commit).

## Summary
- `docs/cli.md`: one page for the binary's command line: `export-json`, `update|upgrade`, `uninstall`, `export-telemetry`, `coverage`, each with usage, output, and exit behaviour; `export-json` gets the fullest section (default filename, output path, round-trip)
- Linked from the README's Documentation section and export section, and from `docs/README.md` as a "Command Line" section

## Test plan
- [x] Docs only; links verified relative to `docs/`

## Changelog
- Docs: the binary's command line has its own page, `docs/cli.md`, linked from the README and the docs index