### PR TITLE
chore: v1.7.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.3] - 2026-08-26
+
+### Fixed
+
+- OpenTelemetry per-call error log records now include a human-readable `error.message` for thrown errors and MCP error results, truncated to 2,048 characters. Values that cannot be converted to strings are reported as `Unknown error` instead of interfering with the tool call (PR #185)
+
 ## [1.7.2] - 2026-08-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intelligentelectron/universal-netlist",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- release the OpenTelemetry failure-message fix from PR #185 as v1.7.3
- add the v1.7.3 changelog entry
- bump package.json and package-lock.json together
- leave open Cadence issue #182 for a later release

## Testing

- npm run type-check
- npm run lint
- npm test — 58 files passed, 1 skipped; 972 tests passed, 11 skipped
- git diff --check