### PR TITLE
chore: v1.7.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.4] - 2026-08-26
+
+### Added
+
+- Development: repository skills are exposed to Codex through `.agents/skills`, a relative symlink to the canonical `.claude/skills` directory (PR #187)
+
+### Changed
+
+- OpenTelemetry `error.type` is now a stable, groupable category for both thrown errors and returned MCP error results. The closed vocabulary is `invalid_argument`, `not_found`, `permission_denied`, `resource_exhausted`, `cancelled`, `timeout`, `unavailable`, and `internal`; thrown exception names remain available separately as `error.class`. The same category is emitted on spans, structured logs, and the `tool.errors.error_type` metric label (#188, PR #189)
+
+### Fixed
+
+- Cadence DSN files containing consecutive Port records or hierarchical DrawnInstance records now parse without losing stream alignment or rejecting the mixed instance array. Thank you to [@RuneSorensen](https://github.com/RuneSorensen) for the careful reference analysis, fix, and regression tests. We independently verified the change against 69 real Cadence designs: it fixes 9 previously failing designs, including `fenlogic/multio`, which now parses as 65 components and 147 nets (#182, PR #183)
+
 ## [1.7.3] - 2026-08-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intelligentelectron/universal-netlist",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intelligentelectron/universal-netlist",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "MCP server for netlist parsing and circuit analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- release the contributor's verified Cadence Port/DrawnInstance parser fix from PR #183
- release the stable OpenTelemetry error-category vocabulary from PR #189
- include the repository skill-sharing change from PR #187
- thank @RuneSorensen in the changelog and record the 69-design corpus verification
- bump both package manifests from 1.7.3 to 1.7.4

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 993 passed, 5 skipped
- [x] `npm run build`
- [x] `npm run format:check`
- [x] built CLI reports `universal-netlist v1.7.4`
- [x] `npm pack --dry-run` reports `@intelligentelectron/universal-netlist@1.7.4`
- [x] `package.json` and `package-lock.json` both report 1.7.4