### PR TITLE
fix(otel): make tool error types groupable

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -97,7 +97,8 @@ One span per call, named `tool/<tool_name>`.
 | `tool.name` | The tool that was invoked. |
 | `tool.outcome` | `success` or `error`. |
 | `tool.duration_ms` | Wall-clock duration of the call in milliseconds. |
-| `error.type` | Present on failure; the error class name (or `tool_error` for an error result). |
+| `error.type` | Stable failure category from the closed set below. Present on failure. |
+| `error.class` | Runtime exception class, present only when the handler throws an `Error`. Intended for debugging, not grouping. |
 | `tool.args` | Full tool arguments as JSON. Only present when `OTEL_CAPTURE_TOOL_ARGS` is enabled. |
 
 The span status is set to `ERROR` on failure and `OK` otherwise; exceptions are recorded on the span.
@@ -110,6 +111,22 @@ The span status is set to `ERROR` on failure and `OK` otherwise; exceptions are 
 | `tool.duration` | Histogram | ms | `tool`, `outcome` |
 | `tool.errors` | Counter | — | `tool`, `error_type` |
 
+`error.type` and the `tool.errors.error_type` label use this closed vocabulary:
+
+| Value | Meaning |
+|-------|---------|
+| `invalid_argument` | The request, selection, or supplied design data is invalid or unsupported. |
+| `not_found` | A requested file, design, component, net, pin, or other resource does not exist. |
+| `permission_denied` | Access was refused by the operating system or an upstream service. |
+| `resource_exhausted` | A size, memory, storage, file-descriptor, or output-buffer limit was reached. |
+| `cancelled` | The operation was cancelled or aborted. |
+| `timeout` | The operation exceeded its time limit or deadline. |
+| `unavailable` | A required service, platform, installation, network, or external tool is unavailable. |
+| `internal` | The failure does not match another category and should be investigated as an implementation or classification gap. |
+
+The same classifier is applied to thrown errors and returned MCP error results. These
+values are telemetry API: changing or renaming one requires an explicit changelog entry.
+
 ### Logs
 
 One structured log record per call, with body `tool/<tool_name> <outcome>` and severity `INFO` on success or `ERROR` on failure. Each record carries:
@@ -119,7 +136,8 @@ One structured log record per call, with body `tool/<tool_name> <outcome>` and s
 | `tool.name` | The tool that was invoked. |
 | `tool.outcome` | `success` or `error`. |
 | `tool.duration_ms` | Duration in milliseconds. |
-| `error.type` | Present on failure. |
+| `error.type` | Stable failure category from the closed set above. Present on failure. |
+| `error.class` | Runtime exception class, present only for thrown `Error` values. |
 | `error.message` | Human-readable failure message, present on failure when available and truncated to 2,048 characters. For MCP error results, this is the result's `error` field. |
 | `enduser.id` | The host OS account name, mirroring the resource attribute below. Best-effort; omitted if it can't be read. |
 | `tool.args` | Full tool arguments as JSON, mirroring the span attribute. Only present when `OTEL_CAPTURE_TOOL_ARGS` is enabled. |

--- a/src/telemetry/error-category.test.ts
+++ b/src/telemetry/error-category.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { classifyToolError, getErrorClass, TOOL_ERROR_TYPES } from "./error-category.js";
+
+describe("classifyToolError", () => {
+  it.each([
+    ["Invalid regex pattern '[abc'", "invalid_argument"],
+    ["Design file not found", "not_found"],
+    ["EACCES: permission denied", "permission_denied"],
+    ["stdout maxBuffer length exceeded", "resource_exhausted"],
+    ["Operation cancelled", "cancelled"],
+    ["Export timed out", "timeout"],
+    ["connect ECONNREFUSED 127.0.0.1:4318", "unavailable"],
+    ["The parser reached an impossible state", "internal"],
+  ] as const)("classifies %s as %s", (message, expected) => {
+    expect(classifyToolError(message)).toBe(expected);
+  });
+
+  it("uses stable Node error codes before message text", () => {
+    const error = Object.assign(new Error("opaque dependency message"), { code: "ENOENT" });
+    expect(classifyToolError(error)).toBe("not_found");
+  });
+
+  it("classifies thrown and returned forms of the same failure identically", () => {
+    expect(classifyToolError(new Error("Design file not found"))).toBe("not_found");
+    expect(classifyToolError("Design file not found")).toBe("not_found");
+  });
+
+  it("always returns a member of the documented closed set", () => {
+    const unstringifiable = Object.create(null);
+    expect(TOOL_ERROR_TYPES).toContain(classifyToolError(unstringifiable));
+  });
+});
+
+describe("getErrorClass", () => {
+  it("keeps thrown exception classes separate from the category", () => {
+    expect(getErrorClass(new TypeError("boom"))).toBe("TypeError");
+    expect(getErrorClass("boom")).toBeUndefined();
+  });
+});

--- a/src/telemetry/error-category.ts
+++ b/src/telemetry/error-category.ts
@@ -1,0 +1,119 @@
+/** Stable, low-cardinality failure categories used by tool telemetry. */
+export const TOOL_ERROR_TYPES = [
+  "invalid_argument",
+  "not_found",
+  "permission_denied",
+  "resource_exhausted",
+  "cancelled",
+  "timeout",
+  "unavailable",
+  "internal",
+] as const;
+
+export type ToolErrorType = (typeof TOOL_ERROR_TYPES)[number];
+
+const CODE_TYPES: Readonly<Record<string, ToolErrorType>> = {
+  ABORT_ERR: "cancelled",
+  ECANCELED: "cancelled",
+  ERR_CANCELED: "cancelled",
+  EACCES: "permission_denied",
+  EPERM: "permission_denied",
+  ENOENT: "not_found",
+  ENOTDIR: "not_found",
+  ENOSPC: "resource_exhausted",
+  ENOMEM: "resource_exhausted",
+  EMFILE: "resource_exhausted",
+  ENFILE: "resource_exhausted",
+  ETIMEDOUT: "timeout",
+  ECONNREFUSED: "unavailable",
+  ECONNRESET: "unavailable",
+  EHOSTUNREACH: "unavailable",
+  ENETUNREACH: "unavailable",
+  EPIPE: "unavailable",
+};
+
+const MESSAGE_TYPES: ReadonlyArray<readonly [ToolErrorType, RegExp]> = [
+  [
+    "permission_denied",
+    /\b(?:eacces|eperm|permission denied|access denied|unauthori[sz]ed|forbidden)\b/i,
+  ],
+  [
+    "resource_exhausted",
+    /\b(?:enospc|enomem|emfile|enfile|out of memory|resource exhausted|too many open files|maxbuffer|exceeds? (?:the )?limit|payload too large)\b/i,
+  ],
+  ["cancelled", /\b(?:abort_err|ecanceled|err_canceled|cancelled|canceled|aborted)\b/i],
+  ["timeout", /\b(?:etimedout|timed out|timeout|deadline exceeded)\b/i],
+  [
+    "unavailable",
+    /\b(?:econnrefused|econnreset|ehostunreach|enetunreach|epipe|connection refused|connection reset|network unreachable|service unavailable|temporarily unavailable|only available on|no cadence spb installation|pstswp failed)\b/i,
+  ],
+  [
+    "invalid_argument",
+    /\b(?:invalid|unsupported|malformed|not an?|unexpected|unbalanced|unterminated|expected|must|needs?|unknown rule|was empty|cannot be queried|matched all|out of bounds|magic signature mismatch|could not find valid|no schematic documents found|no hierarchy stream)\b/i,
+  ],
+  ["invalid_argument", /\blists\b.+\bbut\b.+\bis on\b/i],
+  ["invalid_argument", /\b(?:stream|section|signature|terminator)\b.+\bnot found\b/i],
+  ["not_found", /\b(?:enoent|no such file|does not exist)\b/i],
+  ["not_found", /\b(?:file|directory|design|component|net|pin|path|resource)\b.+\bnot found\b/i],
+  ["not_found", /\bno (?:components?|nets?|pins?|designs?|files?|directories)\b.+\bfound\b/i],
+];
+
+/**
+ * Classify either a thrown value or an MCP error-result message.
+ *
+ * Unknown failures intentionally become `internal`: gaps remain visible instead
+ * of silently growing the vocabulary or inventing a category from free text.
+ */
+export const classifyToolError = (failure: unknown): ToolErrorType => {
+  try {
+    const code = readStringProperty(failure, "code")?.toUpperCase();
+    if (code && CODE_TYPES[code]) return CODE_TYPES[code];
+
+    const cause = readProperty(failure, "cause");
+    const causeCode = readStringProperty(cause, "code")?.toUpperCase();
+    if (causeCode && CODE_TYPES[causeCode]) return CODE_TYPES[causeCode];
+
+    const message = describeFailure(failure);
+    for (const [type, pattern] of MESSAGE_TYPES) {
+      if (pattern.test(message)) return type;
+    }
+  } catch {
+    // Telemetry classification must never affect the tool call.
+  }
+  return "internal";
+};
+
+/** Keep the runtime exception class for debugging, separate from `error.type`. */
+export const getErrorClass = (failure: unknown): string | undefined => {
+  try {
+    if (!(failure instanceof Error)) return undefined;
+    return failure.name || "Error";
+  } catch {
+    return undefined;
+  }
+};
+
+const describeFailure = (failure: unknown): string => {
+  try {
+    if (failure instanceof Error) return failure.message;
+    return typeof failure === "string" ? failure : String(failure);
+  } catch {
+    return "";
+  }
+};
+
+const readProperty = (value: unknown, property: string): unknown => {
+  try {
+    if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+      return undefined;
+    }
+    return (value as Record<string, unknown>)[property];
+  } catch {
+    return undefined;
+  }
+};
+
+const readStringProperty = (value: unknown, property: string): string | undefined => {
+  const candidate = readProperty(value, property);
+  return typeof candidate === "string" ? candidate : undefined;
+};

--- a/src/telemetry/otel.test.ts
+++ b/src/telemetry/otel.test.ts
@@ -106,7 +106,8 @@ describe("instrumentTool log records", () => {
     expect(record.severityText).toBe("ERROR");
     expect(record.attributes).toMatchObject({
       "tool.outcome": "error",
-      "error.type": "TypeError",
+      "error.type": "internal",
+      "error.class": "TypeError",
       "error.message": "boom",
       "enduser.id": userInfo().username,
       "tool.args": JSON.stringify({ a: 1 }),
@@ -126,15 +127,40 @@ describe("instrumentTool log records", () => {
     expect(result).toBe(errorResult);
     expect(lastRecord().attributes).toMatchObject({
       "tool.outcome": "error",
-      "error.type": "tool_error",
+      "error.type": "not_found",
       "error.message": "Design file not found",
     });
+  });
+
+  it("gives thrown and returned not-found failures the same category", async () => {
+    await expect(
+      instrumentTool("thrown_tool", {}, async () => {
+        throw new Error("Design file not found");
+      })
+    ).rejects.toThrow("Design file not found");
+
+    const errorResult = {
+      content: [{ type: "text", text: JSON.stringify({ error: "Design file not found" }) }],
+    };
+    await instrumentTool("returned_tool", {}, async () => errorResult, {
+      isErrorResult: () => true,
+      getErrorMessage: (value) => JSON.parse(value.content[0].text).error,
+    });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].attributes).toMatchObject({
+      "error.type": "not_found",
+      "error.class": "Error",
+    });
+    expect(captured[1].attributes).toMatchObject({ "error.type": "not_found" });
+    expect(captured[1].attributes ?? {}).not.toHaveProperty("error.class");
   });
 
   it("omits error attributes from successful calls", async () => {
     await instrumentTool("demo_tool", {}, async () => "ok");
 
     expect(lastRecord().attributes ?? {}).not.toHaveProperty("error.type");
+    expect(lastRecord().attributes ?? {}).not.toHaveProperty("error.class");
     expect(lastRecord().attributes ?? {}).not.toHaveProperty("error.message");
   });
 
@@ -164,8 +190,9 @@ describe("instrumentTool log records", () => {
 
     expect(lastRecord().attributes).toMatchObject({
       "tool.outcome": "error",
-      "error.type": "Error",
+      "error.type": "internal",
       "error.message": "Unknown error",
     });
+    expect(lastRecord().attributes ?? {}).not.toHaveProperty("error.class");
   });
 });

--- a/src/telemetry/otel.ts
+++ b/src/telemetry/otel.ts
@@ -23,6 +23,7 @@ import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { PushMetricExporter } from "@opentelemetry/sdk-metrics";
 import type { LogRecordExporter } from "@opentelemetry/sdk-logs";
+import { classifyToolError, getErrorClass, type ToolErrorType } from "./error-category.js";
 
 const INSTRUMENTATION_NAME = "@intelligentelectron/mcp";
 const MAX_ERROR_MESSAGE_LENGTH = 2048;
@@ -286,27 +287,26 @@ export const instrumentTool = async <R>(
       const result = await run();
 
       const isError = opts?.isErrorResult?.(result) ?? false;
-      const errorMessage = isError
-        ? normalizeErrorMessage(opts?.getErrorMessage?.(result))
-        : undefined;
+      const resultErrorMessage = isError ? opts?.getErrorMessage?.(result) : undefined;
       finishSpan(
         span,
         toolName,
         isError ? "error" : "success",
-        isError ? "tool_error" : undefined,
-        errorMessage,
+        isError ? classifyToolError(resultErrorMessage) : undefined,
+        undefined,
+        normalizeErrorMessage(resultErrorMessage),
         Date.now() - start,
         capturedArgs
       );
       return result;
     } catch (err) {
-      const errorType = err instanceof Error ? err.name : "Error";
       safely(() => span.recordException(err instanceof Error ? err : new Error(String(err))));
       finishSpan(
         span,
         toolName,
         "error",
-        errorType,
+        classifyToolError(err),
+        getErrorClass(err),
         normalizeErrorMessage(describeError(err)),
         Date.now() - start,
         capturedArgs
@@ -320,7 +320,8 @@ const finishSpan = (
   span: Span,
   toolName: string,
   outcome: "success" | "error",
-  errorType: string | undefined,
+  errorType: ToolErrorType | undefined,
+  errorClass: string | undefined,
   errorMessage: string | undefined,
   durationMs: number,
   capturedArgs: string | undefined
@@ -329,6 +330,7 @@ const finishSpan = (
     span.setAttribute("tool.outcome", outcome);
     span.setAttribute("tool.duration_ms", durationMs);
     if (errorType) span.setAttribute("error.type", errorType);
+    if (errorClass) span.setAttribute("error.class", errorClass);
     span.setStatus({ code: outcome === "error" ? SpanStatusCode.ERROR : SpanStatusCode.OK });
   });
 
@@ -342,7 +344,9 @@ const finishSpan = (
     }
   });
 
-  safely(() => emitLog(span, toolName, outcome, errorType, errorMessage, durationMs, capturedArgs));
+  safely(() =>
+    emitLog(span, toolName, outcome, errorType, errorClass, errorMessage, durationMs, capturedArgs)
+  );
 
   safely(() => span.end());
 };
@@ -358,7 +362,8 @@ const emitLog = (
   span: Span,
   toolName: string,
   outcome: "success" | "error",
-  errorType: string | undefined,
+  errorType: ToolErrorType | undefined,
+  errorClass: string | undefined,
   errorMessage: string | undefined,
   durationMs: number,
   capturedArgs: string | undefined
@@ -374,6 +379,7 @@ const emitLog = (
       "tool.outcome": outcome,
       "tool.duration_ms": durationMs,
       ...(errorType ? { "error.type": errorType } : {}),
+      ...(errorClass ? { "error.class": errorClass } : {}),
       ...(errorMessage ? { "error.message": errorMessage } : {}),
       ...hostEnduser(),
       ...(capturedArgs !== undefined ? { "tool.args": capturedArgs } : {}),

--- a/test/otel/e2e.test.ts
+++ b/test/otel/e2e.test.ts
@@ -225,7 +225,7 @@ describe.skipIf(!loopbackAvailable)("OpenTelemetry end-to-end", () => {
       const span = receiver
         .spans()
         .find((s) => s.name === "tool/run_erc" && s.attributes["tool.outcome"] === "error")!;
-      expect(span.attributes["error.type"]).toBeDefined();
+      expect(span.attributes["error.type"]).toBe("invalid_argument");
 
       const log = receiver
         .logs()
@@ -233,11 +233,16 @@ describe.skipIf(!loopbackAvailable)("OpenTelemetry end-to-end", () => {
           (l) =>
             l.body === "tool/run_erc error" && l.attributes["error.message"] === BROKEN_DESIGN_ERROR
         )!;
-      expect(log.attributes["error.type"]).toBe("tool_error");
+      expect(log.attributes["error.type"]).toBe("invalid_argument");
       expect(log.attributes["error.message"]).toBe(BROKEN_DESIGN_ERROR);
 
       await waitFor(() => receiver.metrics().some((m) => m.name === "tool.errors"));
-      expect(receiver.metrics().some((m) => m.name === "tool.errors")).toBe(true);
+      const errors = receiver.metrics().find((m) => m.name === "tool.errors")!;
+      expect(
+        errors.points.some(
+          (p) => p.attributes.tool === "run_erc" && p.attributes.error_type === "invalid_argument"
+        )
+      ).toBe(true);
     },
     TEST_TIMEOUT
   );


### PR DESCRIPTION
## Summary

- classify thrown failures and returned MCP error results into one documented eight-value `error.type` vocabulary
- keep thrown exception names in the separate debugging-only `error.class` attribute
- apply the category consistently to spans, structured logs, and the `tool.errors.error_type` metric label

Closes #188

## Test plan

- [x] category unit tests cover every documented value, Node error codes, the catch-all, and matching thrown/returned failures
- [x] OpenTelemetry record tests cover both failure paths and `error.class`
- [x] real MCP-to-OTLP end-to-end test verifies `invalid_argument` on the span, log, and metric
- [x] `npm test` — 992 passed, 5 skipped
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run format:check`

## Changelog

OpenTelemetry `error.type` is now a stable, groupable failure category across thrown errors and returned MCP error results. The closed vocabulary is `invalid_argument`, `not_found`, `permission_denied`, `resource_exhausted`, `cancelled`, `timeout`, `unavailable`, and `internal`; thrown exception names remain available separately as `error.class`.