### PR TITLE
chore: v1.7.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-08-23
+
+### Changed
+
+- CLI: the help header no longer implies that running the binary by hand starts the server. An MCP client's spawn serves over stdio; run by hand with no command, the binary prints how to set that up. Same correction in `docs/cli.md` (PR #180)
+
 ## [1.7.1] - 2026-08-23
 
 Every command is now a word as well as a flag: `universal-netlist update` and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intelligentelectron/universal-netlist",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `CHANGELOG.md`: 1.7.2 section from #180's Changelog section
- `npm version patch --no-git-tag-version`: 1.7.1 → 1.7.2

Patch bump: one help-copy correction.

## Test plan
- [ ] CI green
- [ ] After merge: `scripts/tag-release.sh --yes` on `main`