### PR TITLE
Simplify the Universal Netlist Format table entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is compatible with Cadence, Altium, and KiCad, with plans to integrate more E
 | Cadence (OrCAD / CIS) | `.DSN` schematic | Reads the binary schematic directly, including CIS variant stuffing information |
 | Altium Designer | `.SchDoc` | Altium schematic documents, discovered via `.PrjPcb` project files |
 | KiCad | `.kicad_pro` (or root `.kicad_sch`) | Reads a committed `.net` export beside the project, or generates one via `kicad-cli` |
-| Universal Netlist | `.netlist.json` | The server's own versioned [netlist format](docs/schemas/universal-netlist.md), with native/vendor origin metadata, UTC generation time, and a verified SHA-256 over `nets` and `components` together |
+| Universal Netlist Format | `.netlist.json` | An open [JSON format](docs/schemas/universal-netlist.md) for netlists |
 
 ## Native Install (Recommended)
 


### PR DESCRIPTION
Rename the supported-format row to “Universal Netlist Format” and shorten its description to “An open JSON format for netlists.” Keep the schema documentation link for readers who need the details.

Validation: type-check, lint, and the full test suite pass.
