### PR TITLE
fix(cadence): parse Port and DrawnInstance page records

### DIFF
--- a/docs/dsn-format.md
+++ b/docs/dsn-format.md
@@ -219,6 +219,7 @@ The full list is `src/parsers/cadence/dsn/structure-types.ts`, ported from `Enum
 | `0x06` | 6 | PartCell | Part cell in Package streams | no |
 | `0x0A` | 10 | Page | Page-level wrapper | yes |
 | `0x0B` | 11 | PartInstance | Part instance (unused by us) | no |
+| `0x0C` | 12 | DrawnInstance | Hierarchical drawn page instance | no |
 | `0x0D` | 13 | PlacedInstance | Component placed on schematic | yes |
 | `0x10` | 16 | T0x10 | Pin instance on a placed component | yes |
 | `0x14` | 20 | WireScalar | Single-signal wire | yes |
@@ -335,9 +336,9 @@ uint16    len_net_table
 uint16    len_wires
           Wire[] sub-records (see 7.6)
 uint16    len_placed_instances
-          PlacedInstance[] sub-records (see 7.7)
+          DrawnInstance or PlacedInstance sub-records (see 7.7)
 uint16    len_ports
-          Port[] sub-records + 5 unknown bytes each (see 7.8)
+          Port[] sub-records (see 7.8)
 uint16    len_globals
           Global[] sub-records + 5 unknown bytes each (see 7.8)
 uint16    len_off_page_connectors
@@ -552,7 +553,7 @@ No-connect is therefore inferred, not read: a pin is called NC when `net_id == 0
 
 ### 7.8 GraphicInst (Global, Port, OffPageConnector)
 
-**Confidence: VERIFIED (layout), OBSERVED (5 trailing bytes)**
+**Confidence: VERIFIED (layout), OBSERVED (5 trailing bytes on Global/OPC)**
 
 Global (type 0x25), Port (type 0x17), and OffPageConnector (type 0x26) share a common base structure:
 
@@ -585,7 +586,7 @@ BODY:
 
 A **Port** carries **9 further unknown bytes** after that checkpoint, which Global and OffPageConnector do not. Those bytes are inside the structure, unlike the five described next.
 
-After each Port, Global, or OffPageConnector record, there are **5 unknown bytes** that are not part of the structure itself. These are read separately in the page parser.
+After each Global or OffPageConnector record, there are **5 unknown bytes** that are not part of the structure itself. These are read separately in the page parser. Ports do not carry this outer five-byte trailer; their only trailing unknown data is the nine bytes inside the Port structure.
 
 **VERIFIED**: OPCs sharing the same `name_str_idx` represent the same net across pages. For Globals/Ports, `name_str_idx` resolves to the power/ground net name (e.g., "VCC_3V3", "GND"). The parser calls this field `pairingId`, the name it goes by in section 12.4.
 
@@ -1303,7 +1304,7 @@ Each unknown area in the format is mapped to its impact on parser coverage. PinN
 |---|---|---|---|---|
 | **PlacedInstance 10 unknown bytes** (section 7.7) | 10 per component | None | None | None observed; may encode a secondary value reference or CIS link |
 | **Port 9 trailing bytes** (section 7.8) | 9 per port | None | None | None |
-| **Port/Global/OPC 5 trailing bytes** (section 7.8) | 5 per symbol | None | None | None |
+| **Global/OPC 5 trailing bytes** (section 7.8) | 5 per symbol | None | None | None |
 | **Hierarchy 24-byte metadata** (section 8) | 24 per net | None | None | None |
 | **T0x10 unknown_int** (section 7.7.1) | 4 per pin | None | None | None |
 | **Page tail after OPCs** (section 7) | Variable | None | None | None |
@@ -1316,6 +1317,7 @@ Each unknown area in the format is mapped to its impact on parser coverage. PinN
 | Bus entries | Bus connection points |
 | Bus wires | Wire type 0x15 is accepted but buses aren't traced |
 | CIS streams | CIS database link information |
+| DrawnInstance bodies | Hierarchical page instances are skipped via their prefix boundaries |
 | Graphical primitives | Shapes inside LibraryPart (lines, rects, arcs) |
 | Title block contents | Skipped entirely |
 | Page sections after OPCs | Everything after OffPageConnectors in the page stream |
@@ -1339,7 +1341,7 @@ Each unknown area in the format is mapped to its impact on parser coverage. PinN
 | GraphicInst | Second uint32 | 4 | Constant per design, purpose unknown |
 | GraphicInst | After bbox | 4 | color + 3 unknown bytes |
 | Port | End of structure | **9** | Port-specific; Global and OPC have no equivalent |
-| Port/Global/OPC | After each record | **5** | Not part of the structure; could contain net reference |
+| Global/OPC | After each record | **5** | Not part of the structure; could contain net reference |
 | LibraryPart | After checkpoint 1 | 4 | Before len_primitives |
 | SymbolPin | After pin_shape | 2 | Unknown |
 | SymbolPin | After port_type | 4 | Unknown |
@@ -1355,7 +1357,7 @@ Each unknown area in the format is mapped to its impact on parser coverage. PinN
 | Hierarchy 0x43 scan | Medium | Wrong net count, corrupt net names |
 | PageSettings = 156 bytes | Low | Parse offset error for everything after it |
 | LOGFONTA = 60 bytes | Low | Wrong strLst offset, corrupt string table |
-| 5 unknown bytes after Port/Global/OPC | Medium | Parse offset error for subsequent records |
+| 5 unknown bytes after Global/OPC | Medium | Parse offset error for subsequent records |
 | 9 unknown bytes at the end of a Port | Medium | Parse offset error for subsequent records |
 | some_len = 24 (Library stream) | Low | Wrong strLst offset |
 | Cache scan bounds (64 pairs, 10 long prefixes) | Low | A wider prefix chain goes unrecovered; the parse throws rather than misreads |

--- a/src/parsers/cadence/dsn/page-parser.test.ts
+++ b/src/parsers/cadence/dsn/page-parser.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { parsePage } from "./page-parser.js";
+import { StructureType } from "./structure-types.js";
+
+const uint16 = (value: number): Buffer => {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value);
+  return buffer;
+};
+
+const int16 = (value: number): Buffer => {
+  const buffer = Buffer.alloc(2);
+  buffer.writeInt16LE(value);
+  return buffer;
+};
+
+const uint32 = (value: number): Buffer => {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+};
+
+const stringLenZeroTerm = (value: string): Buffer =>
+  Buffer.concat([
+    uint16(Buffer.byteLength(value, "ascii")),
+    Buffer.from(value, "ascii"),
+    Buffer.alloc(1),
+  ]);
+
+const shortPrefix = (type: StructureType): Buffer => Buffer.from([type, 0x00, 0x00]);
+
+const emptyBoundedStructure = (type: StructureType): Buffer => {
+  const longPrefix = Buffer.alloc(9);
+  longPrefix[0] = type;
+  longPrefix.writeUInt32LE(3, 1); // Stop immediately after the following short prefix.
+  return Buffer.concat([longPrefix, shortPrefix(type)]);
+};
+
+const port = (pairingId: number, dbId: number): Buffer =>
+  Buffer.concat([
+    shortPrefix(StructureType.Port),
+    uint32(pairingId),
+    uint32(0), // library string index
+    stringLenZeroTerm("PORT"),
+    uint32(dbId),
+    int16(20), // locY
+    int16(10), // locX
+    int16(21), // y2
+    int16(11), // x2
+    int16(9), // x1
+    int16(19), // y1
+    Buffer.alloc(4), // color and unknown bytes
+    uint16(0), // SymbolDisplayProp count
+    Buffer.from([0x00]), // unknown flag
+    Buffer.alloc(9), // Port-specific trailing bytes
+  ]);
+
+const placedInstance = (reference: string): Buffer =>
+  Buffer.concat([
+    shortPrefix(StructureType.PlacedInstance),
+    Buffer.alloc(8),
+    stringLenZeroTerm("RES.Normal"),
+    uint32(1234),
+    Buffer.alloc(8),
+    int16(100),
+    int16(200),
+    Buffer.alloc(4),
+    uint16(0), // SymbolDisplayProp count
+    Buffer.alloc(1),
+    stringLenZeroTerm(reference),
+    uint32(0), // part value string index
+    Buffer.alloc(10),
+    uint16(0), // pin instance count
+    stringLenZeroTerm("RES"),
+    uint16(0), // section index
+  ]);
+
+const page = (instances: Buffer[], ports: Buffer[]): Buffer =>
+  Buffer.concat([
+    shortPrefix(StructureType.Page),
+    stringLenZeroTerm("Synthetic"),
+    stringLenZeroTerm("A"),
+    Buffer.alloc(156), // PageSettings
+    uint16(0), // TitleBlocks
+    uint16(0), // T0x34
+    uint16(0), // T0x35
+    uint16(0), // net table
+    uint16(0), // wires
+    uint16(instances.length),
+    ...instances,
+    uint16(ports.length),
+    ...ports,
+    uint16(0), // Globals
+    uint16(0), // OffPageConnectors
+  ]);
+
+describe("parsePage", () => {
+  it("parses consecutive Port records without an outer five-byte trailer", () => {
+    const parsed = parsePage(page([], [port(1001, 2001), port(1002, 2002)]));
+
+    expect(parsed.ports).toHaveLength(2);
+    expect(parsed.ports.map((item) => item.pairingId)).toEqual([1001, 1002]);
+    expect(parsed.ports.map((item) => item.dbId)).toEqual([2001, 2002]);
+  });
+
+  it("skips DrawnInstance records in a mixed page instance array", () => {
+    const drawn = emptyBoundedStructure(StructureType.DrawnInstance);
+    const parsed = parsePage(page([drawn, placedInstance("R1")], []));
+
+    expect(parsed.placedInstances).toHaveLength(1);
+    expect(parsed.placedInstances[0].reference).toBe("R1");
+  });
+});

--- a/src/parsers/cadence/dsn/page-parser.ts
+++ b/src/parsers/cadence/dsn/page-parser.ts
@@ -123,6 +123,13 @@ export function parsePage(buffer: Buffer): PageData {
   const lenPlacedInstances = reader.readUint16();
   const placedInstances: PlacedInstance[] = [];
   for (let i = 0; i < lenPlacedInstances; i++) {
+    // Hierarchical pages may interleave DrawnInstance records with the
+    // component-bearing PlacedInstances. OpenOrCadParser reads this list
+    // generically and skips DrawnInstance because its body is unimplemented.
+    if (reader.peek(1)[0] === StructureType.DrawnInstance) {
+      skipStructure(reader);
+      continue;
+    }
     placedInstances.push(parsePlacedInstance(reader));
   }
 
@@ -131,7 +138,6 @@ export function parsePage(buffer: Buffer): PageData {
   const ports: GraphicInst[] = [];
   for (let i = 0; i < lenPorts; i++) {
     ports.push(parsePort(reader));
-    reader.skip(5); // 5 unknown bytes after each Port
   }
 
   // Globals

--- a/src/parsers/cadence/dsn/structure-types.ts
+++ b/src/parsers/cadence/dsn/structure-types.ts
@@ -10,6 +10,7 @@ export enum StructureType {
   PartCell = 6,
   Page = 10,
   PartInstance = 11,
+  DrawnInstance = 12,
   PlacedInstance = 13,
   T0x10 = 16,
   WireScalar = 20,
@@ -63,6 +64,7 @@ export interface PinMapData {
 
 export const structureTypeName: Partial<Record<StructureType, string>> = {
   [StructureType.Page]: "Page",
+  [StructureType.DrawnInstance]: "DrawnInstance",
   [StructureType.PlacedInstance]: "PlacedInstance",
   [StructureType.T0x10]: "T0x10",
   [StructureType.WireScalar]: "WireScalar",


### PR DESCRIPTION
## Summary

- Fix Cadence DSN parsing after consecutive Port records.
- Accept hierarchical DrawnInstance records interleaved with PlacedInstance records.
- Add synthetic regression coverage and document both record layouts.

## Changes

- Removed the nonexistent five-byte trailer skip after Port records.
- Added the type-12 DrawnInstance structure type.
- Skip DrawnInstance records using their encoded prefix boundaries while retaining subsequent PlacedInstance records.
- Corrected the page-record documentation in `docs/dsn-format.md`.
- Added synthetic tests for consecutive Ports and mixed instance records.

## Related Issues

Closes #182

## Testing

- [x] Added/updated tests
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes — 974 passed, 6 skipped
- [x] `npm run build` passes
- [x] Existing Cadence oracle fixtures retain 100% pin-to-net connectivity agreement

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added documentation where needed

## Compatibility and risk

Low risk. The change restores parity with the vendored C++ parser and is limited to Cadence DSN page records. It changes no public API, dependency, or output schema.

The regression tests use synthetic binary records; no proprietary design files are included or required.

## Changelog

Cadence DSN files containing Port symbols or hierarchical DrawnInstance records now parse successfully instead of failing with a generic prefix-count error.