### PR TITLE
docs(cli): say who runs the server, not what running it does

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # Command Line
 
-The `universal-netlist` binary is an MCP server: run with no command, it serves the [tools](README.md) over stdio and is meant to be started by an MCP client. Everything else it can do is a command. Every command is accepted as a word (`universal-netlist update`) and as a flag (`universal-netlist --update`); the pages below use the word form.
+The `universal-netlist` binary is an MCP server: an MCP client runs it with no command and speaks to it over stdio. Run by hand with no command, it prints how to set that up instead of serving. Everything else it can do is a command. Every command is accepted as a word (`universal-netlist update`) and as a flag (`universal-netlist --update`); the pages below use the word form.
 
 ```
 Usage: universal-netlist [options] [command]

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -51,7 +51,8 @@ ${BINARY_NAME} v${VERSION}
 Usage: ${BINARY_NAME} [options] [command]
 
 MCP server for querying EDA netlists: Cadence, Altium Designer, KiCad, and Universal Netlist JSON.
-Run with no command to start the server over stdio.
+An MCP client runs the binary with no command and speaks to it over stdio; the commands
+below are what you run by hand.
 
 Options:
   -v, --version        Output the version number


### PR DESCRIPTION
## Summary
- The help header said "Run with no command to start the server over stdio", but running it by hand in a terminal prints the setup hint instead; the server only serves when an MCP client spawns it. The sentence in `help` and the matching one in `docs/cli.md` now say that

## Test plan
- [x] `npm run type-check`; CLI tests pass; `help` output reads correctly

## Changelog
- CLI: the help header no longer implies running the binary by hand starts the server; an MCP client's spawn does