### PR TITLE
Describe Universal Netlist as the open JSON format for netlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is compatible with Cadence, Altium, and KiCad, with plans to integrate more E
 | Cadence (OrCAD / CIS) | `.DSN` schematic | Reads the binary schematic directly, including CIS variant stuffing information |
 | Altium Designer | `.SchDoc` | Altium schematic documents, discovered via `.PrjPcb` project files |
 | KiCad | `.kicad_pro` (or root `.kicad_sch`) | Reads a committed `.net` export beside the project, or generates one via `kicad-cli` |
-| Universal Netlist Format | `.netlist.json` | An open [JSON format](docs/schemas/universal-netlist.md) for netlists |
+| Universal Netlist Format | `.netlist.json` | The open [JSON format](https://github.com/IntelligentElectron/universal-netlist/blob/main/docs/schemas/universal-netlist.md) for netlists |
 
 ## Native Install (Recommended)
 


### PR DESCRIPTION
Update the supported-formats table to read “The open JSON format for netlists,” with “JSON format” linking directly to the format documentation on GitHub.

Validation: type-check, lint, and the full test suite pass.
