### PR TITLE
fix(ci): make release retries safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          # A manual release retry runs the current workflow from main while
+          # rebuilding the immutable source tag that was originally pushed.
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,17 @@ on:
   push:
     tags:
       - 'v*'
-  # Re-run a dropped tag webhook against the tag without deleting a public tag.
+  # Retry an existing tag using the latest release-workflow fixes from main,
+  # without deleting or moving the public tag.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag to release, such as v1.7.5
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -17,7 +23,7 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     with:
-      release_tag: ${{ github.ref_name }}
+      release_tag: ${{ inputs.tag || github.ref_name }}
 
   release:
     needs: ci
@@ -29,15 +35,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Validate release tag
         id: version
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
           REF_TYPE: ${{ github.ref_type }}
         run: |
-          if [ "$REF_TYPE" != tag ]; then
+          if [ -z "$DISPATCH_TAG" ] && [ "$REF_TYPE" != tag ]; then
             echo "::error::Release must run against a version tag, got $GITHUB_REF."
+            exit 1
+          fi
+
+          if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Release tag $RELEASE_TAG does not exist."
             exit 1
           fi
 
@@ -156,13 +170,14 @@ jobs:
           if npm view "$PACKAGE_NAME@$VERSION" version >/dev/null 2>&1; then
             echo "$PACKAGE_NAME@$VERSION is already published; continuing."
           else
-            npm publish npm-package/*.tgz --provenance --access public --ignore-scripts
+            npm publish ./npm-package/*.tgz --provenance --access public --ignore-scripts
           fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: ${{ github.ref_name }}
+          name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: |
             bin/universal-netlist-darwin-universal


### PR DESCRIPTION
## Summary

- publish the CI-built npm tarball using an explicit local path
- let manual release retries name an existing tag while using the latest workflow definition
- rebuild and release the original tag without deleting or moving it

## Validation

- workflow YAML parses successfully
- release run 33194589048 completed CI, all 7 OTEL e2e tests, cross-platform builds, signing, and notarization before exposing the npm path bug

This repairs the v1.7.5 release without rewriting its tag.