### PR TITLE
Telemetry: record tool calls rejected by input schemas

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -7,6 +7,7 @@ The server can emit [OpenTelemetry](https://opentelemetry.io/) **traces, metrics
 - **Disabled by default.** Telemetry is a no-op with zero overhead unless you point it at an OTLP endpoint. The heavy SDK packages are not imported until telemetry is configured; only the lightweight OpenTelemetry API stubs are always present, and they are no-ops when telemetry is off.
 - **Configured purely through standard `OTEL_*` environment variables.** No bespoke config and no code changes.
 - **Never affects tool results.** Every span, metric, and log operation is wrapped so that an exporter fault, misconfiguration, or unreachable backend degrades to "no telemetry" rather than an error. Pending data is flushed on shutdown.
+- **Starts at the MCP request boundary.** Calls rejected by a tool's input schema are instrumented even though the SDK never invokes the tool handler. They are counted as `invalid_argument` failures, and their validation message identifies the offending argument.
 - **stdio-safe.** The MCP stdio transport owns stdout, so all diagnostics are written to stderr only; no console/stdout exporter is ever used.
 
 ## Enabling and disabling
@@ -86,7 +87,8 @@ One additional, clearly-scoped option is specific to this server:
 
 ## What gets emitted
 
-Each tool call produces a span, three metric updates, and one log record.
+Each tool call produces a span, three metric updates, and one log record. An input-schema
+rejection has the same telemetry shape as any other failed call, including duration.
 
 ### Spans
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { VERSION } from "./version.js";
-import { initTelemetry, withTelemetry, initOtel } from "./telemetry/index.js";
+import {
+  initTelemetry,
+  withTelemetry,
+  instrumentMcpToolCalls,
+  initOtel,
+} from "./telemetry/index.js";
 import {
   listDesigns,
   listComponents,
@@ -100,6 +105,10 @@ export const createServer = (): McpServer => {
       instructions: SERVER_INSTRUCTIONS,
     }
   );
+
+  // Wrap the complete SDK tools/call path so schema rejections are measured
+  // before the SDK has a chance to return without invoking a tool handler.
+  instrumentMcpToolCalls(server);
 
   // -------------------------------------------------------------------------
   // Tool: list_designs

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -8,4 +8,5 @@
  * Import telemetry from this barrel rather than the individual modules.
  */
 export * from "./local.js";
+export * from "./mcp.js";
 export * from "./otel.js";

--- a/src/telemetry/local.test.ts
+++ b/src/telemetry/local.test.ts
@@ -148,6 +148,21 @@ describe("withTelemetry", () => {
     expect(toolEvent.success).toBe(false);
   });
 
+  it("logs success=false for MCP validation error results", async () => {
+    const handler = withTelemetry("list_designs", async (_args: Record<string, unknown>) => ({
+      isError: true,
+      content: [{ type: "text" as const, text: 'Unrecognized key: "search_path"' }],
+    }));
+
+    await handler({ search_path: "/tmp" });
+
+    const lines = readFileSync(testTelemetryPath, "utf-8").trim().split("\n");
+    const toolEvent = JSON.parse(lines[lines.length - 1]);
+    expect(toolEvent.tool).toBe("list_designs");
+    expect(toolEvent.args).toEqual({ search_path: "/tmp" });
+    expect(toolEvent.success).toBe(false);
+  });
+
   it("logs success=false and re-throws on handler exceptions", async () => {
     const handler = withTelemetry("failing_tool", async (_args: Record<string, unknown>) => {
       throw new Error("boom");

--- a/src/telemetry/local.ts
+++ b/src/telemetry/local.ts
@@ -11,6 +11,7 @@ import { userInfo, hostname, platform, arch, release } from "node:os";
 import { execSync } from "node:child_process";
 import { VERSION } from "../version.js";
 import { instrumentTool } from "./otel.js";
+import { markToolHandlerInstrumented } from "./request-context.js";
 
 // =============================================================================
 // Types
@@ -151,6 +152,7 @@ export const withTelemetry = <T extends Record<string, unknown>, R>(
   handler: ToolHandler<T, R>
 ): ToolHandler<T, R> => {
   return async (args: T): Promise<R> => {
+    markToolHandlerInstrumented();
     const start = Date.now();
     let success = true;
     try {
@@ -162,7 +164,8 @@ export const withTelemetry = <T extends Record<string, unknown>, R>(
         () => handler(args),
         { isErrorResult: isErrorContent, getErrorMessage: getErrorContentMessage }
       );
-      // Detect error results (objects with an "error" field in the text content)
+      // Detect both application error content and MCP `isError` results created
+      // by the SDK for validation/dispatch failures.
       if (isErrorContent(result)) {
         success = false;
       }
@@ -252,8 +255,9 @@ const isErrorContent = (result: unknown): boolean => {
 /** Read the human-facing message from a formatted MCP error result. */
 const getErrorContentMessage = (result: unknown): string | undefined => {
   if (typeof result !== "object" || result === null) return undefined;
-  const r = result as { content?: Array<{ text?: string }> };
+  const r = result as { content?: Array<{ text?: string }>; isError?: boolean };
   if (!Array.isArray(r.content) || r.content.length === 0) return undefined;
+  if (r.isError === true) return r.content[0].text || "Tool call failed";
   try {
     const parsed: unknown = JSON.parse(r.content[0].text ?? "");
     if (typeof parsed !== "object" || parsed === null || !("error" in parsed)) return undefined;

--- a/src/telemetry/mcp.ts
+++ b/src/telemetry/mcp.ts
@@ -1,0 +1,53 @@
+/** Instrument MCP tool requests around the SDK's validation and dispatch. */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import {
+  CallToolRequestSchema,
+  type CallToolRequest,
+  type CallToolResult,
+  type ServerNotification,
+  type ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import { withTelemetry } from "./local.js";
+import { runWithToolRequestState } from "./request-context.js";
+
+type CallToolHandler = (
+  request: CallToolRequest,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+) => CallToolResult | Promise<CallToolResult>;
+
+/**
+ * Install telemetry at the `tools/call` request boundary.
+ *
+ * McpServer validates a registered tool's Zod schema before it invokes the
+ * tool callback. Wrapping callbacks therefore misses schema rejections. The
+ * underlying Server deliberately exposes `setRequestHandler` for advanced
+ * request handling, so intercept its one tools/call registration and wrap the
+ * complete SDK path: validation, callback dispatch, and error-result creation.
+ */
+export const instrumentMcpToolCalls = (mcp: McpServer): void => {
+  const lowLevelServer = mcp.server;
+  const setRequestHandler = lowLevelServer.setRequestHandler.bind(lowLevelServer);
+
+  lowLevelServer.setRequestHandler = ((schema: unknown, handler: unknown): void => {
+    if (schema !== CallToolRequestSchema) {
+      setRequestHandler(schema as never, handler as never);
+      return;
+    }
+
+    const callTool = handler as CallToolHandler;
+    setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+      const args = request.params.arguments ?? {};
+      const { result, handlerInstrumented } = await runWithToolRequestState(() =>
+        Promise.resolve(callTool(request, extra))
+      );
+
+      // Existing handlers keep their wrapper so thrown exception classes and
+      // application error results retain today's semantics. When validation
+      // rejects before a handler starts, instrument the SDK-created result now.
+      if (handlerInstrumented) return result;
+      return withTelemetry(request.params.name, async () => result)(args);
+    });
+  }) as typeof lowLevelServer.setRequestHandler;
+};

--- a/src/telemetry/request-context.ts
+++ b/src/telemetry/request-context.ts
@@ -1,0 +1,24 @@
+/** Per-request state shared by MCP dispatch and tool-handler telemetry. */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface ToolRequestState {
+  handlerInstrumented: boolean;
+}
+
+const toolRequestState = new AsyncLocalStorage<ToolRequestState>();
+
+/** Run SDK dispatch with isolated state, including when requests overlap. */
+export const runWithToolRequestState = async <T>(
+  run: () => Promise<T>
+): Promise<{ result: T; handlerInstrumented: boolean }> => {
+  const state: ToolRequestState = { handlerInstrumented: false };
+  const result = await toolRequestState.run(state, run);
+  return { result, handlerInstrumented: state.handlerInstrumented };
+};
+
+/** Mark that the normal handler-level wrapper owns telemetry for this request. */
+export const markToolHandlerInstrumented = (): void => {
+  const state = toolRequestState.getStore();
+  if (state) state.handlerInstrumented = true;
+};

--- a/test/otel/e2e.test.ts
+++ b/test/otel/e2e.test.ts
@@ -10,6 +10,7 @@
  *   - structured log correlated by trace/span id
  *   - log-record attributes mirror enduser.id and, opt-in, tool.args (issue #82)
  *   - error logs carry the failure message from a fixture-backed MCP result (issue #184)
+ *   - SDK input-schema rejections are counted and classified (issue #191)
  *   - failure path: outcome=error, tool result still returned
  *   - exporter unreachable: tool calls still succeed
  *   - flush on shutdown
@@ -241,6 +242,80 @@ describe.skipIf(!loopbackAvailable)("OpenTelemetry end-to-end", () => {
       expect(
         errors.points.some(
           (p) => p.attributes.tool === "run_erc" && p.attributes.error_type === "invalid_argument"
+        )
+      ).toBe(true);
+    },
+    TEST_TIMEOUT
+  );
+
+  test(
+    "input-schema rejection: SDK failure emits the complete error telemetry shape",
+    async () => {
+      await withServer(otelEnv(receiver), async (client) => {
+        const res: any = await client.callTool({
+          name: "list_designs",
+          arguments: { search_path: "/tmp" },
+        });
+        expect(res.isError).toBe(true);
+        expect(res.content?.[0]?.text ?? "").toContain('Unrecognized key: "search_path"');
+      });
+
+      const got = await waitFor(
+        () =>
+          receiver.spans().some(
+            (s) =>
+              s.name === "tool/list_designs" &&
+              s.attributes["tool.outcome"] === "error" &&
+              s.attributes["error.type"] === "invalid_argument"
+          ) &&
+          receiver.logs().some(
+            (l) =>
+              l.body === "tool/list_designs error" &&
+              String(l.attributes["error.message"]).includes("search_path")
+          )
+      );
+      expect(got).toBe(true);
+
+      const rejectionSpans = receiver
+        .spans()
+        .filter(
+          (s) =>
+            s.name === "tool/list_designs" && s.attributes["tool.outcome"] === "error"
+        );
+      expect(rejectionSpans).toHaveLength(1);
+      const span = rejectionSpans[0];
+      expect(span.attributes["error.type"]).toBe("invalid_argument");
+      expect(typeof span.attributes["tool.duration_ms"]).toBe("number");
+
+      const rejectionLogs = receiver
+        .logs()
+        .filter((l) => l.body === "tool/list_designs error");
+      expect(rejectionLogs).toHaveLength(1);
+      const log = rejectionLogs[0];
+      expect(log.attributes["error.type"]).toBe("invalid_argument");
+      expect(log.attributes["error.message"]).toContain("search_path");
+
+      const hasMetricPoint = (
+        name: string,
+        matches: (attributes: Record<string, string | number | boolean>) => boolean
+      ): boolean =>
+        receiver
+          .metrics()
+          .filter((metric) => metric.name === name)
+          .some((metric) => metric.points.some((point) => matches(point.attributes)));
+
+      expect(
+        await waitFor(
+          () =>
+            hasMetricPoint(
+              "tool.calls",
+              (attrs) => attrs.tool === "list_designs" && attrs.outcome === "error"
+            ) &&
+            hasMetricPoint(
+              "tool.errors",
+              (attrs) =>
+                attrs.tool === "list_designs" && attrs.error_type === "invalid_argument"
+            )
         )
       ).toBe(true);
     },


### PR DESCRIPTION
## Summary

- instrument the MCP tools/call request boundary so SDK input-schema rejections are observable
- preserve existing handler-level telemetry and exception classes without double-reporting
- classify validation failures as invalid_argument and carry the SDK validation message into error.message
- record the rejected call in local JSONL and OpenTelemetry calls/errors/duration/log/span output
- document that schema-rejected calls are included

Closes #191

## Testing

- npm run type-check
- npm run lint
- npm test (995 passed, 5 skipped)
- npm run build
- end-to-end OTLP test verifies one error span, one error log, tool.calls, tool.errors, invalid_argument, and the offending search_path argument
- Bun standalone binary smoke-built with VERSION=1.7.5 and reported v1.7.5