### PR TITLE
chore(ci): update artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Save npm release
         if: inputs.release_tag != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-package
           path: npm-package/*.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         run: RELEASE_DIR=$PWD/bin OUTPUT_DIR=$PWD/bin scripts/build-mcpb.sh "$VERSION"
 
       - name: Download CI-built npm package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: npm-package


### PR DESCRIPTION
Use the official current artifact-action majors (upload v7 and download v8) so CI and releases no longer run their JavaScript actions through GitHub's Node 20 compatibility warning. No release behavior changes.