### PR TITLE
chore: share repository skills with Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary

- expose the repository's `.claude/skills` directory at Codex's `.agents/skills` discovery path
- keep one canonical copy of each repository skill through a relative Unix symlink

## Test plan

- [x] verify `.agents/skills/release/SKILL.md` resolves through the symlink